### PR TITLE
Scratch work sketching out more of the data model

### DIFF
--- a/datahost-ld-openapi/doc/datahost-ontology.ttl
+++ b/datahost-ld-openapi/doc/datahost-ontology.ttl
@@ -1,0 +1,53 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dh: <https://publishmydata.com/def/datahost/> .
+
+
+# TODO add comments and make into a proper ontology
+
+dh:baseEntity
+    a rdf:Property ;
+    rdfs:comment "Establishes a base URI string to be used for items logically beneath this resource in the data model." ;
+    rdfs:range xsd:string ;
+    rdfs:domain dh:DatasetSeries .
+
+dh:DatasetSeries a rdfs:Class .
+dh:Release a rdfs:Class .
+dh:Revision a rdfs:Class .
+dh:TableSchema a rdfs:Class .
+
+dh:DimensionColumn rdfs:subClassOf csvw:Column .
+dh:MeasureColumn rdfs:subClassOf csvw:Column .
+dh:AttributeColumn rdfs:subClassOf csvw:Column .
+
+dh:ChangeSet a rdfs:Class .
+dh:Commit a rdfs:Class .
+
+dh:Append rdfs:subClassOf dh:Commit .
+dh:Delete rdfs:subClassOf dh:Commit .
+dh:Correction rdfs:subClassOf dh:Append, dh:Delete .
+
+dh:commitId
+    a rdf:Property ;
+    rdfs:range xsd:integer ;
+    rdfs:domain dh:Commit .
+
+
+dh:previousCommit a rdf:Property ;
+    rdfs:range dh:Commit ;
+    rdfs:domain dh:Commit .
+
+
+dh:append
+    a rdf:Property ;
+    rdfs:domain dh:Commit ;
+    rdfs:range dh:AppendData .
+
+dh:delete
+    a rdf:Property ;
+    rdfs:domain dh:Commit ;
+    rdfs:range dh:DeleteData .
+
+dh:AppendData a rdfs:Class .
+dh:DeleteData a rdfs:Class .

--- a/datahost-ld-openapi/env/test/resources/test-inputs/release/metadata-1.json
+++ b/datahost-ld-openapi/env/test/resources/test-inputs/release/metadata-1.json
@@ -1,0 +1,6 @@
+{"@context":["https://publishmydata.com/def/datahost/context",
+             {"@base": "https://example.org/data/my-dataset-series/"}],
+ "@id": "2018",
+ "dcterms:title": "2018",
+
+ "dcat:inSeries": "../my-dataset-series"}

--- a/datahost-ld-openapi/resources/jsonld-context.json
+++ b/datahost-ld-openapi/resources/jsonld-context.json
@@ -96,8 +96,9 @@
   "yearMonthDuration": "xsd:yearMonthDuration",
 
 
-  "dh": "https://publishmydata.com/def/datahost/"
+  "dh": "https://publishmydata.com/def/datahost/",
 
+  "dcat:inSeries": {"@type": "@id"}
 
 
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/release.clj
@@ -28,3 +28,9 @@
     (if-let [old-release (get db release-path)]
       (update db release-path update-release base-entity new-release)
       (assoc db release-path (normalise-release base-entity new-release)))))
+
+(defn add-schema [release schema]
+  ;; TODO
+  )
+
+(defn add-changeset [release revision {:keys [description append delete]}])

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/release.clj
@@ -1,0 +1,30 @@
+(ns tpximpact.datahost.scratch.release
+  (:require
+   [clojure.tools.logging :as log]
+   [tpximpact.datahost.scratch.series :as series]))
+
+(defn normalise-release [base-entity {:keys [api-params jsonld-doc]}]
+  (let [{:keys [series-slug release-slug]} api-params
+        _ (assert base-entity "Expected base entity to be set")
+        context ["https://publishmydata.com/def/datahost/context"
+                 {"@base" base-entity}]]
+
+    (-> (series/merge-params-with-doc api-params jsonld-doc)
+        (assoc "@context" context
+               "@id" release-slug
+               "dcat:inSeries" (str "../" series-slug)))))
+
+(defn- update-release [_old-release base-entity {:keys [api-params _jsonld-doc] :as new-release}]
+  (log/info "Updating release " (:series-slug api-params) "/" (:release-slug api-params))
+  (normalise-release base-entity new-release))
+
+(defn upsert-release [db {:keys [api-params jsonld-doc] :as new-release}] ;[db {:keys [series-slug release-slug] :as api-params} jsonld-doc]
+  (let [{:keys [series-slug release-slug]} api-params
+        release-path (str (.getPath series/ld-root) series-slug "/" release-slug)
+        series-path (str (.getPath series/ld-root) series-slug)
+        series (get db series-path)
+        base-entity (get series "dh:baseEntity")]
+
+    (if-let [old-release (get db release-path)]
+      (update db release-path update-release base-entity new-release)
+      (assoc db release-path (normalise-release base-entity new-release)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/changeset.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/changeset.clj
@@ -1,0 +1,1 @@
+(ns tpximpact.datahost.scratch.release.changeset)

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/changeset.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/changeset.clj
@@ -1,1 +1,26 @@
 (ns tpximpact.datahost.scratch.release.changeset)
+
+;; TODO WIP sketching out shape
+
+(def example-changesets [{:description "first changeset"
+                          :commits [{:append [["male" "manchester" 3]]
+                                     :description "add obs"}]}
+                         {:description "second changeset"
+                          :commits [{:append [["female" "manchester" 4]]
+                                     :description "add obs"}]}
+                         {:description "second changeset"
+                          :commits [{:delete [["male" "manchester" 3]]
+                                     :append [["male" "manchester" 4]]
+                                     :description "correct incorrect observation"}]}
+                         ])
+
+(def equivalent-changes-in-one-changeset [{:description "Coin the first release"
+                                           :commits [{:append [["male" "manchester" 3]]
+                                                      :description "add obs"}
+                                                     {:append [["female" "manchester" 4]]
+                                                      :description "add obs"}
+                                                     {:delete [["male" "manchester" 3]]
+                                                      :append [["male" "manchester" 4]]
+                                                      :description "correct incorrect observation"}]}
+
+                                          ])

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/revision.clj
@@ -1,0 +1,1 @@
+(ns tpximpact.datahost.scratch.release.revision)

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/schema.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/schema.clj
@@ -9,12 +9,26 @@
 
 
   (def reserved-schema-properties
-    "These csvw properties are currently intentional unsupported, but some may
-  be supported in the future.
+    "These csvw properties are currently intentional unsupported, but
+  some may be supported in the future.
 
   For example we're hoping to automatically define and generate
   aboutUrl's from the CSV when we know the type of all columns in the
-  cube."
+  cube.
+
+  We also currently exclude any CSVW properties to do with coercion
+  because the semantics of coercion are a little fuzzy when a schema
+  is used for both input and output purposes... i.e. are the
+  expectations that we apply the coercion to the input data at
+  ingestion, or leave the data uncoerced and rely on users applying
+  them from the CSVW? The later adds a burden to users, whilst the
+  former means these properties are then redundant at output time.
+
+  For now it seems simpler to avoid the issues and assume we don't do
+  coercion with the schemas as these coercions can also in principle
+  be done upstream.
+
+  "
     (set/union coercion-properties transformation-properties)))
 
 (defn normalise-schema [release schema]

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/schema.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/release/schema.clj
@@ -1,0 +1,55 @@
+(ns tpximpact.datahost.scratch.release.schema
+  (:require [clojure.set :as set]))
+
+;; TODO
+
+
+(let [coercion-properties #{"csvw:null" "csvw:default" "csvw:separator" "csvw:ordered"}
+      transformation-properties #{"csvw:aboutUrl" "csvw:propertyUrl" "csvw:valueUrl" "csvw:virtual" "csvw:suppressOutput"}]
+
+
+  (def reserved-schema-properties
+    "These csvw properties are currently intentional unsupported, but some may
+  be supported in the future.
+
+  For example we're hoping to automatically define and generate
+  aboutUrl's from the CSV when we know the type of all columns in the
+  cube."
+    (set/union coercion-properties transformation-properties)))
+
+(defn normalise-schema [release schema]
+  {"@type" #{"dh:TableSchema" "dh:UserSchema"} ; | dh:RevisionSchema
+   "@context" ["https://publishmydata.com/def/datahost/context"
+               {"@base" "https://example.org/data/my-dataset-series/2018/schema/"}]
+   "@id" "2018"
+   "dh:columns" [{"csvw:datatype" "string" ;; should support all/most csvw datatype definitions
+                  "csvw:name" "sex"
+                  "csvw:title" "Sex"
+                  "@type" "dh:DimensionColumn" ;; | "dh:MeasureColumn" | "dh:AttributeColumn"
+                  ;;"csvw:ordered" false
+                  ;;"csvw:virtual" true
+
+                  ;;"csvw:aboutUrl" "uri-template"
+                  ;;"csvw:propertyUrl" "uri-template"
+                  ;;"csvw:valueUrl" "uri-template"
+
+                  ;;"csvw:required" true
+                  ;;"csvw:separator" ";"
+                  ;;"csvw:suppressOutput" false
+                  ;;"csvw:textDirection" "ltr"
+                  ;;"csvw:transformations" []
+                  ;;
+                  ;;"csvw:default" "default-value"
+                  ;;"csvw:null" "n/a"
+
+
+                  ;;"csvw:lang" "en"
+
+
+                  }]}
+  )
+
+(defn derive-revision-schema
+  "Derive a dh:RevisionSchema from a dh:CubeSchema"
+  [cube-schema]
+  )

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
@@ -121,11 +121,11 @@
 
 (def SeriesJsonLdInput [:map
                         ["@id" :series-slug-string]
-                        ["dh:base-entity" :url-string]])
+                        ["dh:baseEntity" :url-string]])
 
 (comment
   (m/validate SeriesJsonLdInput {"@id" "foo-bar"
-                                 "dh:base-entity" "http://foo"}
+                                 "dh:baseEntity" "http://foo"}
               {:registry registry})
 
   (m/validate SeriesApiParams
@@ -197,7 +197,7 @@
            final-doc (assoc validated-doc
                             ;; add any managed params
                             "@id" series-slug
-                            "dh:base-entity" (str ld-root series-slug "/") ;; coin base-entity to serve as the @base for nested resources
+                            "dh:baseEntity" (str ld-root series-slug "/") ;; coin base-entity to serve as the @base for nested resources
                             )]
        final-doc))))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
@@ -196,10 +196,45 @@
 
            final-doc (assoc validated-doc
                             ;; add any managed params
+                            "@type" "dh:DatasetSeries"
                             "@id" series-slug
                             "dh:baseEntity" (str ld-root series-slug "/") ;; coin base-entity to serve as the @base for nested resources
                             )]
        final-doc))))
+
+(defn- update-series [old-series {:keys [api-params jsonld-doc] :as _new-series}]
+  (log/info "Updating series " (:series-slug api-params))
+  (normalise-series api-params jsonld-doc))
+
+(defn- create-series [api-params jsonld-doc]
+  (log/info "Updating series " (:series-slug api-params))
+  (normalise-series api-params jsonld-doc))
+
+(defn upsert-series
+  "Takes a derefenced db state map with the shape {path jsonld} and
+  upserts a new dataset series into it.
+
+  Intended usage is via swap!
+
+  ```
+  (swap! db upsert-series {:api-params {:series-slug \"my-dataset-series\"}
+                           :jsonld-doc {}})
+  ```
+
+  An upsert will insert a new series if it isn't there already.
+
+  If the series exists already it will replace the majority of the
+  fields with those newly supplied, but may ignore or manage some
+  fields specially on update.
+
+  For example a `dcterms:issued` time should not change after a
+  document is updated (TODO: https://github.com/Swirrl/datahost-prototypes/issues/57)
+  "
+  [db {:keys [api-params jsonld-doc] :as new-series}]
+  (let [k (str (.getPath ld-root) (:series-slug api-params))]
+    (if-let [_old-series (get db k)]
+      (update db k update-series new-series)
+      (assoc db k (create-series api-params jsonld-doc)))))
 
 (comment
   (def db (db/duratom :local-file
@@ -207,43 +242,20 @@
                       :commit-mode :sync
                       :init {}))
 
-  (defn update-series [old-series {:keys [api-params jsonld-doc] :as _new-series}]
-    (log/info "Updating series " (:series-slug api-params))
-    (normalise-series api-params jsonld-doc))
-
-  (defn create-series [api-params jsonld-doc]
-    (log/info "Updating series " (:series-slug api-params))
-    (normalise-series api-params jsonld-doc))
-
-  (defn put-db [db {:keys [api-params jsonld-doc] :as new-series}]
-    (let [k (str (.getPath ld-root) (:series-slug api-params))]
-      (if-let [old-series (get db k)]
-        (update db k update-series new-series)
-        (assoc db k (normalise-series api-params jsonld-doc)))))
-
   (let [db (atom {})]
 
-    (swap! db put-db {:api-params {:series-slug "my-dataset-series"} :jsonld-doc (io/resource "./test-inputs/series/empty-1.json")})
+    (swap! db upsert-series {:api-params {:series-slug "my-dataset-series"}
+                             :jsonld-doc {}})
 
-    (swap! db put-db {:api-params {:series-slug "my-other-series"} :jsonld-doc (io/resource "./test-inputs/series/empty-1.json")})
-    (swap! db put-db {:api-params {:series-slug "my-other-series" :title "my title"} :jsonld-doc (io/resource "./test-inputs/series/empty-1.json")})
-    #_(swap! db put-db {:api-params {:series-slug "my-dataset-series"} :jsonld-doc (io/resource "./test-inputs/series/empty-1.json")})
-
-    db)
-
-  )
+    (swap! db upsert-series {:api-params {:series-slug "my-other-series"} :jsonld-doc {}})
+    (swap! db upsert-series {:api-params {:series-slug "my-other-series"}
+                             :jsonld-doc {"dcterms:title" "New title"}})
 
 
-
-(comment
-
-
-
-  (swap! db assoc "some-other-path" {"some" "jsonld"})
-
-  (db/destroy db)
+    @db)
 
   )
+
 
 
 ;; POST /data/:series-slug/:release-slug

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -1,9 +1,11 @@
 (ns tpximpact.datahost.scratch.model-test
   (:require
-   [clojure.test :as t]
+   [clojure.test :refer [deftest is testing]]
    [clojure.set :as set]
+   [clojure.java.io :as io]
    [clojure.tools.logging :as log]
-   [tpximpact.datahost.scratch.series :as series]))
+   [tpximpact.datahost.scratch.series :as series]
+   [grafter-2.rdf4j.io :as gio]))
 
 (def db (atom {}))
 
@@ -66,7 +68,7 @@
    "@context" ["https://publishmydata.com/def/datahost/context"
                {"@base" "https://example.org/data/my-dataset-series/2018/schema/"}]
    "@id" "2018"
-   "dh:columns": [{"csvw:datatype" "string" ;; should support all/most csvw datatype definitions
+   "dh:columns" [{"csvw:datatype" "string" ;; should support all/most csvw datatype definitions
                    "csvw:name" "sex"
                    "csvw:title" "Sex"
                    "@type" "dh:DimensionColumn" ;; | "dh:MeasureColumn" | "dh:AttributeColumn"
@@ -122,3 +124,7 @@
                                           ])
 
 (defn add-changeset [release {:keys [description append delete]}])
+
+
+(deftest ontology-parses
+  (is (< 0 (count (gio/statements (io/file "./doc/datahost-ontology.ttl"))))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -69,55 +69,7 @@
       )))
 
 
-(let [coercion-properties #{"csvw:null" "csvw:default" "csvw:separator" "csvw:ordered"}
-      transformation-properties #{"csvw:aboutUrl" "csvw:propertyUrl" "csvw:valueUrl" "csvw:virtual" "csvw:suppressOutput"}]
 
-
-  (def reserved-schema-properties
-    "These csvw properties are currently intentional unsupported, but some may
-  be supported in the future.
-
-  For example we're hoping to automatically define and generate
-  aboutUrl's from the CSV when we know the type of all columns in the
-  cube."
-    (set/union coercion-properties transformation-properties)))
-
-(defn normalise-schema [release schema]
-  {"@type" #{"dh:TableSchema" "dh:UserSchema"} ; | dh:RevisionSchema
-   "@context" ["https://publishmydata.com/def/datahost/context"
-               {"@base" "https://example.org/data/my-dataset-series/2018/schema/"}]
-   "@id" "2018"
-   "dh:columns" [{"csvw:datatype" "string" ;; should support all/most csvw datatype definitions
-                  "csvw:name" "sex"
-                  "csvw:title" "Sex"
-                  "@type" "dh:DimensionColumn" ;; | "dh:MeasureColumn" | "dh:AttributeColumn"
-                  ;;"csvw:ordered" false
-                  ;;"csvw:virtual" true
-
-                  ;;"csvw:aboutUrl" "uri-template"
-                  ;;"csvw:propertyUrl" "uri-template"
-                  ;;"csvw:valueUrl" "uri-template"
-
-                  ;;"csvw:required" true
-                  ;;"csvw:separator" ";"
-                  ;;"csvw:suppressOutput" false
-                  ;;"csvw:textDirection" "ltr"
-                  ;;"csvw:transformations" []
-                  ;;
-                  ;;"csvw:default" "default-value"
-                  ;;"csvw:null" "n/a"
-
-
-                  ;;"csvw:lang" "en"
-
-
-                  }]}
-  )
-
-(defn derive-revision-schema
-  "Derive a dh:RevisionSchema from a dh:CubeSchema"
-  [cube-schema]
-  )
 
 (def example-changesets [{:description "first changeset"
                           :commits [{:append [["male" "manchester" 3]]

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -15,6 +15,8 @@
 
 
 
+(deftest ontology-parses
+  (is (< 0 (count (gio/statements (io/file "./doc/datahost-ontology.ttl"))))))
 
 (defn db->matcha [db]
   (->> db
@@ -31,6 +33,9 @@
 
 
 (deftest loading-data-workflow-with-rdf
+
+  ;; NOTE this is a stateful test with accreting data
+
   (let [db (atom {})] ;; an empty database
     (testing "Constructing the series"
       ;; first make a series
@@ -61,20 +66,11 @@
                                                           :jsonld-doc {"dcterms:title" "2018"}})]
           (is (= start-state end-state))))
 
+      (testing "RDF graph joins up"
+        (let [mdb (db->matcha @db)]
+          (is (matcha/ask [[example:my-release dcat:inSeries example:my-dataset-series]]
+                          mdb))))
 
       (testing "TODO inverse triples see issue: https://github.com/Swirrl/datahost-prototypes/issues/54"
 
-        )
-
-      )))
-
-
-
-
-
-
-
-
-
-(deftest ontology-parses
-  (is (< 0 (count (gio/statements (io/file "./doc/datahost-ontology.ttl"))))))
+        ))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -1,0 +1,82 @@
+(ns tpximpact.datahost.scratch.model-test
+  (:require
+   [clojure.test :as t]
+   [clojure.tools.logging :as log]
+   [tpximpact.datahost.scratch.series :as series]))
+
+(def db (atom {}))
+
+(defn update-series [old-series {:keys [api-params jsonld-doc] :as _new-series}]
+  (log/info "Updating series " (:series-slug api-params))
+  (series/normalise-series api-params jsonld-doc))
+
+(defn create-series [api-params jsonld-doc]
+  (log/info "Updating series " (:series-slug api-params))
+  (series/normalise-series api-params jsonld-doc))
+
+(defn upsert-series [db {:keys [api-params jsonld-doc] :as new-series}]
+  (let [k (str (.getPath series/ld-root) (:series-slug api-params))]
+    (if-let [old-series (get db k)]
+      (update db k update-series new-series)
+      (assoc db k (normalise-series api-params jsonld-doc)))))
+
+(defn normalise-release [{:keys [series-slug release-slug] :as api-params} jsonld-doc]
+  (let [series-path (str (.getPath series/ld-root) series-slug)
+        series (get @db series-path)
+        base-entity (get series "dh:base-entity")
+        _ (assert base-entity "Expected base entity to be set")
+        context ["https://publishmydata.com/def/datahost/context"
+                 {"@base" base-entity}]]
+
+    (-> (series/merge-params-with-doc api-params jsonld-doc)
+        (assoc "@context" context
+               "@id" release-slug
+               "dcat:inSeries" (str "../" series-slug)))))
+
+(defn- update-release [old-release {:keys [api-params jsonld-doc] :as _new-release}]
+  (log/info "Updating release " (:series-slug api-params) "/" (:release-slug api-params))
+  (normalise-release api-params jsonld-doc))
+
+(defn upsert-release [db {:keys [series-slug release-slug] :as api-params} jsonld-doc]
+  (let [release-path (str (.getPath series/ld-root) series-slug "/" release-slug)]
+    (if-let [old-release (get db release-path)]
+      (update db release-path update-release {:api-params api-params :jsonld-doc jsonld-doc})
+      (assoc db release-path (normalise-release api-params jsonld-doc)))))
+
+;; create-series
+(swap! db upsert-series {:api-params {:series-slug "my-dataset-series"}})
+
+;; upsert release
+;;(swap! db normalise-release {:series-slug "my-dataset-series" :release-slug "2018"} {})
+
+(swap! db upsert-release {:series-slug "my-dataset-series" :release-slug "2018"} {"dcterms:title" "my release"})
+
+
+(defn add-schema [release schema]
+  ;; TODO
+  )
+
+(def example-changesets [{:description "first changeset"
+                          :commits [{:append [["male" "manchester" 3]]
+                                     :description "add obs"}]}
+                         {:description "second changeset"
+                          :commits [{:append [["female" "manchester" 4]]
+                                     :description "add obs"}]}
+                         {:description "second changeset"
+                          :commits [{:delete [["male" "manchester" 3]]
+                                     :append [["male" "manchester" 4]]
+                                     :description "correct incorrect observation"}]}
+                         ])
+
+(def equivalent-changes-in-one-changeset [{:description "Coin the first release"
+                                           :commits [{:append [["male" "manchester" 3]]
+                                                      :description "add obs"}
+                                                     {:append [["female" "manchester" 4]]
+                                                      :description "add obs"}
+                                                     {:delete [["male" "manchester" 3]]
+                                                      :append [["male" "manchester" 4]]
+                                                      :description "correct incorrect observation"}]}
+
+                                          ])
+
+(defn add-changeset [release {:keys [description append delete]}])

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -71,30 +71,9 @@
 
 
 
-(def example-changesets [{:description "first changeset"
-                          :commits [{:append [["male" "manchester" 3]]
-                                     :description "add obs"}]}
-                         {:description "second changeset"
-                          :commits [{:append [["female" "manchester" 4]]
-                                     :description "add obs"}]}
-                         {:description "second changeset"
-                          :commits [{:delete [["male" "manchester" 3]]
-                                     :append [["male" "manchester" 4]]
-                                     :description "correct incorrect observation"}]}
-                         ])
 
-(def equivalent-changes-in-one-changeset [{:description "Coin the first release"
-                                           :commits [{:append [["male" "manchester" 3]]
-                                                      :description "add obs"}
-                                                     {:append [["female" "manchester" 4]]
-                                                      :description "add obs"}
-                                                     {:delete [["male" "manchester" 3]]
-                                                      :append [["male" "manchester" 4]]
-                                                      :description "correct incorrect observation"}]}
 
-                                          ])
 
-(defn add-changeset [release {:keys [description append delete]}])
 
 
 (deftest ontology-parses

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -124,30 +124,30 @@
                {"@base" "https://example.org/data/my-dataset-series/2018/schema/"}]
    "@id" "2018"
    "dh:columns" [{"csvw:datatype" "string" ;; should support all/most csvw datatype definitions
-                   "csvw:name" "sex"
-                   "csvw:title" "Sex"
-                   "@type" "dh:DimensionColumn" ;; | "dh:MeasureColumn" | "dh:AttributeColumn"
-                   ;;"csvw:ordered" false
-                   ;;"csvw:virtual" true
+                  "csvw:name" "sex"
+                  "csvw:title" "Sex"
+                  "@type" "dh:DimensionColumn" ;; | "dh:MeasureColumn" | "dh:AttributeColumn"
+                  ;;"csvw:ordered" false
+                  ;;"csvw:virtual" true
 
-                   ;;"csvw:aboutUrl" "uri-template"
-                   ;;"csvw:propertyUrl" "uri-template"
-                   ;;"csvw:valueUrl" "uri-template"
+                  ;;"csvw:aboutUrl" "uri-template"
+                  ;;"csvw:propertyUrl" "uri-template"
+                  ;;"csvw:valueUrl" "uri-template"
 
-                   ;;"csvw:required" true
-                   ;;"csvw:separator" ";"
-                   ;;"csvw:suppressOutput" false
-                   ;;"csvw:textDirection" "ltr"
-                   ;;"csvw:transformations" []
-                   ;;
-                   ;;"csvw:default" "default-value"
-                   ;;"csvw:null" "n/a"
-
-
-                   ;;"csvw:lang" "en"
+                  ;;"csvw:required" true
+                  ;;"csvw:separator" ";"
+                  ;;"csvw:suppressOutput" false
+                  ;;"csvw:textDirection" "ltr"
+                  ;;"csvw:transformations" []
+                  ;;
+                  ;;"csvw:default" "default-value"
+                  ;;"csvw:null" "n/a"
 
 
-                   }]}
+                  ;;"csvw:lang" "en"
+
+
+                  }]}
   )
 
 (defn derive-revision-schema

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/series_test.clj
@@ -69,6 +69,7 @@
       (is (= {"@id" "my-dataset-series"
               "@context" ["https://publishmydata.com/def/datahost/context"
                           {"@base" "https://example.org/data/"}]
+              "@type" "dh:DatasetSeries"
               "dh:baseEntity" "https://example.org/data/my-dataset-series/"}
              returned-value))
 
@@ -82,9 +83,10 @@
 
         (is (= {"@context"
                 ["https://publishmydata.com/def/datahost/context"
-                 {"@base" "https://example.org/data/"}],
-                "dcterms:title" "My Dataset Series",
-                "@id" "my-dataset-series",
+                 {"@base" "https://example.org/data/"}]
+                "@id" "my-dataset-series"
+                "@type" "dh:DatasetSeries"
+                "dcterms:title" "My Dataset Series"
                 "dh:baseEntity" "https://example.org/data/my-dataset-series/"}
                ednld))
 

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/series_test.clj
@@ -69,7 +69,7 @@
       (is (= {"@id" "my-dataset-series"
               "@context" ["https://publishmydata.com/def/datahost/context"
                           {"@base" "https://example.org/data/"}]
-              "dh:base-entity" "https://example.org/data/my-dataset-series/"}
+              "dh:baseEntity" "https://example.org/data/my-dataset-series/"}
              returned-value))
 
       (is (canonicalisation-idempotent? {:series-slug "my-dataset-series"} returned-value)))
@@ -85,7 +85,7 @@
                  {"@base" "https://example.org/data/"}],
                 "dcterms:title" "My Dataset Series",
                 "@id" "my-dataset-series",
-                "dh:base-entity" "https://example.org/data/my-dataset-series/"}
+                "dh:baseEntity" "https://example.org/data/my-dataset-series/"}
                ednld))
 
         (testing "as RDF"


### PR DESCRIPTION
The tests all pass so this can be merged if we want.

It’s still all in the scratch namespace in the source tree, so it’s not integrated with the http layer, so is relatively independent from the rest of the code.

It does however define a bit more of the shape regarding dataset-series and releases (and hints towards the future with schemas attached to releases, and some small sketch work on changesets).

But the main thing that’s getting closer are dataset-series and release entities.

The main other relevant thing is that I’ve written some tests defining expectations around constructing a series and a release within it:

https://github.com/Swirrl/datahost-prototypes/blob/49ee1d326f65db7f3c564f9d20fa2783050bd399/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj#L33-L69

The test basically just creates a series called my-dataset-series and a single 2018 release within it, tests idempotency (upserting twice) and that the two entities RDFize to some of triples we expect.

Obviously at some point we will want to recreate these sort of tests but through the OpenAPI layer.
