### PR TITLE
fix: facet search

### DIFF
--- a/datahost-graphql/src/tpximpact/catql.clj
+++ b/datahost-graphql/src/tpximpact/catql.clj
@@ -50,6 +50,7 @@
 
   If values seq is empty, the var will be uncostrained."
   [pred values]
+  (let [facet-var (gensym "?")]
     (if (seq values)
       [[:values {facet-var values}]
        ['?id pred facet-var]]

--- a/datahost-graphql/src/tpximpact/catql.clj
+++ b/datahost-graphql/src/tpximpact/catql.clj
@@ -34,7 +34,7 @@
 
 (def default-catalog (URI. "http://gss-data.org.uk/catalog/datasets"))
 
-(defn query 
+(defn query
   "Returns a vector result of a query specified by query-data
   argument (a SPARQL query as clojure data)."
   [repo query-data]
@@ -43,8 +43,6 @@
       (log/info sparql)
       (into [] (repo/query conn sparql)))))
 
-(defn constrain-by-pred [pred values]
-  (let [facet-var (gensym "?")]
 (defn constrain-by-pred
   "Returns a SPARQL query fragment in clojure data form.
 

--- a/datahost-graphql/src/tpximpact/catql/search.clj
+++ b/datahost-graphql/src/tpximpact/catql/search.clj
@@ -22,15 +22,15 @@
 
   Always returns a set of tokens, or the empty set."
   [s]
-  (let [lower-case (fnil str/lower-case "")]
-    (-> (->> (-> s
-                 lower-case
-                 (str/split #"\p{Space}+"))
-             (map clean-chars)
-             (remove stopwords)
-             (map snowball)
-             set)
-        (disj ""))))
+  (let [lower-case (fnil str/lower-case "")
+        split (-> s
+                  lower-case
+                  (str/split #"\p{Space}+"))
+        result (sequence (comp (map clean-chars)
+                               (remove stopwords)
+                               (map snowball))
+                         split)]
+    (disj (set result) "")))
 
 (defn check-result [search-tokens {:keys [title description]}]
   (let [data-tokens (tokenise (str title " " description))]

--- a/datahost-graphql/test/tpximpact/facet_search_test.clj
+++ b/datahost-graphql/test/tpximpact/facet_search_test.clj
@@ -1,14 +1,11 @@
 (ns tpximpact.facet-search-test
   (:require
+   [clojure.set :as set]
    [clojure.test :refer :all]
    [tpximpact.test-helpers :as h]))
 
-(deftest ^{:kaocha/pending "https://github.com/Swirrl/catql-prototype/issues/8"}
-  facet-search-test
-  (let [schema (h/catql-schema)]
-    (testing "Faceted queries"
-      (testing "with no facet constraints applied"
-        (let [result (h/execute schema "
+(def query-no-facets-constraints
+  "
 query testQuery {
   endpoint {
     catalog {
@@ -33,23 +30,10 @@ query testQuery {
       }
     }
   }
+}")
 
-}")]
-          (testing "all datasets are returned"
-            (is (= 137 (count (h/result-datasets result)))))
-
-          (testing "all facets are enabled"
-            (is (= 25 (h/facets-enabled result :themes)))
-            (is (= 22 (h/facets-enabled result :creators)))
-            (is (= 12 (h/facets-enabled result :publishers))))
-
-          (testing "facet ids are returned"
-            (is (= 25 (->> (h/facets result :themes) (map :id) count)))
-            (is (= 22 (->> (h/facets result :creators) (map :id) count)))
-            (is (= 12 (->> (h/facets result :publishers) (map :id) count))))))
-
-      (testing "with one facet constrained"
-        (let [result (h/execute schema "
+(def one-facet-constraint
+  "
 query testQuery {
   endpoint {
     catalog {
@@ -58,6 +42,7 @@ query testQuery {
         datasets {
           id
           theme
+          creator
         }
         facets {
           themes {
@@ -67,6 +52,7 @@ query testQuery {
           creators {
             id
             label
+            enabled
           }
           publishers {
             id
@@ -77,14 +63,53 @@ query testQuery {
     }
   }
 }
-")]
+")
+
+(deftest ^{:kaocha/pending "https://github.com/Swirrl/catql-prototype/issues/8"}
+  facet-search-test
+  (let [schema (h/catql-schema)]
+    (testing "Faceted queries"
+
+      (testing "with no facet constraints applied"
+        (let [result (h/execute schema query-no-facets-constraints)]
+          
+          (testing "all datasets are returned"
+            (is (= 137 (count (h/result-datasets result)))))
+
+          (testing "all facets are enabled"
+            ;; (tap> {:common-themes (set/intersection
+            ;;                        (set (map :id (h/facets result :themes)))
+            ;;                        (set (map :theme (h/result-datasets result))))
+            ;;        :num-themes (count (h/facets result :themes))})
+            ;; NOTE: original count was '25'. There are 25 themes, but
+            ;; not all are present in the dataset. See 'common-themes'
+            (is (= 23 (count (h/facets-enabled result :themes))))
+            (is (= 22 (count (h/facets-enabled result :creators))))
+            ;; (tap> {:common-publishers (set/intersection
+            ;;                            (set (map :id (h/facets result :publishers)))
+            ;;                            (set (map :publisher (h/result-datasets result))))
+            ;;        :num-publishers (count (h/facets result :publishers))})
+            ;; NOTE: original count was '12'. Comment as above.
+            (is (= 10 (count (h/facets-enabled result :publishers)))))
+
+          (testing "facet ids are returned"
+            (is (= 25 (->> (h/facets result :themes) (map :id) count)))
+            (is (= 22 (->> (h/facets result :creators) (map :id) count)))
+            (is (= 12 (->> (h/facets result :publishers) (map :id) count))))))
+
+      (testing "with one facet constrained"
+        (let [result (h/execute schema one-facet-constraint)]
           (testing "datasets are filtered by the given facet"
             (is (= 7 (count (h/result-datasets result))))
             (is (= ["http://gss-data.org.uk/def/gdp#trade"]
                    (->> result h/result-datasets (map :theme) distinct))))
 
           (testing "locking a facet doesn't disable other selections within that facet"
-            (is (= 25 (h/facets-enabled result :themes))))
+            ;; NOTE: we would need to know whether each of the facet
+            ;; values is referenced by datasets that were *not*
+            ;; returned in the query. So we cant' set 'facet.enabled'
+            ;; because we're missing data at the moment.
+            (is (= 25 (count (h/facets-enabled result :themes)))))
 
           (testing "unconstrained facets that would expand search results are enabled"
             ;; publishers and creators who publish to the trade theme


### PR DESCRIPTION
Fixes: #8 

Main update is in Lacinia's `facets-resolver` fn which needs to index the received data to set the 'enabled' flag. Since this is still a prototype, I did not pay much attention to performance (we're querying the datasets twice anyway atm, I have not changed that).
