### PR TITLE
Integrating handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 .envrc
 .rebl
 datahost-ld-openapi/tmp
+.datahostdb.edn

--- a/datahost-ld-openapi/resources/ldapi/base-system.edn
+++ b/datahost-ld-openapi/resources/ldapi/base-system.edn
@@ -9,5 +9,10 @@
 
  :tpximpact.datahost.ldapi.native-datastore/repo {:data-directory "/tmp/ld-dev-db"}
 
- :tpximpact.datahost.ldapi.router/handler {:triplestore #ig/ref :tpximpact.datahost.ldapi.native-datastore/repo}
- }
+ :tpximpact.datahost.ldapi.router/handler {:triplestore #ig/ref :tpximpact.datahost.ldapi.native-datastore/repo
+                                           :db #ig/ref :tpximpact.datahost.ldapi.db/db}
+
+ :tpximpact.datahost.ldapi.db/db {:storage-type :local-file
+                                  :opts {:file-path ".datahostdb.edn"
+                                         :commit-mode :sync
+                                         :init {}}}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -1,7 +1,7 @@
 (ns tpximpact.datahost.ldapi.db
-  (:require [duratom.core :as da]))
+  (:require
+   [duratom.core :as da]
+   [integrant.core :as ig]))
 
-(def db (da/duratom :local-file
-                    :file-path ".datahostdb.edn"
-                    :commit-mode :sync
-                    :init {}))
+(defmethod ig/init-key :tpximpact.datahost.ldapi.db/db [_ {:keys [storage-type opts]}]
+  (da/duratom storage-type opts))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -1,0 +1,7 @@
+(ns tpximpact.datahost.ldapi.db
+  (:require [duratom.core :as da]))
+
+(def db (da/duratom :local-file
+                    :file-path ".datahostdb.edn"
+                    :commit-mode :sync
+                    :init {}))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -1,7 +1,15 @@
 (ns tpximpact.datahost.ldapi.db
   (:require
    [duratom.core :as da]
-   [integrant.core :as ig]))
+   [integrant.core :as ig]
+   [tpximpact.datahost.ldapi.series :as series]))
 
 (defmethod ig/init-key :tpximpact.datahost.ldapi.db/db [_ {:keys [storage-type opts]}]
   (da/duratom storage-type opts))
+
+(defn upsert-series! [db {:keys [series-slug] :as api-params} incoming-jsonld-doc]
+  (let [new-series (series/normalise-series api-params incoming-jsonld-doc)
+        series-key (series/dataset-series-key series-slug)
+        updated-db (swap! db series/upsert-series {:api-params api-params
+                                                   :jsonld-doc incoming-jsonld-doc})]
+    (get updated-db series-key)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -1,4 +1,7 @@
-(ns  tpximpact.datahost.ldapi.handlers)
+(ns tpximpact.datahost.ldapi.handlers
+  (:require
+   [tpximpact.datahost.ldapi.series :as series]
+   [tpximpact.datahost.ldapi.db :as db]))
 
 (defn get-dataset-series [{{:keys [dataset-series]} :path-params}]
   ;; (sc.api/spy)
@@ -6,13 +9,15 @@
    :body {:name "foo"
           :size 123}})
 
-(defn put-dataset-series [{:keys [body-params]
+
+
+(defn put-dataset-series [{:keys [body-params path-params query-params]
                            {:keys [dataset-series]} :path-params
-                           {:keys [title description]} :query :as request}]
+                           {:keys [title description]} :query-params :as request}]
   (let [json-ld-doc body-params]
-    (println json-ld-doc)
-    ;; (sc.api/spy)
-    )
+    (series/upsert-series @db/db (merge path-params
+                                        query-params
+                                        {:jsonld-doc body-params})))
   {:status 200
    :body {:name "foo"
           :size 123}})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -1,0 +1,16 @@
+(ns  tpximpact.datahost.ldapi.handlers)
+
+(defn get-dataset-series [{{:keys [dataset-series]} :path-params}]
+  ;; (sc.api/spy)
+  {:status 200
+   :body {:name "foo"
+          :size 123}})
+
+(defn put-dataset-series [{:keys [body-params]
+                           {:keys [dataset-series]} :path-params
+                           {:keys [title description]} :query :as request}]
+  (let [json-ld-doc body-params])
+  ;; (sc.api/spy)
+  {:status 200
+   :body {:name "foo"
+          :size 123}})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -11,16 +11,16 @@
       {:status 404
        :body "Not found"})))
 
-(defn put-dataset-series [db {:keys [body-params path-params query-params] :as request}]
-  (try
-    (swap! db series/upsert-series {:api-params (merge path-params
-                                                          query-params)
-                                       :jsonld-doc body-params})
-    {:status 200
-     :body {:status "success"}}
+(defn put-dataset-series [db {:keys [body-params path-params query-params]}]
+  (let [params (-> query-params (update-keys keyword) (merge path-params))]
+    (try
+      (swap! db series/upsert-series {:api-params params
+                                      :jsonld-doc body-params})
+      {:status 200
+       :body {"status" "success"}}
 
-    (catch Throwable e
-      (let [message (ex-message e)]
-        {:status 500
-         :body {:status "error"
-                :message message}}))))
+      (catch Throwable e
+        (let [message (ex-message e)]
+          {:status 500
+           :body {:status "error"
+                  :message message}})))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -9,8 +9,10 @@
 (defn put-dataset-series [{:keys [body-params]
                            {:keys [dataset-series]} :path-params
                            {:keys [title description]} :query :as request}]
-  (let [json-ld-doc body-params])
-  ;; (sc.api/spy)
+  (let [json-ld-doc body-params]
+    (println json-ld-doc)
+    ;; (sc.api/spy)
+    )
   {:status 200
    :body {:name "foo"
           :size 123}})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -1,17 +1,16 @@
 (ns tpximpact.datahost.ldapi.handlers
   (:require
-   [tpximpact.datahost.ldapi.series :as series]
-   [tpximpact.datahost.ldapi.db :as db]))
+   [tpximpact.datahost.ldapi.series :as series]))
 
-(defn get-dataset-series [{{:keys [series-slug]} :path-params}]
+(defn get-dataset-series [db {{:keys [series-slug]} :path-params}]
   (let [key (series/dataset-series-key series-slug)
-        jsonld-doc (get @db/db key)]
+        jsonld-doc (get @db key)]
     {:status 200
      :body jsonld-doc}))
 
-(defn put-dataset-series [{:keys [body-params path-params query-params]}]
+(defn put-dataset-series [db {:keys [body-params path-params query-params]}]
   (try
-    (swap! db/db series/upsert-series {:api-params (merge path-params
+    (swap! db series/upsert-series {:api-params (merge path-params
                                                           query-params)
                                        :jsonld-doc body-params})
     {:status 200

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -21,6 +21,6 @@
 
     (catch Throwable e
       (let [{:keys [type expected-value actual-value]} (ex-data e)
-            cause (ex-cause e)]
+            message (ex-message e)]
         {:status 500
-         :body (str "error: " (name type))}))))
+         :body (str "Error: " message)}))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -16,8 +16,11 @@
   (try
     (let [api-params (-> query-params (update-keys keyword) (merge path-params))
           incoming-jsonld-doc body-params
-          jsonld-doc (db/upsert-series! db api-params incoming-jsonld-doc)]
-      {:status 200
+          {:keys [op jsonld-doc]} (db/upsert-series! db api-params incoming-jsonld-doc)
+          response-code (case op
+                          :create 201
+                          :update 200)]
+      {:status response-code
        :body jsonld-doc})
 
     (catch Throwable e

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -5,10 +5,13 @@
 (defn get-dataset-series [db {{:keys [series-slug]} :path-params}]
   (let [key (series/dataset-series-key series-slug)
         jsonld-doc (get @db key)]
-    {:status 200
-     :body jsonld-doc}))
+    (if jsonld-doc
+      {:status 200
+       :body jsonld-doc}
+      {:status 404
+       :body "Not found"})))
 
-(defn put-dataset-series [db {:keys [body-params path-params query-params]}]
+(defn put-dataset-series [db {:keys [body-params path-params query-params] :as request}]
   (try
     (swap! db series/upsert-series {:api-params (merge path-params
                                                           query-params)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -18,7 +18,7 @@
      :body {:status "success"}}
 
     (catch Throwable e
-      (let [{:keys [type expected-value actual-value]} (ex-data e)
-            message (ex-message e)]
+      (let [message (ex-message e)]
         {:status 500
-         :body (str "Error: " message)}))))
+         :body {:status "error"
+                :message message}}))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -4,14 +4,12 @@
    [tpximpact.datahost.ldapi.db :as db]))
 
 (defn get-dataset-series [{{:keys [series-slug]} :path-params}]
-  ;; (sc.api/spy)
-  {:status 200
-   :body {:name "foo"
-          :size 123}})
+  (let [key (series/dataset-series-key series-slug)
+        jsonld-doc (get @db/db key)]
+    {:status 200
+     :body jsonld-doc}))
 
-(defn put-dataset-series [{:keys [body-params path-params query-params]
-                           {:keys [series-slug]} :path-params
-                           {:keys [title description]} :query-params :as request}]
+(defn put-dataset-series [{:keys [body-params path-params query-params]}]
   (try
     (swap! db/db series/upsert-series {:api-params (merge path-params
                                                           query-params)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -50,9 +50,10 @@
 
 (defn router [triplestore db]
   (ring/router
-   [["/triplestore-query" ;; TODO remove this route when we have real ones using the triplestore
-     {:get {:nodoc true}
-      :handler #(query-example triplestore %)}]
+   [["/triplestore-query"
+     ;; TODO remove this route when we have real ones using the triplestore
+     {:get {:no-doc true
+            :handler #(query-example triplestore %)}}]
     ["/openapi.json"
      {:get {:no-doc true
             :openapi {:openapi "3.0.0"

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -97,9 +97,12 @@
                                   [:description {:title "Description"
                                                  :description "Description of dataset"
                                                  :optional true} string?]]}
-             :responses {;200 {:body [:maybe [:map]]}
-                         ;;201 {:body [:maybe [:map]]}
-                         500 {:body [:map
+             :responses {200 {:description "Series already existed and was successfully updated"
+                              :body map?}
+                         201 {:description "Series did not exist previously and was successfully created"
+                              :body map?}
+                         500 {:description "Internal server error"
+                              :body [:map
                                      [:status [:enum "error"]]
                                      [:message string?]]}}
              :handler (partial handlers/put-dataset-series db)}}]]]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -60,14 +60,14 @@
             :handler (openapi/create-openapi-handler)}}]
 
     ["/data" {:tags ["linked data api"]}
-     ["/:dataset-series"
+     ["/:series-slug"
       {:muuntaja json-string-keys-muuntaja-coercer
        :get {:summary "Retrieve metadata for an existing dataset-series"
              :description "blah blah blah. [a link](http://foo.com/)
 * bulleted
 * list
 * here"
-             :parameters {:path {:dataset-series string?}}
+             :parameters {:path {:series-slug string?}}
              :responses {200 {:body {:name string?, :size int?}}}
              :handler handlers/get-dataset-series}
        :put {:summary "Create or update metadata on a dataset-series"
@@ -77,7 +77,7 @@
                                   ["@context" [:or :string
                                                [:tuple :string [:map
                                                                 ["@base" string?]]]]]]]
-                          :path {:dataset-series string?}
+                          :path {:series-slug string?}
                           :query [:map
                                   [:title {:title "X parameter"
                                            :description "Description for X parameter"

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -68,22 +68,24 @@
 * list
 * here"
              :parameters {:path {:series-slug string?}}
-             :responses {200 {:body {:name string?, :size int?}}}
+             ;; :responses {200 {:body [:maybe [:map ]]}}
              :handler handlers/get-dataset-series}
        :put {:summary "Create or update metadata on a dataset-series"
-             :parameters {:body [:maybe
-                                 [:map
-                                  ["dcterms:title" string?]
-                                  ["@context" [:or :string
-                                               [:tuple :string [:map
-                                                                ["@base" string?]]]]]]]
+             :parameters {:body [:map]
+                          ;; [:maybe
+                          ;;        [:map
+                          ;;         ["dcterms:title" string?]
+                          ;;         ["@context" [:or :string
+                          ;;                      [:tuple :string [:map
+                          ;;                                       ["@base" string?]]]]]]]
                           :path {:series-slug string?}
-                          :query [:map
-                                  [:title {:title "X parameter"
-                                           :description "Description for X parameter"
-                                           :optional true} string?]
-                                  [:description {:optional true} string?]]}
-             :responses {200 {:body {:name string?, :size int?}}}
+                          ;; :query [:map
+                          ;;         [:title {:title "X parameter"
+                          ;;                  :description "Description for X parameter"
+                          ;;                  :optional true} string?]
+                          ;;         [:description {:optional true} string?]]
+                          }
+             :responses {200 {:body {:status string?}}}
              :handler handlers/put-dataset-series}}]]]
 
    {;;:reitit.middleware/transform dev/print-request-diffs ;; pretty diffs

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -74,10 +74,11 @@
                                       ["dcterms:description" {:optional true} string?]
                                       ["@context" [:or :string
                                                    [:tuple :string [:map
-                                                                    ["@base" string?]]]]]]]}}
+                                                                    ["@base" string?]]]]]]]}
+                         404 {:body [:enum "Not found"]}}
              :handler (partial handlers/get-dataset-series db)}
        :put {:summary "Create or update metadata on a dataset-series"
-             :parameters {:body [:map]
+             :parameters {;;:body [:map]
                           ;; [:maybe
                           ;;        [:map
                           ;;         ["dcterms:title" string?]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -68,7 +68,16 @@
 * list
 * here"
              :parameters {:path {:series-slug string?}}
-             ;; :responses {200 {:body [:maybe [:map ]]}}
+             :responses {200 {:body [:maybe
+                                     [:map
+                                      ["dcterms:title" {:optional true} string?]
+                                      ["dcterms:description" {:optional true} string?]
+                                      ["@context" [:or :string
+                                                   [:tuple :string [:map
+                                                                    ["@base" string?]]]]]]]}
+                         500 {:body [:map
+                                     [:status [:enum "error"]]
+                                     [:message string?]]}}
              :handler handlers/get-dataset-series}
        :put {:summary "Create or update metadata on a dataset-series"
              :parameters {:body [:map]
@@ -79,12 +88,13 @@
                           ;;                      [:tuple :string [:map
                           ;;                                       ["@base" string?]]]]]]]
                           :path {:series-slug string?}
-                          ;; :query [:map
-                          ;;         [:title {:title "X parameter"
-                          ;;                  :description "Description for X parameter"
-                          ;;                  :optional true} string?]
-                          ;;         [:description {:optional true} string?]]
-                          }
+                          :query [:map
+                                  [:title {:title "Title"
+                                           :description "Title of dataset"
+                                           :optional true} string?]
+                                  [:description {:title "Description"
+                                                 :description "Description of dataset"
+                                                 :optional true} string?]]}
              :responses {200 {:body {:status string?}}}
              :handler handlers/put-dataset-series}}]]]
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -39,6 +39,15 @@
        (assoc-in [:formats "application/json" :decoder-opts] {:decode-key-fn identity})
        (assoc-in [:formats "application/json" :encoder-opts] {:encode-key-fn identity}))))
 
+(def JsonLdSchema
+  [:maybe
+   [:map
+    ["dcterms:title" {:optional true} string?]
+    ["dcterms:description" {:optional true} string?]
+    ["@context" [:or :string
+                 [:tuple :string [:map
+                                  ["@base" string?]]]]]]])
+
 (defn router [triplestore db]
   (ring/router
    [["/triplestore-query" ;; TODO remove this route when we have real ones using the triplestore
@@ -68,13 +77,7 @@
 * list
 * here"
              :parameters {:path {:series-slug string?}}
-             :responses {200 {:body [:maybe
-                                     [:map
-                                      ["dcterms:title" {:optional true} string?]
-                                      ["dcterms:description" {:optional true} string?]
-                                      ["@context" [:or :string
-                                                   [:tuple :string [:map
-                                                                    ["@base" string?]]]]]]]}
+             :responses {200 {:body JsonLdSchema}
                          404 {:body [:enum "Not found"]}}
              :handler (partial handlers/get-dataset-series db)}
        :put {:summary "Create or update metadata on a dataset-series"
@@ -93,8 +96,8 @@
                                   [:description {:title "Description"
                                                  :description "Description of dataset"
                                                  :optional true} string?]]}
-             :responses {200 {:body [:map
-                                     ["status" [:enum "success"]]]}
+             :responses {;200 {:body [:maybe [:map]]}
+                         ;;201 {:body [:maybe [:map]]}
                          500 {:body [:map
                                      [:status [:enum "error"]]
                                      [:message string?]]}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
@@ -1,0 +1,146 @@
+(ns tpximpact.datahost.ldapi.series
+  (:require
+   [clojure.set :as set]
+   [clojure.tools.logging :as log]
+   [tpximpact.datahost.ldapi.util]
+   [malli.core :as m]
+   [malli.error :as me])
+  (:import
+   [java.net URI] ;; [com.github.jsonldjava.core JsonLdProcessor RDFDatasetUtils JsonLdTripleCallback]
+   ))
+
+(def ld-root
+  "For the prototype this item will come from config or be derived from
+  it. It should have a trailing slash."
+  (URI. "https://example.org/data/"))
+
+(def SeriesApiParams [:map
+                      [:series-slug :series-slug-string]
+                      [:title {:optional true} :string]
+                      [:description {:optional true} :string]])
+
+(def registry
+  (merge
+   (m/class-schemas)
+   (m/comparator-schemas)
+   (m/base-schemas)
+   (m/type-schemas)
+   {:series-slug-string [:and :string [:re {:error/message "should contain alpha numeric characters and hyphens only."}
+                                       #"^[a-z,A-Z,\-,0-9]+$"]]
+    :url-string (m/-simple-schema {:type :url-string :pred
+                                   (fn [x]
+                                     (and (string? x)
+                                          (try (URI. x)
+                                               true
+                                               (catch Exception ex
+                                                 false))))})}))
+
+(defn normalise-context [ednld]
+  (let [normalised-context ["https://publishmydata.com/def/datahost/context"
+                            {"@base" (str ld-root)}]]
+    (if-let [context (get ednld "@context")]
+      (cond
+        (= context "https://publishmydata.com/def/datahost/context") normalised-context
+        (= context normalised-context) normalised-context
+
+        :else (throw (ex-info "Invalid @context" {:supplied-context context
+                                                  :valid-context normalised-context})))
+
+      ;; return normalised-context if none provided
+      normalised-context)))
+
+(defn validate-id [{:keys [series-slug] :as _api-params} cleaned-doc]
+  (let [id-in-doc (get cleaned-doc "@id")]
+    (cond
+      (nil? id-in-doc) cleaned-doc
+
+      (= series-slug id-in-doc) cleaned-doc
+
+      :else (throw
+             (ex-info "@id should for now be expressed as a slugged style suffix, and if present match that supplied as the API slug."
+                      {:supplied-id id-in-doc
+                       :expected-id series-slug})))))
+
+(defn validate-series-context [ednld]
+  (if-let [base-in-doc (get-in ednld ["@context" 1 "@base"])]
+    (if (= (str ld-root) base-in-doc)
+      (update ednld "@context" normalise-context)
+      (throw (ex-info
+              (str "@base for the dataset-series must currently be set to the linked-data root '" ld-root "'")
+              {:type :validation-error
+               :expected-value (str ld-root)
+               :actual-value base-in-doc})))
+    (update ednld "@context" normalise-context)))
+
+(defn merge-params-with-doc [{:keys [series-slug] :as api-params} jsonld-doc]
+  (let [merged-doc (merge (set/rename-keys api-params
+                                           {:title "dcterms:title"
+                                            :description "dcterms:description"})
+                          jsonld-doc)
+        cleaned-doc (-> merged-doc
+                        (util/dissoc-by-key keyword?)
+                        #_(update "@context" normalise-context))]
+
+    cleaned-doc))
+
+(defn normalise-series
+  "Takes api params and an optional json-ld document of metadata, and
+  returns a normalised EDN form of the JSON-LD, with the API
+  parameters applied, validated and some structures like the context
+  normalised."
+  ([api-params]
+   (normalise-series api-params nil))
+  ([{:keys [series-slug] :as api-params} jsonld-doc]
+   (when-not (m/validate SeriesApiParams api-params {:registry registry})
+     (throw (ex-info "Invalid API parameters"
+                     {:type :validation-error
+                      :validation-error (-> (m/explain SeriesApiParams api-params {:registry registry})
+                                            (me/humanize))})))
+
+   (let [cleaned-doc (merge-params-with-doc api-params jsonld-doc)
+
+         validated-doc (-> (validate-id api-params cleaned-doc)
+                           (validate-series-context))
+
+         final-doc (assoc validated-doc
+                            ;; add any managed params
+                          "@type" "dh:DatasetSeries"
+                          "@id" series-slug
+                          "dh:baseEntity" (str ld-root series-slug "/") ;; coin base-entity to serve as the @base for nested resources
+                          )]
+     final-doc)))
+
+(defn- update-series [old-series {:keys [api-params jsonld-doc] :as _new-series}]
+  (log/info "Updating series " (:series-slug api-params))
+  (normalise-series api-params jsonld-doc))
+
+(defn- create-series [api-params jsonld-doc]
+  (log/info "Updating series " (:series-slug api-params))
+  (normalise-series api-params jsonld-doc))
+
+(defn upsert-series
+  "Takes a derefenced db state map with the shape {path jsonld} and
+  upserts a new dataset series into it.
+
+  Intended usage is via swap!
+
+  ```
+  (swap! db upsert-series {:api-params {:series-slug \"my-dataset-series\"}
+                           :jsonld-doc {}})
+  ```
+
+  An upsert will insert a new series if it isn't there already.
+
+  If the series exists already it will replace the majority of the
+  fields with those newly supplied, but may ignore or manage some
+  fields specially on update.
+
+  For example a `dcterms:issued` time should not change after a
+  document is updated (TODO: https://github.com/Swirrl/datahost-prototypes/issues/57)
+  "
+  [db {:keys [api-params jsonld-doc] :as new-series}]
+  (let [k (str (.getPath ld-root) (:series-slug api-params))]
+    (sc.api/spy)
+    (if-let [_old-series (get db k)]
+      (update db k update-series new-series)
+      (assoc db k (create-series api-params jsonld-doc)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
@@ -127,8 +127,7 @@
   Intended usage is via swap!
 
   ```
-  (swap! db upsert-series {:api-params {:series-slug \"my-dataset-series\"}
-                           :jsonld-doc {}})
+  (swap! db upsert-series {:series-slug \"my-dataset-series\"} {})
   ```
 
   An upsert will insert a new series if it isn't there already.
@@ -140,8 +139,8 @@
   For example a `dcterms:issued` time should not change after a
   document is updated (TODO: https://github.com/Swirrl/datahost-prototypes/issues/57)
   "
-  [db api-params jsonld-doc]
-  (let [series-key (dataset-series-key (:series-slug api-params))]
-    (if-let [_old-series (get db series-key)]
-      (update db series-key update-series api-params jsonld-doc)
-      (assoc db series-key (create-series api-params jsonld-doc)))))
+  ([db api-params jsonld-doc]
+   (let [series-key (dataset-series-key (:series-slug api-params))]
+     (if-let [_old-series (get db series-key)]
+       (update db series-key update-series api-params jsonld-doc)
+       (assoc db series-key (create-series api-params jsonld-doc))))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
@@ -14,6 +14,9 @@
   it. It should have a trailing slash."
   (URI. "https://example.org/data/"))
 
+(defn dataset-series-key [series-slug]
+  (str (.getPath ld-root) series-slug))
+
 (def SeriesApiParams [:map
                       [:series-slug :series-slug-string]
                       [:title {:optional true} :string]
@@ -139,7 +142,7 @@
   document is updated (TODO: https://github.com/Swirrl/datahost-prototypes/issues/57)
   "
   [db {:keys [api-params jsonld-doc] :as new-series}]
-  (let [k (str (.getPath ld-root) (:series-slug api-params))]
+  (let [k (dataset-series-key (:series-slug api-params))]
     (if-let [_old-series (get db k)]
       (update db k update-series new-series)
       (assoc db k (create-series api-params jsonld-doc)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
@@ -112,7 +112,7 @@
                           )]
      final-doc)))
 
-(defn- update-series [_old-series {:keys [api-params jsonld-doc] :as _new-series}]
+(defn- update-series [_old-series api-params jsonld-doc]
   (log/info "Updating series " (:series-slug api-params))
   (normalise-series api-params jsonld-doc))
 
@@ -140,8 +140,8 @@
   For example a `dcterms:issued` time should not change after a
   document is updated (TODO: https://github.com/Swirrl/datahost-prototypes/issues/57)
   "
-  [db {:keys [api-params jsonld-doc] :as new-series}]
+  [db api-params jsonld-doc]
   (let [series-key (dataset-series-key (:series-slug api-params))]
     (if-let [_old-series (get db series-key)]
-      (update db series-key update-series new-series)
+      (update db series-key update-series api-params jsonld-doc)
       (assoc db series-key (create-series api-params jsonld-doc)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
@@ -112,7 +112,7 @@
                           )]
      final-doc)))
 
-(defn- update-series [old-series {:keys [api-params jsonld-doc] :as _new-series}]
+(defn- update-series [_old-series {:keys [api-params jsonld-doc] :as _new-series}]
   (log/info "Updating series " (:series-slug api-params))
   (normalise-series api-params jsonld-doc))
 
@@ -141,7 +141,7 @@
   document is updated (TODO: https://github.com/Swirrl/datahost-prototypes/issues/57)
   "
   [db {:keys [api-params jsonld-doc] :as new-series}]
-  (let [k (dataset-series-key (:series-slug api-params))]
-    (if-let [_old-series (get db k)]
-      (update db k update-series new-series)
-      (assoc db k (create-series api-params jsonld-doc)))))
+  (let [series-key (dataset-series-key (:series-slug api-params))]
+    (if-let [_old-series (get db series-key)]
+      (update db series-key update-series new-series)
+      (assoc db series-key (create-series api-params jsonld-doc)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
@@ -140,7 +140,6 @@
   "
   [db {:keys [api-params jsonld-doc] :as new-series}]
   (let [k (str (.getPath ld-root) (:series-slug api-params))]
-    (sc.api/spy)
     (if-let [_old-series (get db k)]
       (update db k update-series new-series)
       (assoc db k (create-series api-params jsonld-doc)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
@@ -6,8 +6,7 @@
    [malli.core :as m]
    [malli.error :as me])
   (:import
-   [java.net URI] ;; [com.github.jsonldjava.core JsonLdProcessor RDFDatasetUtils JsonLdTripleCallback]
-   ))
+   [java.net URI]))
 
 (def ld-root
   "For the prototype this item will come from config or be derived from

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/series.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.set :as set]
    [clojure.tools.logging :as log]
-   [tpximpact.datahost.ldapi.util]
+   [tpximpact.datahost.ldapi.util :as util]
    [malli.core :as m]
    [malli.error :as me])
   (:import

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util.clj
@@ -1,4 +1,7 @@
-(ns tpximpact.datahost.ldapi.util)
+(ns tpximpact.datahost.ldapi.util
+  (:require
+   [grafter-2.rdf4j.io :as rio])
+  (:import [com.github.jsonldjava.core JsonLdProcessor RDFDatasetUtils JsonLdTripleCallback]))
 
 (defn dissoc-by-key [m pred]
   (reduce (fn [acc k]
@@ -6,3 +9,25 @@
               (dissoc acc k)
               acc))
           m (keys m)))
+
+(defn ednld->rdf
+  "Takes a JSON-LD map as an EDN datastructure and converts it into RDF
+  triples.
+
+  NOTE: the implementation is the easiest but worst way to do, but
+  should at least be correct.
+
+  TODO: At some point we should change this to a more direct/better
+  implementation."
+  [edn-ld]
+  (JsonLdProcessor/toRDF edn-ld
+                         (reify
+                           JsonLdTripleCallback
+                           (call [_ dataset]
+                             (let [nquad-string (let [sb (java.lang.StringBuilder.)]
+                                                  (RDFDatasetUtils/toNQuads dataset sb)
+                                                  (str sb))]
+
+                               (tap> nquad-string)
+
+                               (rio/statements (java.io.StringReader. nquad-string) :format :nq))))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util.clj
@@ -1,0 +1,8 @@
+(ns tpximpact.datahost.ldapi.util)
+
+(defn dissoc-by-key [m pred]
+  (reduce (fn [acc k]
+            (if (pred k)
+              (dissoc acc k)
+              acc))
+          m (keys m)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/release.clj
@@ -1,7 +1,7 @@
 (ns tpximpact.datahost.scratch.release
   (:require
    [clojure.tools.logging :as log]
-   [tpximpact.datahost.scratch.series :as series]))
+   [tpximpact.datahost.ldapi.series :as series]))
 
 (defn normalise-release [base-entity {:keys [api-params jsonld-doc]}]
   (let [{:keys [series-slug release-slug]} api-params

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
@@ -1,20 +1,11 @@
 (ns tpximpact.datahost.scratch.series
   (:require [clojure.java.io :as io]
             [grafter-2.rdf4j.io :as rio]
-            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.walk :as walk]
-            [clojure.tools.logging :as log]
-            [integrant.core :as ig]
             [malli.core :as m]
-            [malli.error :as me]
-            [malli.util :as mu]
-            [duratom.core :as db])
-  (:import [java.net URI]
-           [com.github.jsonldjava.core JsonLdProcessor RDFDatasetUtils JsonLdTripleCallback]
-           [com.github.jsonldjava.utils JsonUtils]))
-
-(def default-catalog-uri (URI. "https://example.org/data/catalog"))
+            [malli.error :as me])
+  (:import [com.github.jsonldjava.utils JsonUtils]))
 
 (def file-store (io/file "./tmp"))
 
@@ -33,27 +24,7 @@
 (defn load-jsonld [jsonld-file]
   (->edn-data (JsonUtils/fromReader (io/reader jsonld-file))))
 
-(defn ednld->rdf
-  "Takes a JSON-LD map as an EDN datastructure and converts it into RDF
-  triples.
 
-  NOTE: the implementation is the easiest but worst way to do, but
-  should at least be correct.
-
-  TODO: At some point we should change this to a more direct/better
-  implementation."
-  [edn-ld]
-  (JsonLdProcessor/toRDF edn-ld
-                         (reify
-                           JsonLdTripleCallback
-                           (call [_ dataset]
-                             (let [nquad-string (let [sb (java.lang.StringBuilder.)]
-                                                  (RDFDatasetUtils/toNQuads dataset sb)
-                                                  (str sb))]
-
-                               (tap> nquad-string)
-
-                               (rio/statements (java.io.StringReader. nquad-string) :format :nq))))))
 
 
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
@@ -43,7 +43,8 @@
   [slug]
   (when-not (valid-slug? slug)
     (throw (ex-info "slug must not start or end in a '/'" {:type :invalid-arguments})))
-  (str ld-root slug "/"))
+  ;; (str ld-root slug "/")
+  )
 
 
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/series.clj
@@ -14,11 +14,6 @@
            [com.github.jsonldjava.core JsonLdProcessor RDFDatasetUtils JsonLdTripleCallback]
            [com.github.jsonldjava.utils JsonUtils]))
 
-(def ld-root
-  "For the prototype this item will come from config or be derived from
-  it.  It should have a trailing slash."
-  (URI. "https://example.org/data/"))
-
 (def default-catalog-uri (URI. "https://example.org/data/catalog"))
 
 (def file-store (io/file "./tmp"))
@@ -60,12 +55,7 @@
 
                                (rio/statements (java.io.StringReader. nquad-string) :format :nq))))))
 
-(defn dissoc-by-key [m pred]
-  (reduce (fn [acc k]
-               (if (pred k)
-                 (dissoc acc k)
-                 acc))
-             m (keys m)))
+
 
 (defn valid-slug? [slug]
   ;; TODO add more slug rules around valid character ranges e.g.
@@ -84,40 +74,11 @@
     (throw (ex-info "slug must not start or end in a '/'" {:type :invalid-arguments})))
   (str ld-root slug "/"))
 
-(defn normalise-context [ednld]
-  (let [normalised-context ["https://publishmydata.com/def/datahost/context"
-                            {"@base" (str ld-root)}]]
-    (if-let [context (get ednld "@context")]
-      (cond
-        (= context "https://publishmydata.com/def/datahost/context") normalised-context
-        (= context normalised-context) normalised-context
 
-        :else (throw (ex-info "Invalid @context" {:supplied-context context
-                                                  :valid-context normalised-context})))
 
-      ;; return normalised-context if none provided
-      normalised-context)))
 
-(def registry
-  (merge
-   (m/class-schemas)
-   (m/comparator-schemas)
-   (m/base-schemas)
-   (m/type-schemas)
-   {:series-slug-string [:and :string [:re {:error/message "should contain alpha numeric characters and hyphens only."}
-                                #"^[a-z,A-Z,\-,0-9]+$"]]
-    :url-string (m/-simple-schema {:type :url-string :pred
-                                   (fn [x]
-                                     (and (string? x)
-                                          (try (URI. x)
-                                               true
-                                               (catch Exception ex
-                                                 false))))})}))
 
-(def SeriesApiParams [:map
-                      [:series-slug :series-slug-string]
-                      [:title {:optional true} :string]
-                      [:description {:optional true} :string]])
+
 
 (def SeriesJsonLdInput [:map
                         ["@id" :series-slug-string]
@@ -137,111 +98,22 @@
                           {:registry registry}))
   )
 
-(defn validate-id [{:keys [series-slug] :as _api-params} cleaned-doc]
-  (let [id-in-doc (get cleaned-doc "@id")]
-    (cond
-      (nil? id-in-doc) cleaned-doc
 
-      (= series-slug id-in-doc) cleaned-doc
 
-      :else (throw
-             (ex-info "@id should for now be expressed as a slugged style suffix, and if present match that supplied as the API slug."
-                      {:supplied-id id-in-doc
-                       :expected-id series-slug})))))
 
-(defn validate-series-context [ednld]
-  (if-let [base-in-doc (get-in ednld ["@context" 1 "@base"])]
-    (if (= (str ld-root) base-in-doc)
-      (update ednld "@context" normalise-context)
-      (throw (ex-info
-              (str "@base for the dataset-series must currently be set to the linked-data root '" ld-root "'")
-              {:type :validation-error
-               :expected-value (str ld-root)
-               :actual-value base-in-doc})))
-    (update ednld "@context" normalise-context)))
 
-(defn merge-params-with-doc [{:keys [series-slug] :as api-params} jsonld-doc]
-  (let [merged-doc (merge (set/rename-keys api-params
-                                           {:title "dcterms:title"
-                                            :description "dcterms:description"})
-                          jsonld-doc)
-        cleaned-doc (-> merged-doc
-                        (dissoc-by-key keyword?)
-                        #_(update "@context" normalise-context))
 
-        ]
-    cleaned-doc))
 
 ;; PUT /data/:series-slug
-(defn normalise-series
-  "Takes api params and an optional json-ld document of metadata, and
-  returns a normalised EDN form of the JSON-LD, with the API
-  parameters applied, validated and some structures like the context
-  normalised."
-  ([api-params]
-   (normalise-series api-params nil))
-  ([{:keys [series-slug] :as api-params} doc]
-   (let [jsonld-doc doc #_(into {} (load-jsonld doc))]
 
-     (when-not (m/validate SeriesApiParams api-params {:registry registry})
-       (throw (ex-info "Invalid API parameters"
-                       {:type :validation-error
-                        :validation-error (-> (m/explain SeriesApiParams api-params {:registry registry})
-                                              (me/humanize))})))
 
-     (let [cleaned-doc (merge-params-with-doc api-params doc)
 
-           validated-doc (-> (validate-id api-params cleaned-doc)
-                             (validate-series-context))
 
-           final-doc (assoc validated-doc
-                            ;; add any managed params
-                            "@type" "dh:DatasetSeries"
-                            "@id" series-slug
-                            "dh:baseEntity" (str ld-root series-slug "/") ;; coin base-entity to serve as the @base for nested resources
-                            )]
-       final-doc))))
 
-(defn- update-series [old-series {:keys [api-params jsonld-doc] :as _new-series}]
-  (log/info "Updating series " (:series-slug api-params))
-  (normalise-series api-params jsonld-doc))
 
-(defn- create-series [api-params jsonld-doc]
-  (log/info "Updating series " (:series-slug api-params))
-  (normalise-series api-params jsonld-doc))
 
-(defn upsert-series
-  "Takes a derefenced db state map with the shape {path jsonld} and
-  upserts a new dataset series into it.
-
-  Intended usage is via swap!
-
-  ```
-  (swap! db upsert-series {:api-params {:series-slug \"my-dataset-series\"}
-                           :jsonld-doc {}})
-  ```
-
-  An upsert will insert a new series if it isn't there already.
-
-  If the series exists already it will replace the majority of the
-  fields with those newly supplied, but may ignore or manage some
-  fields specially on update.
-
-  For example a `dcterms:issued` time should not change after a
-  document is updated (TODO: https://github.com/Swirrl/datahost-prototypes/issues/57)
-  "
-  [db {:keys [api-params jsonld-doc] :as new-series}]
-  (let [k (str (.getPath ld-root) (:series-slug api-params))]
-    (if-let [_old-series (get db k)]
-      (update db k update-series new-series)
-      (assoc db k (create-series api-params jsonld-doc)))))
 
 (comment
-  (def db (db/duratom :local-file
-                      :file-path ".datahostdb.edn"
-                      :commit-mode :sync
-                      :init {}))
-
   (let [db (atom {})]
 
     (swap! db upsert-series {:api-params {:series-slug "my-dataset-series"}

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/series_test.clj
@@ -23,23 +23,30 @@
             (is (= status 404))
             (is (= body "Not found"))))))
 
-    ;; (testing "A series can be created and retrieved via the API"
-    ;;   (let [response (http/put
-    ;;                   "http://localhost:3400/data/new-series"
-    ;;                   {;;:content-type :json
-    ;;                    :body
-    ;;                    (json/write-str
-    ;;                     {"@context" ["https://publishmydata.com/def/datahost/context",
-    ;;                                  {"@base" "https://example.org/data/"}],
-    ;;                      "dcterms:title" "New title"})
-    ;;                    })]
-    ;;     (is (= (:status response) 200))
-    ;;     (is (= (:body response) {:status "success"})))
+    (testing "A series can be created and retrieved via the API"
+      (let [jsonld-doc {"@context"
+                        ["https://publishmydata.com/def/datahost/context"
+                         {"@base" "https://example.org/data/"}],
+                        "dcterms:title" "A title"}]
+        (let [response (http/put
+                        "http://localhost:3400/data/new-series"
+                        {:content-type :json
+                         :body (json/write-str jsonld-doc)})]
+          (is (= (:status response) 200))
+          (is (= (json/read-str (:body response)) {"status" "success"})))
 
-    ;;   (let [response (http/get "http://localhost:3400/data/new-series")]
-    ;;     (is (= (:statis response) 200)
-    ;;         (= (:body response) {"@context" "https://example"}))))
-    ))
+        (let [response (http/get "http://localhost:3400/data/new-series")]
+          (is (= (:status response) 200))
+          (is (= (json/read-str (:body response)) jsonld-doc)))))
+
+    (testing "A series can be updated via the API"
+      (let [response (http/put "http://localhost:3400/data/new-series?title=A%20new%20title")]
+        (is (= (:status response) 200))
+        (is (= (json/read-str (:body response)) {"status" "success"})))
+
+      (let [response (http/get "http://localhost:3400/data/new-series")]
+        (is (= (:status response) 200))
+        (is (= (-> response :body json/read-str (get "dcterms:title")) "A new title"))))))
 
 (deftest normalise-context-test
   (let [expected-context ["https://publishmydata.com/def/datahost/context"

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/series_test.clj
@@ -23,30 +23,32 @@
             (is (= status 404))
             (is (= body "Not found"))))))
 
-    (testing "A series can be created and retrieved via the API"
-      (let [jsonld-doc {"@context"
-                        ["https://publishmydata.com/def/datahost/context"
-                         {"@base" "https://example.org/data/"}],
-                        "dcterms:title" "A title"}]
+    (let [incoming-jsonld-doc {"@context"
+                               ["https://publishmydata.com/def/datahost/context"
+                                {"@base" "https://example.org/data/"}],
+                               "dcterms:title" "A title"}
+          augmented-jsonld-doc (sut/normalise-series {:series-slug "new-series"}
+                                                     incoming-jsonld-doc)]
+      (testing "A series can be created and retrieved via the API"
+
         (let [response (http/put
                         "http://localhost:3400/data/new-series"
                         {:content-type :json
-                         :body (json/write-str jsonld-doc)})]
+                         :body (json/write-str incoming-jsonld-doc)})]
           (is (= (:status response) 200))
-          (is (= (json/read-str (:body response)) {"status" "success"})))
+          (is (= (json/read-str (:body response)) augmented-jsonld-doc)))
 
         (let [response (http/get "http://localhost:3400/data/new-series")]
           (is (= (:status response) 200))
-          (is (= (json/read-str (:body response)) jsonld-doc)))))
+          (is (= (json/read-str (:body response)) incoming-jsonld-doc))))
 
-    (testing "A series can be updated via the API"
-      (let [response (http/put "http://localhost:3400/data/new-series?title=A%20new%20title")]
-        (is (= (:status response) 200))
-        (is (= (json/read-str (:body response)) {"status" "success"})))
+      (testing "A series can be updated via the API"
+        (let [response (http/put "http://localhost:3400/data/new-series?title=A%20new%20title")]
+          (is (= (:status response) 200)))
 
-      (let [response (http/get "http://localhost:3400/data/new-series")]
-        (is (= (:status response) 200))
-        (is (= (-> response :body json/read-str (get "dcterms:title")) "A new title"))))))
+        (let [response (http/get "http://localhost:3400/data/new-series")]
+          (is (= (:status response) 200))
+          (is (= (-> response :body json/read-str (get "dcterms:title")) "A new title")))))))
 
 (deftest normalise-context-test
   (let [expected-context ["https://publishmydata.com/def/datahost/context"

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/series_test.clj
@@ -1,17 +1,45 @@
-(ns tpximpact.datahost.scratch.series-test
+(ns tpximpact.datahost.ldapi.series-test
   (:require
-   [clojure.data.json :as json]
+   [clj-http.client :as http]
    [clojure.test :refer [deftest is testing]]
    [grafter.matcha.alpha :as matcha]
    [grafter.vocabularies.dcterms :refer [dcterms:title]]
-   [tpximpact.datahost.scratch.series :as sut])
+   [tpximpact.datahost.ldapi.series :as sut]
+   [tpximpact.datahost.ldapi.util :as util]
+   [tpximpact.test-helpers :as th]
+   [clojure.data.json :as json])
   (:import
    (clojure.lang ExceptionInfo)
-   (java.io StringReader)
    (java.net URI)))
 
-(defn- coerce-test-json [json-as-edn]
-  (StringReader. (json/write-str json-as-edn)))
+(deftest round-tripping-series-test
+  (th/with-system sys
+    (testing "A series that does not exist returns 'not found'"
+      (try
+        (http/get "http://localhost:3400/data/does-not-exist")
+
+        (catch Throwable ex
+          (let [{:keys [status body]} (ex-data ex)]
+            (is (= status 404))
+            (is (= body "Not found"))))))
+
+    ;; (testing "A series can be created and retrieved via the API"
+    ;;   (let [response (http/put
+    ;;                   "http://localhost:3400/data/new-series"
+    ;;                   {;;:content-type :json
+    ;;                    :body
+    ;;                    (json/write-str
+    ;;                     {"@context" ["https://publishmydata.com/def/datahost/context",
+    ;;                                  {"@base" "https://example.org/data/"}],
+    ;;                      "dcterms:title" "New title"})
+    ;;                    })]
+    ;;     (is (= (:status response) 200))
+    ;;     (is (= (:body response) {:status "success"})))
+
+    ;;   (let [response (http/get "http://localhost:3400/data/new-series")]
+    ;;     (is (= (:statis response) 200)
+    ;;         (= (:body response) {"@context" "https://example"}))))
+    ))
 
 (deftest normalise-context-test
   (let [expected-context ["https://publishmydata.com/def/datahost/context"
@@ -91,7 +119,7 @@
                ednld))
 
         (testing "as RDF"
-          (let [triples (matcha/index-triples (sut/ednld->rdf ednld))]
+          (let [triples (matcha/index-triples (util/ednld->rdf ednld))]
             (testing "All emitted triples have the same expected subject"
               (is (matcha/ask [[(URI. "https://example.org/data/my-dataset-series") dcterms:title ?o]] triples))
               ;; TODO add some more tests

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/series_test.clj
@@ -35,7 +35,7 @@
                         "http://localhost:3400/data/new-series"
                         {:content-type :json
                          :body (json/write-str incoming-jsonld-doc)})]
-          (is (= (:status response) 200))
+          (is (= (:status response) 201))
           (is (= (json/read-str (:body response)) augmented-jsonld-doc)))
 
         (let [response (http/get "http://localhost:3400/data/new-series")]

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -39,7 +39,7 @@
   (let [db (atom {})] ;; an empty database
     (testing "Constructing the series"
       ;; first make a series
-      (swap! db series/upsert-series {:api-params {:series-slug "my-dataset-series" :title "My series"}})
+      (swap! db series/upsert-series {:series-slug "my-dataset-series" :title "My series"} {})
 
       (is (matcha/ask [[example:my-dataset-series dh:baseEntity ?o]] (db->matcha @db)))
       (is (matcha/ask [[example:my-dataset-series dcterms:title "My series"]] (db->matcha @db)))
@@ -47,7 +47,8 @@
       (testing "idempotent - upserting same request again is equivalent to inserting once"
 
         (let [start-state @db
-              end-state (swap! db series/upsert-series {:api-params {:series-slug "my-dataset-series" :title "My series"}})]
+              end-state (swap! db series/upsert-series
+                               {:series-slug "my-dataset-series" :title "My series"} {})]
           (is (= start-state end-state)))))
 
     (testing "Constructing a release"
@@ -71,6 +72,4 @@
           (is (matcha/ask [[example:my-release dcat:inSeries example:my-dataset-series]]
                           mdb))))
 
-      (testing "TODO inverse triples see issue: https://github.com/Swirrl/datahost-prototypes/issues/54"
-
-        ))))
+      (testing "TODO inverse triples see issue: https://github.com/Swirrl/datahost-prototypes/issues/54"))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -1,17 +1,17 @@
 (ns tpximpact.datahost.scratch.model-test
   (:require
-   [clojure.test :refer [deftest is testing]]
-   [clojure.set :as set]
    [clojure.java.io :as io]
-   [clojure.tools.logging :as log]
-   [tpximpact.datahost.scratch.series :as series]
-   [tpximpact.datahost.scratch.release :as release]
+   [clojure.test :refer [deftest is testing]]
    [grafter-2.rdf4j.io :as gio]
    [grafter.matcha.alpha :as matcha]
    [grafter.vocabularies.core :refer [prefixer]]
-   [grafter.vocabularies.dcterms :refer [dcterms:title dcterms:description]]
-   [grafter.vocabularies.dcat :refer [dcat:keyword dcat:Dataset dcat]])
-  (:import [java.net URI]))
+   [grafter.vocabularies.dcat :refer [dcat]]
+   [grafter.vocabularies.dcterms :refer [dcterms:title]]
+   [tpximpact.datahost.ldapi.util :as util]
+   [tpximpact.datahost.scratch.release :as release]
+   [tpximpact.datahost.ldapi.series :as series])
+  (:import
+   [java.net URI]))
 
 
 
@@ -21,7 +21,7 @@
 (defn db->matcha [db]
   (->> db
        vals
-       (mapcat series/ednld->rdf)
+       (mapcat util/ednld->rdf)
        (matcha/index-triples)))
 
 (def example:my-dataset-series (URI. "https://example.org/data/my-dataset-series"))

--- a/datahost-ld-openapi/test/tpximpact/ldapi_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/ldapi_test.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.test :refer :all]
     [clj-http.client :as http]
-    [tpximpact.test-helper :as th]))
+    [tpximpact.test-helpers :as th]))
 
 (deftest service-sanity-test
   (th/with-system sys

--- a/datahost-ld-openapi/test/tpximpact/native_datastore_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/native_datastore_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :refer :all]
             [com.yetanalytics.flint :as fl]
             [tpximpact.datahost.ldapi.native-datastore :as sut]
-            [tpximpact.test-helper :as th]))
-
+            [tpximpact.test-helpers :as th]))
 
 (deftest native-datastore-test
   (testing "Base data is loaded on startup"

--- a/datahost-ld-openapi/test/tpximpact/test_helpers.clj
+++ b/datahost-ld-openapi/test/tpximpact/test_helpers.clj
@@ -1,4 +1,4 @@
-(ns tpximpact.test-helper
+(ns tpximpact.test-helpers
   (:require [clojure.test :refer :all]
             [integrant.core :as ig]
             [tpximpact.datahost.ldapi :as ldapi-system]))

--- a/datahost-ld-openapi/test/tpximpact/test_helpers.clj
+++ b/datahost-ld-openapi/test/tpximpact/test_helpers.clj
@@ -3,6 +3,9 @@
             [integrant.core :as ig]
             [tpximpact.datahost.ldapi :as ldapi-system]))
 
+(defn clean-up-database! [system]
+  (let [db (get system :tpximpact.datahost.ldapi.db/db)]
+    (reset! db {})))
 
 (defmacro with-system [system-binding & body]
   `(let [config# (ldapi-system/load-configs ["ldapi/base-system.edn"
@@ -14,6 +17,7 @@
          sys# (ldapi-system/start-system config#)
          ~system-binding sys#]
      (try
-      ~@body
-      (finally
-        (ig/halt! sys#)))))
+       ~@body
+       (finally
+         (clean-up-database! sys#)
+         (ig/halt! sys#)))))


### PR DESCRIPTION
This integrates the work making series work into the api/integrant system. There are routes for `put`-ing and `get`-ing datasets, the data is currently stored in a configured duratom, and key type (i.e. string vs keyword etc) is preserved round-trip.

Closes #51 
Closes #25 