### PR TITLE
Issue 33

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,11 @@
 # See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
+orbs:
+  aws-cli: circleci/aws-cli@3.1.5
+  gcp-cli: circleci/gcp-cli@3.1.0
+  terraform: circleci/terraform@3.2.1
+
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
@@ -49,8 +54,13 @@ jobs:
       - checkout
       - run:
           name: "Deploy GraphQL docker image to registry"
-          command: "cd datahost-graphql && clojure -T:build docker :image-type :registry"
+          command: "clojure -T:build docker :image-type :registry > graphql_container_digest"
+          working_directory: datahost-graphql
           project-dir: datahost-graphql
+      - persist_to_workspace:
+          root: datahost-graphql
+          paths:
+            - graphql_container_digest
 
   deploy-ld-openapi-service:
     docker:
@@ -65,6 +75,35 @@ jobs:
           command: "cd datahost-ld-openapi && clojure -T:build docker :image-type :registry"
           project-dir: datahost-ld-openapi
 
+  deploy-graphql-vm:
+    docker:
+      - image: cimg/base:2023.05
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - terraform/install:
+          terraform_version: 1.4.6
+      - aws-cli/setup:
+          role-arn: 'arn:aws:iam::557197822758:role/circleci-datahost'
+          session-duration: '900'
+      - gcp-cli/setup:
+          version: latest
+          use_oidc: true
+      - run:
+          command: gcloud version
+      - run:
+          command: terraform init
+          working_directory: deploy/terraform/graphql
+      - run:
+          command: terraform get
+          working_directory: deploy/terraform/graphql
+      - run:
+          command: terraform plan -out update.tfplan -var digest=$(cat /tmp/workspace/graphql_container_digest)
+          working_directory: deploy/terraform/graphql
+      - run:
+          command: terraform apply update.tfplan
+          working_directory: deploy/terraform/graphql
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
@@ -109,3 +148,8 @@ workflows:
             #   ignore: /.*/
           requires:
             - test-ld-openapi-service
+      - deploy-graphql-vm:
+          context:
+            - swirrl-ons-datahost-gcloud
+          requires:
+            - deploy-graphql-service

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,3 +153,6 @@ workflows:
             - swirrl-ons-datahost-gcloud
           requires:
             - deploy-graphql-service
+          filters:
+            branches:
+              only: main

--- a/datahost-graphql/build.clj
+++ b/datahost-graphql/build.clj
@@ -1,7 +1,8 @@
 (ns build
   (:require [clojure.tools.build.api :as b]
             [clojure.string :as str]
-            [juxt.pack.api :as pack]))
+            [juxt.pack.api :as pack])
+  (:import [com.google.cloud.tools.jib.api JibContainer]))
 
 (def lib 'tpximpact/catql)
 (def version (format "2.0.%s" (b/git-count-revs nil)))
@@ -23,30 +24,30 @@
                    "branch --show-current"]
                   (map #(tag (b/git-process {:git-args %})))
                   (remove nil?))
-        image-type (get opts :image-type :docker)]
-    (pack/docker
-     {:basis (b/create-basis {:project "deps.edn" :aliases [:catql/docker]})
-      ;; If we don't include a tag in the :image-name, then pack implicitly
-      ;; tags the image with latest, even when we specify additional tags. So
-      ;; choose a tag arbitrarily to be part of the :image-name, and then
-      ;; provide the rest in :tags.
-      :image-name (str repo "/datahost-graphql:" (first tags))
-      :tags (set (rest tags))
-      :image-type image-type
+        image-type (get opts :image-type :docker)
+        ^JibContainer container (pack/docker
+                                  {:basis (b/create-basis {:project "deps.edn" :aliases [:catql/docker]})
+                                   ;; If we don't include a tag in the :image-name, then pack implicitly
+                                   ;; tags the image with latest, even when we specify additional tags. So
+                                   ;; choose a tag arbitrarily to be part of the :image-name, and then
+                                   ;; provide the rest in :tags.
+                                   :image-name (str repo "/datahost-graphql:" (first tags))
+                                   :tags (set (rest tags))
+                                   :image-type image-type
 
-      :base-image "eclipse-temurin:17" ;; An openJDK 17 base docker provided by https://github.com/adoptium/containers#containers
+                                   :base-image "eclipse-temurin:17" ;; An openJDK 17 base docker provided by https://github.com/adoptium/containers#containers
 
-      :platforms #{:linux/amd64 :linux/arm64}
+                                   :platforms #{:linux/amd64 :linux/arm64}
 
-      ;; NOTE Not as documented!
-      ;; The docstring states that these should be
-      ;;     :to-registry {:username ... :password ...}
-      ;; but alas, that is a lie.
-      ;; https://github.com/juxt/pack.alpha/issues/101
-      :to-registry-username "_json_key"
-      :to-registry-password (System/getenv "GCLOUD_SERVICE_KEY")
-
-      })))
+                                   ;; NOTE Not as documented!
+                                   ;; The docstring states that these should be
+                                   ;;     :to-registry {:username ... :password ...}
+                                   ;; but alas, that is a lie.
+                                   ;; https://github.com/juxt/pack.alpha/issues/101
+                                   :to-registry-username "_json_key"
+                                   :to-registry-password (System/getenv "GCLOUD_SERVICE_KEY")
+                                   })]
+    (println (.. container (getDigest) (getHash)))))
 
 (defn clean [_]
   (b/delete {:path "target"}))

--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -1,0 +1,2 @@
+*.tfplan
+.terraform/

--- a/deploy/terraform/.tool-versions
+++ b/deploy/terraform/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.4.6

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,56 @@
+# Terraform
+
+This directory contains Terraform modules for configuring a deployment of the GraphQL prototype. The prototype is
+currently hosted within its own `swirrl-ons-datahost` gcloud project. The two modules configure aspects of the host
+project (required services, firewall rules etc.) and the provisioning of a VM running the configured version of the
+GraphQL application.
+
+## Running Terraform
+
+### Directly
+
+The required version of Terraform is listed within the `.tool-versions` file. You can install this manually via the
+[instructions on the downloads page](https://developer.hashicorp.com/terraform/downloads?product_intent=terraform) or
+using [asdf](https://asdf-vm.com/)
+
+```
+asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
+asdf install
+```
+
+### Via Docker
+
+You can also run Terraform via the corresponding Docker container. The AWS and GCloud providers are configured through
+the environment (see [below](#configuration), so these variables must be provided to the container. Similarly, the module root directory must also
+be mapped into the container. For example, if your current directory is a module root directory, you can run `terraform init`
+with:
+
+```
+docker run --rm --workdir /infra -v .:/infra \
+           --env AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+           --env AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+           --env AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
+           --env GOOGLE_OAUTH_ACCESS_TOKEN=${GOOGLE_OAUTH_ACCESS_TOKEN} \
+           hashicorp/terraform:1.4.6 init 
+```
+
+## Configuration
+
+### AWS
+
+The AWS provider requires `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and optionally `AWS_SESSION_TOKEN` to be set in 
+the environment. The corresponding user must have permission to read and write to the `swirrl-terraform-states` S3 bucket
+where all Terraform state files are stored.
+
+It is recommended you use [aws vault](https://github.com/99designs/aws-vault) to manage AWS credentials and generate
+short-lived sessions.
+
+### GCloud
+
+It is recommended you configure the GCloud provider by generating a short-lived access token and exporting it via the
+`GOOGLE_OAUTH_ACCESS_TOKEN` environment variable e.g.
+
+    export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
+
+
+

--- a/deploy/terraform/gcloud/swirrl-ons-datahost/.terraform.lock.hcl
+++ b/deploy/terraform/gcloud/swirrl-ons-datahost/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.50.0"
+  constraints = "4.50.0"
+  hashes = [
+    "h1:Qyg0jc9JupG+n2lR/e+nfgmM/brmqLGdYxi58sOOMc4=",
+    "zh:051b7d64b9808296606475f16cb6848577ba559c704c04af7d24789a7ba96e36",
+    "zh:2c6af345add3fa4c92521ce49f52c72c1724afad2f47908bcd878136b03436b9",
+    "zh:2daad7d49bcbf2fe036790249c8504e67b03dded3ea9f00fc0822ae1892d8292",
+    "zh:3b5d0996f35d251ec5723b300337af17bf229838f6f6b77eb09516676236956f",
+    "zh:462eeb217fcc0d15453369be1bec8ad9fa59957e7398ef8e82fcf931058805f7",
+    "zh:5141ef282f69854622221d3bf7580d73d389676fb7362f73c8132f1b82a4f561",
+    "zh:9a83ab13cd57f50a9ac93fed4b02a3fdb525e69a971b0519583ffefbcdf60ba7",
+    "zh:b1cd0e10dcef0b7e7f8f4c51296bbe08767671b145d55e38f011f6c52c78f144",
+    "zh:bc135972d274d8af2c3434ef09ca4028f4ead6cfddb20bfb13809034b0b70730",
+    "zh:db3b4ce4e864b8246edc9e7c5f3581e2c2f6269740307c254b0e5c37fd6665ee",
+    "zh:f384bf5749bdabf9419ada9d3c73a5937ee989753bb40f7060dc586973faa3d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/deploy/terraform/gcloud/swirrl-ons-datahost/README.md
+++ b/deploy/terraform/gcloud/swirrl-ons-datahost/README.md
@@ -1,0 +1,4 @@
+# swirrl-ons-datahost project
+
+This module contains configuration for the `swirrl-ons-datahost` GCloud project. Any changes required to the project
+itself (e.g. enabling new services, CI service account permissions) should be defined here.

--- a/deploy/terraform/gcloud/swirrl-ons-datahost/main.tf
+++ b/deploy/terraform/gcloud/swirrl-ons-datahost/main.tf
@@ -1,0 +1,149 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "4.50.0"
+    }
+  }
+
+  # S3 backend state configuration
+  backend "s3" {
+    bucket = "swirrl-terraform-states"
+    key = "datahost/gcloud/swirrl-ons-datahost.tfstate"
+    region = "eu-west-2"
+
+    dynamodb_table = "swirrl-terraform-locks"
+    encrypt = true
+  }
+}
+
+# config for GCP provider
+provider "google" {
+  project = local.project
+  region = "europe-west2"
+}
+
+locals {
+  project = "swirrl-ons-datahost"
+  services = [
+    "compute.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "iam.googleapis.com",
+    "cloudresourcemanager.googleapis.com"
+  ]
+  ci_service_account_roles = [
+    "roles/compute.instanceAdmin.v1",
+    "roles/iam.serviceAccountUser"
+  ]
+  swirrl_circleci_organisation_id = "294dc3ff-773f-44a8-820e-f12f3ba2e1ac"
+}
+
+# services required within the project
+resource "google_project_service" "services" {
+  count = length(local.services)
+  service = local.services[count.index]
+}
+
+## firewall rules
+
+# Allow incoming SSH for VMs with ssh-server tag
+resource "google_compute_firewall" "allow_ssh" {
+  name = "allow-ssh"
+  network = "default"
+  direction = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags = ["ssh-server"]
+}
+
+resource "google_compute_firewall" "allow_https" {
+  name = "allow-https"
+  network = "default"
+  direction = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports = ["443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags = ["https-server"]
+}
+
+resource "google_compute_firewall" "allow_http" {
+  name = "allow-http"
+  network = "default"
+  direction = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports = ["80"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags = ["http-server"]
+}
+
+# Service account for circle ci
+resource "google_service_account" "ci_account" {
+  account_id   = "circleci"
+  display_name = "Service account impersonated by circleci jobs"
+}
+
+resource "google_project_iam_member" "ci_service_account_permissions" {
+  project = local.project
+  count = length(local.ci_service_account_roles)
+  role = local.ci_service_account_roles[count.index]
+  member = "serviceAccount:${google_service_account.ci_account.email}"
+}
+
+# CI account needs to be able to make IAM changes within the swirrl-devops-infrastructure-1 project
+resource "google_project_iam_member" "ci_devops_infrastructure_iam" {
+  project = "swirrl-devops-infrastructure-1"
+  role = "roles/iam.securityAdmin" // TODO: is there a role with fewer permissions?!
+  member = "serviceAccount:${google_service_account.ci_account.email}"
+}
+
+# configure workload identity pool for CircleCI
+# this allows CircleCI access tokens to be exchanged for a gcloud token
+# see https://circleci.com/blog/openid-connect-identity-tokens/
+resource "google_iam_workload_identity_pool" "circleci" {
+  workload_identity_pool_id = "circleci-oidc-pool"
+  display_name = "CirclCI Workload Identity Pool"
+  description = "Workload Identity Pool used to create tokens from CircleCI OIDC tokens"
+}
+
+resource "google_iam_workload_identity_pool_provider" "circleci_provider" {
+  workload_identity_pool_id = google_iam_workload_identity_pool.circleci.workload_identity_pool_id
+  workload_identity_pool_provider_id = "circlci-oidc-provider"
+  display_name = "CircleCI OIDC Provider"
+  description = "Identity provider for CircleCI OIDC tokens"
+  attribute_condition = "attribute.org_id=='${local.swirrl_circleci_organisation_id}'"
+  attribute_mapping = {
+    "google.subject" = "assertion.sub"
+    "attribute.org_id" = "assertion.aud"
+  }
+  oidc {
+    allowed_audiences = [local.swirrl_circleci_organisation_id]
+    issuer_uri = "https://oidc.circleci.com/org/${local.swirrl_circleci_organisation_id}"
+  }
+}
+
+# required to get project number for the devops infrastructure project
+data "google_project" "deployment_project" {
+  project_id = local.project
+}
+
+# map CircleCI tokens to service account
+# allow any tokens with the Swirrl organisation id to impersonate the service account
+# see https://cloud.google.com/iam/docs/workload-identity-federation
+resource "google_service_account_iam_member" "circleci_binding" {
+  service_account_id = google_service_account.ci_account.name
+  role = "roles/iam.workloadIdentityUser"
+  member = "principalSet://iam.googleapis.com/projects/${data.google_project.deployment_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.circleci.workload_identity_pool_id}/attribute.org_id/${local.swirrl_circleci_organisation_id}"
+}

--- a/deploy/terraform/graphql/.terraform.lock.hcl
+++ b/deploy/terraform/graphql/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.64.0"
+  constraints = "4.64.0"
+  hashes = [
+    "h1:e9YVOqH5JQTR0LbT+VkOlJb1pDoZEvzXkqaA0Xsn5Mo=",
+    "h1:fA1kuAkOfuDLSdpcyKpeBPZinyPWLpmzBcRyNiaSxYc=",
+    "zh:097fcb0a45fa41c2476deeb7a9adeadf5142e35e4d1a9eeb7b1720900a06807c",
+    "zh:177e6e34f10efb5cec16b4106af5aef5240f20c33d91d40f3ea73fdc6ce9a24a",
+    "zh:3331b0f62f900f8f1447e654a7318f3db03723739ac5dcdc446f1a1b1bf5fd0b",
+    "zh:39e5a19693f8d598d35968660837d1b55ca82d7c314cd433fd957d1c2a5b6616",
+    "zh:44d09cb871e7ec242610d84f93367755d0c532f744e5871a032cdba430e39ec7",
+    "zh:77769c0f8ace0be3f85b702b7d4cc0fd43d89bfbea1493166c4f288338222f0a",
+    "zh:a83ca3e204a85d1d04ee7a6432fdabc7b7e2ef7f46513b6309d8e30ea9e855a3",
+    "zh:bbf1e983d24877a690886aacd48085b37c8c61dc65e128707f36b7ae6de11abf",
+    "zh:c359fcf8694af0ec490a1784575eeb355d6e5a922b225f49d5307a06e9715ad0",
+    "zh:f0df551e19cf8cc9a021a4148518a610b856a50a55938710837fa55b4fbd252f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb171d37178d46d711f3e09107492343f8356c1237bc6df23114920dc23c4528",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = "3.1.1"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/deploy/terraform/graphql/README.md
+++ b/deploy/terraform/graphql/README.md
@@ -1,0 +1,18 @@
+# GraphQL Terraform module
+
+This directory contains a module defining the configuration for a VM running a version of the GraphQL application.
+The VM runs under a service account with permission to read images published to the 
+
+## Configuration
+
+The module must be configured with the SHA256 digest of the image to run. This must identify an image published to the
+`europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-graphql` repository. The digest is specified
+as a variable to the `terraform plan` command e.g.
+
+    terraform plan -var digest=4c0c40fba6a658da6769a07a1370655b7c1e2aac03c0f91d89d6b8d32103a80b -out update.tfplan
+
+## Updates
+
+The host VM must be re-created if the configured Docker image changes. This will happen automatically when running `apply` e.g.
+
+    terraform apply update.tfplan

--- a/deploy/terraform/graphql/docker-compose.yml
+++ b/deploy/terraform/graphql/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.7'
+
+services:
+  terraform:
+    image: hashicorp/terraform:1.4.6
+    volumes:
+      - .:/infra
+    working_dir: /infra
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+      - GOOGLE_OAUTH_ACCESS_TOKEN=${GOOGLE_OAUTH_ACCESS_TOKEN}
+    networks:
+      hostnet: {}
+
+networks:
+  hostnet:
+    external: true
+    name: host

--- a/deploy/terraform/graphql/main.tf
+++ b/deploy/terraform/graphql/main.tf
@@ -1,0 +1,101 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "4.64.0"
+    }
+
+    null = {
+      source = "hashicorp/null"
+      version = "3.1.1"
+    }
+  }
+
+  # S3 backend state configuration
+  backend "s3" {
+    bucket = "swirrl-terraform-states"
+    key = "datahost/dev/graphql.tfstate"
+    region = "eu-west-2"
+
+    dynamodb_table = "swirrl-terraform-locks"
+    encrypt = true
+  }
+}
+
+provider "google" {
+  project = "swirrl-ons-datahost"
+  region = "europe-west2-b"
+}
+
+locals {
+  name = "tf-datahost-graphql"
+  service_account_id = "${local.name}-account"
+}
+
+module "gce_container_spec" {
+  source = "terraform-google-modules/container-vm/google"
+  version = "~> 2.0"
+
+  container = {
+    image = "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-graphql@sha256:${var.digest}"
+  }
+
+  restart_policy = "Always"
+}
+
+resource "null_resource" "image_digest" {
+  triggers = {
+    digest = var.digest
+  }
+}
+
+resource "google_service_account" "graphql_service_account" {
+  account_id   = local.service_account_id
+  display_name = "Service account to run the graphql server"
+}
+
+# service account needs to be able to read images from the swirrl-devops-infrastructure project
+resource "google_project_iam_member" "image_creator_service_account_permissions" {
+  project = "swirrl-devops-infrastructure-1"
+  role = "roles/artifactregistry.reader"
+  member = "serviceAccount:${google_service_account.graphql_service_account.email}"
+}
+
+resource "google_compute_instance" "datahost_instance" {
+  name = "tf-datahost-graphql"
+  machine_type = "e2-small"
+  zone = "europe-west2-b"
+
+  boot_disk {
+    initialize_params {
+      size = "10"
+      image = module.gce_container_spec.source_image
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // ephemeral public IP
+    }
+  }
+
+  tags = ["http-server", "https-server"]
+
+  labels = {
+    container-vm = module.gce_container_spec.vm_container_label
+  }
+
+  metadata = {
+    gce-container-declaration = module.gce_container_spec.metadata_value
+  }
+
+  lifecycle {
+    replace_triggered_by = [null_resource.image_digest]
+  }
+
+  service_account {
+    email = google_service_account.graphql_service_account.email
+    scopes = ["cloud-platform"]
+  }
+}

--- a/deploy/terraform/graphql/terraform.sh
+++ b/deploy/terraform/graphql/terraform.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+docker-compose -f "${SCRIPT_DIR}/docker-compose.yml" run --rm terraform "$@"

--- a/deploy/terraform/graphql/variables.tf
+++ b/deploy/terraform/graphql/variables.tf
@@ -1,0 +1,4 @@
+variable "digest" {
+  type = string
+  description = "SHA256 digest of the graphql application image to deploy"
+}


### PR DESCRIPTION
Create terraform modules to:

* Configure the `swirrl-ons-datahost` gcloud project (firewall rules, OIDC provider and CI service account)
* Create a VM hosting a configured version of the GraphQL application

Update the GraphQL application `docker` build task to display the SHA256 digest of the deployed image
Update the CircleCI build to deploy the published docker image to a VM via a terraform plan/apply when built from the `main` branch.