### PR TITLE
Create external IP address for datahost server

### DIFF
--- a/deploy/terraform/gcloud/swirrl-ons-datahost/main.tf
+++ b/deploy/terraform/gcloud/swirrl-ons-datahost/main.tf
@@ -33,7 +33,8 @@ locals {
   ]
   ci_service_account_roles = [
     "roles/compute.instanceAdmin.v1",
-    "roles/iam.serviceAccountUser"
+    "roles/iam.serviceAccountUser",
+    "roles/compute.publicIpAdmin"
   ]
   swirrl_circleci_organisation_id = "294dc3ff-773f-44a8-820e-f12f3ba2e1ac"
 }

--- a/deploy/terraform/graphql/main.tf
+++ b/deploy/terraform/graphql/main.tf
@@ -24,7 +24,7 @@ terraform {
 
 provider "google" {
   project = "swirrl-ons-datahost"
-  region = "europe-west2-b"
+  region = "europe-west2"
 }
 
 locals {
@@ -61,6 +61,11 @@ resource "google_project_iam_member" "image_creator_service_account_permissions"
   member = "serviceAccount:${google_service_account.graphql_service_account.email}"
 }
 
+resource "google_compute_address" "datahost_instance_address" {
+  name = "datahost-address"
+  address_type = "EXTERNAL"
+}
+
 resource "google_compute_instance" "datahost_instance" {
   name = "tf-datahost-graphql"
   machine_type = "e2-small"
@@ -76,7 +81,7 @@ resource "google_compute_instance" "datahost_instance" {
   network_interface {
     network = "default"
     access_config {
-      // ephemeral public IP
+      nat_ip = google_compute_address.datahost_instance_address.address
     }
   }
 


### PR DESCRIPTION
Issue #71 - Create an external IP address and assign it to the datahost server.

Add permissions to the CircleCI service account to allow it to create and delete addresses.