### PR TITLE
LD API service: Proper Integrant use with namespace reloading

### DIFF
--- a/datahost-ld-openapi/env/dev/src/dev.clj
+++ b/datahost-ld-openapi/env/dev/src/dev.clj
@@ -1,15 +1,21 @@
 (ns dev
+  (:refer-clojure :exclude [test])
   (:require
-   [integrant.core :as ig]
-   [tpximpact.datahost.ldapi :as main]))
+    [clojure.repl :refer :all]
+    [clojure.tools.namespace.repl :refer [refresh] :as tns]
+    [integrant.repl :refer [clear halt go init prep reset]]
+    [integrant.repl.state :refer [config system]]
+    [tpximpact.datahost.sys :as sys]))
+
+;; temp disable this line if working on the dev namespace, obviously.
+(tns/disable-reload! (find-ns 'dev))
 
 ;; require scope capture as a side effect
 (require 'sc.api)
 
-(defn start! []
-  (def sys (main/start-system (main/load-configs ["ldapi/base-system.edn"])))
-  :ready)
+(clojure.tools.namespace.repl/set-refresh-dirs "dev/src" "src" "test" "resources")
 
-(defn reset! []
-  (ig/halt! sys)
-  (def sys (main/start-system (main/load-configs ["ldapi/base-system.edn"]))))
+(def start go)
+
+(integrant.repl/set-prep!
+  #(sys/prep-config (sys/load-configs ["ldapi/base-system.edn"])))

--- a/datahost-ld-openapi/env/dev/src/user.clj
+++ b/datahost-ld-openapi/env/dev/src/user.clj
@@ -1,12 +1,14 @@
 (ns user)
 
 (defn help []
-  (println "Welcome to ldapi")
+  (println)
+  (println "Welcome to LD API")
+  (println "*****************")
   (println)
   (println "Available commands are:")
   (println)
-  (println "(start!)                  ;; Start the system")
-  (println "(reset!)                  ;; Reset the system"))
+  (println "(start) or (go)          ;; Start the system")
+  (println "(reset)                  ;; Reset the system"))
 
 (defn dev
   "Load and switch to the 'dev' namespace."

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -5,7 +5,8 @@
    [tpximpact.datahost.ldapi.series :as series]))
 
 (defmethod ig/init-key :tpximpact.datahost.ldapi.db/db [_ {:keys [storage-type opts]}]
-  (da/duratom storage-type opts))
+  (when storage-type
+    (da/duratom storage-type opts)))
 
 (defn upsert-series! [db {:keys [series-slug] :as api-params} incoming-jsonld-doc]
   (let [series-key (series/dataset-series-key series-slug)

--- a/datahost-ld-openapi/src/tpximpact/datahost/sys.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/sys.clj
@@ -1,0 +1,30 @@
+(ns tpximpact.datahost.sys
+  (:require [clojure.java.io :as io]
+            [meta-merge.core :as mm]
+            [integrant.core :as ig]))
+
+(defn load-system-config [config]
+  (if config
+    (-> config
+        slurp
+        ig/read-string)
+    {}))
+
+(defn load-configs [configs]
+  (->> configs
+       (map (comp load-system-config io/resource))
+       (apply mm/meta-merge)))
+
+(defn build-config
+  [config]
+  (-> config ig/prep (ig/init)))
+
+(defn prep-config
+  "Load, build and prep a configuration of modules into an Integrant
+  configuration that's ready to be initiated."
+  [config]
+  (-> config
+      (doto ig/load-namespaces)
+      (build-config)
+      (doto ig/load-namespaces)
+      (ig/prep)))

--- a/datahost-ld-openapi/test/tpximpact/test_helpers.clj
+++ b/datahost-ld-openapi/test/tpximpact/test_helpers.clj
@@ -1,20 +1,26 @@
 (ns tpximpact.test-helpers
   (:require [clojure.test :refer :all]
             [integrant.core :as ig]
-            [tpximpact.datahost.ldapi :as ldapi-system]))
+            [tpximpact.datahost.sys :as sys]))
 
 (defn clean-up-database! [system]
-  (let [db (get system :tpximpact.datahost.ldapi.db/db)]
+  (when-let [db (get system :tpximpact.datahost.ldapi.db/db)]
     (reset! db {})))
 
+(defn start-system [configs]
+  (-> configs
+      (sys/load-configs)
+      (sys/prep-config)
+      (ig/init)))
+
 (defmacro with-system [system-binding & body]
-  `(let [config# (ldapi-system/load-configs ["ldapi/base-system.edn"
-                                             "test-system.edn"
-                                             ;; env.edn contains environment specific
-                                             ;; overrides to the base-system.edn and
-                                             ;; is set on classpath depending on env.
-                                             "ldapi/env.edn"])
-         sys# (ldapi-system/start-system config#)
+  `(let [sys# (start-system ["ldapi/base-system.edn"
+                             ;; TODO - nuke test-system & move contents to env.edn
+                             "test-system.edn"
+                             ;; env.edn contains environment specific
+                             ;; overrides to the base-system.edn and
+                             ;; is set on classpath depending on env.
+                             "ldapi/env.edn"])
          ~system-binding sys#]
      (try
        ~@body


### PR DESCRIPTION
This is for the LD API catalog service. GraphQL service has already been revised for reloading.

- `(reset)` in the REPL now works as expected - namespaces with code changes will be reloaded.
- dev namespace does not call main to start the system.

