### PR TITLE
fix: ensure query doesn't hang when `datasets` field not specified

### DIFF
--- a/datahost-graphql/test/tpximpact/facet_search_test.clj
+++ b/datahost-graphql/test/tpximpact/facet_search_test.clj
@@ -201,7 +201,7 @@ query testQuery {
   }
 }")
 
-(deftest no-datasets-query
+(deftest no-datasets-query-test
   (let [schema (h/catql-schema)]
     (testing "Query without 'datasets' doesn't hang."
       (let [result (h/with-timeout 5000 (h/execute schema query-no-datasets))]

--- a/datahost-graphql/test/tpximpact/facet_search_test.clj
+++ b/datahost-graphql/test/tpximpact/facet_search_test.clj
@@ -177,3 +177,32 @@ query testQuery {
                    (->> (h/facets-enabled result :creators)
                         (map :id)
                         sort)))))))))
+
+
+(def query-no-datasets
+  "Note: Not including 'datasets' field int the query"
+  "
+query testQuery {
+  endpoint {
+    catalog {
+      catalog_query {
+        facets {
+          themes {
+            id
+            enabled
+          }
+          creators {
+            id
+            enabled
+          }
+        }
+      }
+    }
+  }
+}")
+
+(deftest no-datasets-query
+  (let [schema (h/catql-schema)]
+    (testing "Query without 'datasets' doesn't hang."
+      (let [result (h/with-timeout 500 (h/execute schema query-no-datasets))]
+        (is (not= :timeout result))))))

--- a/datahost-graphql/test/tpximpact/facet_search_test.clj
+++ b/datahost-graphql/test/tpximpact/facet_search_test.clj
@@ -1,8 +1,10 @@
 (ns tpximpact.facet-search-test
   (:require
    [clojure.set :as set]
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest testing is use-fixtures]]
    [tpximpact.test-helpers :as h]))
+
+(use-fixtures :once h/with-system)
 
 (def query-no-facets-constraints
   "
@@ -65,8 +67,7 @@ query testQuery {
 }
 ")
 
-(deftest ^{:kaocha/pending "https://github.com/Swirrl/catql-prototype/issues/8"}
-  facet-search-test
+(deftest facet-search-test
   (let [schema (h/catql-schema)]
     (testing "Faceted queries"
 

--- a/datahost-graphql/test/tpximpact/facet_search_test.clj
+++ b/datahost-graphql/test/tpximpact/facet_search_test.clj
@@ -204,5 +204,5 @@ query testQuery {
 (deftest no-datasets-query
   (let [schema (h/catql-schema)]
     (testing "Query without 'datasets' doesn't hang."
-      (let [result (h/with-timeout 1000 (h/execute schema query-no-datasets))]
+      (let [result (h/with-timeout 5000 (h/execute schema query-no-datasets))]
         (is (not= :timeout result))))))

--- a/datahost-graphql/test/tpximpact/facet_search_test.clj
+++ b/datahost-graphql/test/tpximpact/facet_search_test.clj
@@ -204,5 +204,5 @@ query testQuery {
 (deftest no-datasets-query
   (let [schema (h/catql-schema)]
     (testing "Query without 'datasets' doesn't hang."
-      (let [result (h/with-timeout 500 (h/execute schema query-no-datasets))]
+      (let [result (h/with-timeout 1000 (h/execute schema query-no-datasets))]
         (is (not= :timeout result))))))

--- a/datahost-graphql/test/tpximpact/test_helpers.clj
+++ b/datahost-graphql/test/tpximpact/test_helpers.clj
@@ -54,6 +54,5 @@
   "Tries to return value of expr in within specified timeout (in ms),
   otherwise returns sentinel `:timeout` value."
   [timeout-ms expr]
-  `(let [p# (promise)]
-     (future (deliver p# ~expr))
-     (deref p# ~timeout-ms :timeout)))
+  `(let [f# (future ~expr)]
+     (deref f# ~timeout-ms :timeout)))

--- a/datahost-graphql/test/tpximpact/test_helpers.clj
+++ b/datahost-graphql/test/tpximpact/test_helpers.clj
@@ -49,3 +49,11 @@
 
 (defn facets-enabled [result facet-key]
   (->> (facets result facet-key) (filter :enabled)))
+
+(defmacro with-timeout
+  "Tries to return value of expr in within specified timeout (in ms),
+  otherwise returns sentinel `:timeout` value."
+  [timeout-ms expr]
+  `(let [p# (promise)]
+     (future (deliver p# ~expr))
+     (deref p# ~timeout-ms :timeout)))


### PR DESCRIPTION
Query that does not specify `datasets` field hangs, because the query waits for the `promise<datasets>` promise in the facets resolver (which will never be delivered in this case).

Fixed by inspecting context's selection and delivering empty datasets value.