### PR TITLE
Proper Integrant use with namespace reloading

### DIFF
--- a/datahost-graphql/env/dev/src/dev.clj
+++ b/datahost-graphql/env/dev/src/dev.clj
@@ -1,38 +1,29 @@
 (ns dev
-  (:refer-clojure :exclude [reset!])
+  (:refer-clojure :exclude [test])
   (:require
-   [clojure.java.io :as io]
-   [grafter-2.rdf4j.repository :as repo]
-   [integrant.core :as ig]
-   [tpximpact.catql :as main]))
+    [clojure.repl :refer :all]
+    [clojure.java.io :as io]
+    [clojure.tools.namespace.repl :refer [refresh] :as tns]
+    [grafter-2.rdf4j.repository :as repo]
+    [integrant.repl :refer [clear halt go init prep reset]]
+    [integrant.core :as ig]
+    [integrant.repl.state :refer [config system]]
+    [tpximpact.sys :as sys]))
+
+;; temp disable this line if working on the dev namespace, obviously.
+(tns/disable-reload! (find-ns 'dev))
 
 ;; require scope capture as a side effect
 (require 'sc.api)
+
+(clojure.tools.namespace.repl/set-refresh-dirs "dev/src" "src" "test" "resources")
+
+(def start go)
 
 (def fixture-repo (repo/fixture-repo (io/resource "fixture-data.ttl")))
 
 (defmethod ig/init-key :dev/fixture-repo [_ _]
   (constantly fixture-repo))
 
-(defn start! []
-  (def sys (main/start-system (main/load-configs ["catql/base-system.edn" "dev-fixtures.edn"])))
-  :ready)
-
-(defn reset! []
-  (ig/halt! sys)
-  (def sys (main/start-system (main/load-configs ["catql/base-system.edn" "dev-fixtures.edn"]))))
-
-(defn start-live! []
-  (def sys (main/start-system (main/load-configs ["catql/base-system.edn"])))
-  :ready)
-
-(defn reset-live! []
-  (ig/halt! sys)
-  (def sys (main/start-system (main/load-configs ["catql/base-system.edn"]))))
-
-(comment
-
-  (with-open [conn (repo/->connection fixture-repo)]
-    (into [] (repo/query conn "select * where { ?s ?p ?o } limit 10")))
-
-  )
+(integrant.repl/set-prep!
+  #(sys/prep-config (sys/load-configs ["catql/base-system.edn"])))

--- a/datahost-graphql/env/dev/src/user.clj
+++ b/datahost-graphql/env/dev/src/user.clj
@@ -1,12 +1,14 @@
 (ns user)
 
 (defn help []
-  (println "Welcome to catql")
+  (println)
+  (println "Welcome to Catql")
+  (println "****************")
   (println)
   (println "Available commands are:")
   (println)
-  (println "(start!)                  ;; Start the system")
-  (println "(reset!)                  ;; Reset the system"))
+  (println "(start) or (go)          ;; Start the system")
+  (println "(reset)                  ;; Reset the system"))
 
 (defn dev
   "Load and switch to the 'dev' namespace."

--- a/datahost-graphql/env/docker/resources/catql/env.edn
+++ b/datahost-graphql/env/docker/resources/catql/env.edn
@@ -1,5 +1,5 @@
 ;; production environment overrides for the docker container
 {
- :tpximpact.catql/service {:host "0.0.0.0" ;; bind to all network interfaces
-                           :port 80}
-}
+ :tpximpact.catql.http/service {:host "0.0.0.0"             ;; bind to all network interfaces
+                                :port 80}
+ }

--- a/datahost-graphql/resources/catql/base-system.edn
+++ b/datahost-graphql/resources/catql/base-system.edn
@@ -1,20 +1,20 @@
 {:tpximpact.catql.schema/schema {:sdl-resource "catql/catalog.graphql"
-                          :default-catalog-id #ig/ref :tpximpact.catql.schema/default-catalog-id
-                          :drafter-base-uri #ig/ref :tpximpact.catql.schema/drafter-base-uri}
+                                 :default-catalog-id #ig/ref :tpximpact.catql.schema/default-catalog-id
+                                 :drafter-base-uri #ig/ref :tpximpact.catql.schema/drafter-base-uri}
 
  :tpximpact.catql.query/sparql-repo {:endpoint "https://beta.gss-data.org.uk/sparql"}
 
  :tpximpact.catql.schema/default-catalog-id "http://gss-data.org.uk/catalog/datasets"
  :tpximpact.catql.schema/drafter-base-uri "https://idp-beta-drafter.publishmydata.com/"
 
- :tpximpact.catql/service {:schema #ig/ref :tpximpact.catql.schema/schema
-                           :host "localhost"
-                           :port 8888
-                           :ide-path "/ide"
-                           :default-asset-path "/assets/graphiql"
-                           :default-subscriptions-path "/ws"}
+ :tpximpact.catql.http/service {:schema #ig/ref :tpximpact.catql.schema/schema
+                                :host "localhost"
+                                :port 8888
+                                :ide-path "/ide"
+                                :default-asset-path "/assets/graphiql"
+                                :default-subscriptions-path "/ws"}
 
- :tpximpact.catql/runnable-service {:service #ig/ref :tpximpact.catql/service} ;; Could probably combine these two components
+ :tpximpact.catql.http/runnable-service {:service #ig/ref :tpximpact.catql.http/service} ;; Could probably combine these two components
 
  :tpximpact.catql.schema/facet-labels {:sparql-repo #ig/ref :tpximpact.catql.query/sparql-repo}
  }

--- a/datahost-graphql/src/tpximpact/catql.clj
+++ b/datahost-graphql/src/tpximpact/catql.clj
@@ -1,60 +1,36 @@
 (ns tpximpact.catql
   (:require
-   [clojure.java.io :as io]
-   [clojure.tools.logging :as log]
-   [com.walmartlabs.lacinia.pedestal2 :as lp]
    [integrant.core :as ig]
-   [io.pedestal.http :as http]
-   [meta-merge.core :as mm])
+   [tpximpact.sys :as sys])
   (:gen-class))
 
-(defmethod ig/init-key ::service [_ {:keys [schema] :as opts}]
-  (lp/default-service schema opts))
+(def system nil)
 
-(def cors-config
-  {:allowed-origins (constantly true)
-   :creds false
-   :max-age (* 60 60 2)         ;; 2 hours
-   :methods "GET, POST, OPTIONS"})
+(defn stop-system! []
+  (println "Stopping Service")
+  (when system
+    (ig/halt! system)))
 
-;; This is an adapted service map, that can be started and stopped.
-;; From the REPL you can call http/start and http/stop on this service:
-(defmethod ig/init-key ::runnable-service [_ {:keys [service]}]
-  (let [{:io.pedestal.http/keys [host port]} service
-        server (-> service
-                   (assoc ::http/allowed-origins cors-config)
-                   http/create-server
-                   http/start)]
-    (log/info (str "CatQL running: http://" host ":" port "/"))
-    server))
+(defn add-shutdown-hook!
+  "Register a shutdown hook with the JVM.  This is not guaranteed to
+  be called in all circumstances, but should be called upon receipt of
+  a SIGTERM (a normal Unix kill command)."
+  []
+  (.addShutdownHook (Runtime/getRuntime) (Thread. stop-system!)))
 
-(defmethod ig/halt-key! ::runnable-service [_ server]
-  (http/stop server))
+(defn start-system [configs]
+  (let [initialised-sys (-> configs
+                            (sys/load-configs)
+                            (sys/prep-config)
+                            (ig/init))]
+    (alter-var-root #'system (constantly initialised-sys))
+    initialised-sys))
 
-(defn load-system-config [config]
-  (if config
-    (-> config
-        slurp
-        ig/read-string)
-    {}))
-
-(defn load-configs [configs]
-  (->> configs
-       (map (comp load-system-config io/resource))
-       (apply mm/meta-merge)))
-
-(defn start-system [config]
-  (let [sys (-> config
-                (doto
-                  (ig/load-namespaces))
-                ig/init)]
-    sys))
-
-(defn -main [& args]
-  (let [config (load-configs ["catql/base-system.edn"
-                              ;; env.edn contains environment specific
-                              ;; overrides to the base-system.edn and
-                              ;; is set on classpath depending on env.
-                              "catql/env.edn"])
-        sys (start-system config)]
-    (log/info "System started")))
+(defn -main [& _args]
+  (println "Starting Service...")
+  (add-shutdown-hook!)
+  (start-system ["catql/base-system.edn"
+                 ;; env.edn contains environment specific
+                 ;; overrides to the base-system.edn and
+                 ;; is set on classpath depending on env.
+                 "catql/env.edn"]))

--- a/datahost-graphql/src/tpximpact/catql/http.clj
+++ b/datahost-graphql/src/tpximpact/catql/http.clj
@@ -1,0 +1,35 @@
+(ns tpximpact.catql.http
+  (:require [clojure.tools.logging :as log]
+            [com.walmartlabs.lacinia.pedestal2 :as lp]
+            [integrant.core :as ig]
+            [io.pedestal.http :as http]))
+
+(def server-instance (atom nil))
+
+(def cors-config
+  {:allowed-origins (constantly true)
+   :creds false
+   :max-age (* 60 60 2)         ;; 2 hours
+   :methods "GET, POST, OPTIONS"})
+
+(defmethod ig/init-key :tpximpact.catql.http/service [_ {:keys [schema] :as opts}]
+  (lp/default-service schema opts))
+
+(defmethod ig/init-key :tpximpact.catql.http/runnable-service [_ {:keys [service]}]
+  (if-let [svr @server-instance]
+    {:server svr}
+    (when service
+      (let [{:io.pedestal.http/keys [host port]} service
+            server (-> service
+                       (assoc ::http/allowed-origins cors-config)
+                       http/create-server
+                       http/start)]
+        (reset! server-instance server)
+        (log/info (str "CatQL running: http://" host ":" port "/"))
+        {:server server}))))
+
+(defmethod ig/halt-key! :tpximpact.catql.http/runnable-service [_ {:keys [server]}]
+  (log/info ::stopping-server)
+  (when server
+    (http/stop server))
+  (reset! server-instance nil))

--- a/datahost-graphql/src/tpximpact/catql/query.clj
+++ b/datahost-graphql/src/tpximpact/catql/query.clj
@@ -16,7 +16,7 @@
                        :xsd (URI. "http://www.w3.org/2001/XMLSchema#")
                        :foaf (URI. "http://xmlns.com/foaf/0.1/")})
 
-(defmethod ig/init-key ::sparql-repo [_ {:keys [endpoint]}]
+(defmethod ig/init-key :tpximpact.catql.query/sparql-repo [_ {:keys [endpoint]}]
   (repo/sparql-repo endpoint))
 
 (defn query

--- a/datahost-graphql/src/tpximpact/catql/schema.clj
+++ b/datahost-graphql/src/tpximpact/catql/schema.clj
@@ -167,20 +167,20 @@
 
 (s/def ::sdl-resource string?)
 
-(defmethod ig/pre-init-spec ::schema [k]
-  (s/keys :req-un [::sdl-resource]))
+;(defmethod ig/pre-init-spec :tpximpact.catql.schema/schema [k]
+;  (s/keys :req-un [::sdl-resource]))
 
-(defmethod ig/init-key ::const [_ v] v)
+(defmethod ig/init-key :tpximpact.catql.schema/const [_ v] v)
 
-(defmethod ig/pre-init-spec ::drafter-base-uri [_]
+(defmethod ig/pre-init-spec :tpximpact.catql.schema/drafter-base-uri [_]
   string?)
 
-(derive ::drafter-base-uri ::const)
+(derive :tpximpact.catql.schema/drafter-base-uri :tpximpact.catql.schema/const)
 
-(defmethod ig/pre-init-spec ::default-catalog-id [_]
+(defmethod ig/pre-init-spec :tpximpact.catql.schema/default-catalog-id [_]
   string?)
 
-(derive ::default-catalog-id ::const)
+(derive :tpximpact.catql.schema/default-catalog-id :tpximpact.catql.schema/const)
 
 (defn- make-prefix-map [custom-prefixes]
   (let [custom-prefixes (zipmap (map :prefix custom-prefixes)
@@ -272,8 +272,10 @@
                        :apply-field-directives (fn [field-def resolver-f]
                                                  nil)})))
 
-(defmethod ig/init-key ::schema [_ opts]
-  (load-schema opts))
+(defmethod ig/init-key :tpximpact.catql.schema/schema [_ opts]
+  ;; init can be called multiple times and doesn't always have its values filled out
+  (when (:sdl-resource opts)
+    (load-schema opts)))
 
 (defn- facet-label-query [pred]
   {:prefixes q/default-prefixes
@@ -292,9 +294,11 @@
                       (into {}))])
          (into {}))))
 
-(defmethod ig/init-key ::facet-labels [_ {:keys [sparql-repo]}]
-  (reset! facet-labels-store
-          (try (load-facet-labels! sparql-repo)
-               (catch Exception ex
-                 (throw (ex-info "Could not load facet labels" {} ex))
-                 {}))))
+(defmethod ig/init-key :tpximpact.catql.schema/facet-labels [_ {:keys [sparql-repo]}]
+  (when sparql-repo
+    (reset! facet-labels-store
+            (try (load-facet-labels! sparql-repo)
+                 (catch Exception ex
+                   (throw (ex-info "Could not load facet labels" {} ex))
+                   {}))))
+  (when @facet-labels-store :initialised))

--- a/datahost-graphql/src/tpximpact/sys.clj
+++ b/datahost-graphql/src/tpximpact/sys.clj
@@ -1,0 +1,30 @@
+(ns tpximpact.sys
+  (:require [clojure.java.io :as io]
+            [meta-merge.core :as mm]
+            [integrant.core :as ig]))
+
+(defn load-system-config [config]
+  (if config
+    (-> config
+        slurp
+        ig/read-string)
+    {}))
+
+(defn load-configs [configs]
+  (->> configs
+       (map (comp load-system-config io/resource))
+       (apply mm/meta-merge)))
+
+(defn build-config
+  [config]
+  (-> config ig/prep (ig/init)))
+
+(defn prep-config
+  "Load, build and prep a configuration of modules into an Integrant
+  configuration that's ready to be initiated."
+  [config]
+  (-> config
+      (doto ig/load-namespaces)
+      (build-config)
+      (doto ig/load-namespaces)
+      (ig/prep)))

--- a/datahost-graphql/test/tpximpact/facet_search_test.clj
+++ b/datahost-graphql/test/tpximpact/facet_search_test.clj
@@ -1,6 +1,5 @@
 (ns tpximpact.facet-search-test
   (:require
-   [clojure.set :as set]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [tpximpact.test-helpers :as h]))
 

--- a/datahost-graphql/test/tpximpact/test_helpers.clj
+++ b/datahost-graphql/test/tpximpact/test_helpers.clj
@@ -1,12 +1,13 @@
 (ns tpximpact.test-helpers
   (:require
-   [clojure.java.io :as io]
-   [clojure.walk :as walk]
-   [com.walmartlabs.lacinia :as lacinia]
-   [grafter-2.rdf4j.repository :as repo]
-   [integrant.core :as ig]
-   [tpximpact.catql :as catql]
-   [tpximpact.catql.schema :as schema]))
+    [clojure.java.io :as io]
+    [clojure.walk :as walk]
+    [com.walmartlabs.lacinia :as lacinia]
+    [grafter-2.rdf4j.repository :as repo]
+    [integrant.core :as ig]
+    [tpximpact.catql.schema :as schema]
+    [tpximpact.sys :as sys])
+  (:import (clojure.lang IPersistentMap)))
 
 (defn simplify
     "Converts all ordered maps nested within the map into standard hash
@@ -16,7 +17,7 @@
     (walk/postwalk
      (fn [node]
        (cond
-         (instance? clojure.lang.IPersistentMap node)
+         (instance? IPersistentMap node)
          (into {} node)
 
          (seq? node)
@@ -62,7 +63,7 @@
 (defn load-configs
   [configs]
   (-> configs
-      (catql/load-configs)
+      (sys/load-configs)
       (dissoc :tpximpact.catql/service :tpximpact.catql/runnable-service)))
 
 (defn- start-system
@@ -89,7 +90,7 @@
     (ig/halt! sys)))
 
 (defn with-system
-  "Test fixture for startin/stopping the system."
+  "Test fixture for starting / stopping the system."
   [test-fn]
   (with-open [f (io/writer (io/file "OUT.log"))]
     (start-test-system)

--- a/shared-deps/deps.edn
+++ b/shared-deps/deps.edn
@@ -3,8 +3,8 @@
         ;; pinned common versions for the monorepo
         org.clojure/clojure {:mvn/version "1.12.0-alpha3"}
 
-        ring/ring-core {:mvn/version "1.7.1"}
-        ring/ring-jetty-adapter {:mvn/version "1.7.1"}
+        ring/ring-core {:mvn/version "1.9.2"}
+        ring/ring-jetty-adapter {:mvn/version "1.9.2"}
 
         integrant/integrant {:mvn/version "0.8.0"}
         meta-merge/meta-merge {:mvn/version "1.0.0"}


### PR DESCRIPTION
This is for the GraphQL catalog service. I will do the same for the LD API service sub-project in a follow-up PR.

- `(reset)` in the REPL now works as expected - namespaces with code changes will be reloaded.
- `dev` namespace does not call `main` to start the system.