### PR TITLE
Create DNS record for GraphQL prototype

### DIFF
--- a/deploy/terraform/graphql/.terraform.lock.hcl
+++ b/deploy/terraform/graphql/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.0.1"
+  constraints = "5.0.1"
+  hashes = [
+    "h1:SB38lIGsF3yHKujEBnTSsH4VOAskn8XZNPpuCPuhJYw=",
+    "zh:006daf4060087b5f0c13562beed33f524a6f9e04ebd72a782bfe60502076368f",
+    "zh:0f49636550aadd373c7e5c710600901c2f153ddd71b6c50482e1afdbb3f8d95d",
+    "zh:1999d2fad0a7a884aab0d191507cf895df0ea7201369a2ef37529f4253ce1065",
+    "zh:1b51774866cddca5a2da5a09a316e9ca078fc821f47611a184245ca892e9335d",
+    "zh:2875579acceba1403563c4281c76a3a9b53b970ed6494e5370e27efb6430bb50",
+    "zh:349eb9ab7c026b72154ce55c7bf9a69ebb3c3a4745ecfdb0c593400762ed1b0c",
+    "zh:38f96c14db5b3beb80748010c0a97dd097a303b24c8478a1286ce1f48a1a0375",
+    "zh:3d212e6e4fc54584e47faeccf501e5a68266c7fe9e36d89ad787c2e1f0e86197",
+    "zh:3ea61ab960ef34ff66457319b9083c8645a9f801f7b5578e7e3f616e26945f90",
+    "zh:584db6d88a07cac639f746104ccd5ed5c517ed99f892a143dad3bb64023098fc",
+    "zh:653def88ffa17b628459f942e743d30ab9fc2194af464d88258a784d9282f9f9",
+    "zh:9737008fea7ffbf5782fceb0108a283e91992c47bfcb93ec55ef43deaa7e509d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ce3ba0cabc1704c584cc46bf1432b14ba1d34b1a30e03a5694b5940cf1673ab8",
+    "zh:de3e6d4e1defc6032359fc229000a1458d777adb07974293f194dde069adcc04",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.64.0"
   constraints = "4.64.0"

--- a/deploy/terraform/graphql/main.tf
+++ b/deploy/terraform/graphql/main.tf
@@ -9,6 +9,11 @@ terraform {
       source = "hashicorp/null"
       version = "3.1.1"
     }
+
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.0.1"
+    }
   }
 
   # S3 backend state configuration
@@ -25,6 +30,10 @@ terraform {
 provider "google" {
   project = "swirrl-ons-datahost"
   region = "europe-west2"
+}
+
+provider "aws" {
+  region = "eu-west-2"
 }
 
 locals {
@@ -64,6 +73,18 @@ resource "google_project_iam_member" "image_creator_service_account_permissions"
 resource "google_compute_address" "datahost_instance_address" {
   name = "datahost-address"
   address_type = "EXTERNAL"
+}
+
+data "aws_route53_zone" "gss_zone" {
+  name = "gss-data.org.uk"
+}
+
+resource "aws_route53_record" "graphql_record" {
+  zone_id = data.aws_route53_zone.gss_zone.zone_id
+  name = "graphql-prototype.gss-data.org.uk"
+  type = "A"
+  ttl = 300
+  records = [google_compute_address.datahost_instance_address.address]
 }
 
 resource "google_compute_instance" "datahost_instance" {


### PR DESCRIPTION
Issue #91 - Add AWS provider and define a route53 DNS record for the GraphQL prototype pointing to the datahost server address.