### PR TITLE
Create load balancer for datahost server

### DIFF
--- a/deploy/terraform/gcloud/swirrl-ons-datahost/main.tf
+++ b/deploy/terraform/gcloud/swirrl-ons-datahost/main.tf
@@ -34,7 +34,7 @@ locals {
   ci_service_account_roles = [
     "roles/compute.instanceAdmin.v1",
     "roles/iam.serviceAccountUser",
-    "roles/compute.publicIpAdmin"
+    "roles/compute.loadBalancerAdmin"
   ]
   swirrl_circleci_organisation_id = "294dc3ff-773f-44a8-820e-f12f3ba2e1ac"
 }

--- a/deploy/terraform/graphql/main.tf
+++ b/deploy/terraform/graphql/main.tf
@@ -38,7 +38,22 @@ provider "aws" {
 
 locals {
   name = "tf-datahost-graphql"
+  gcloud_zone = "europe-west2-a"
   service_account_id = "${local.name}-account"
+
+  health_check_name = "lb-health-check"
+  backend_service_name = "lb-backend-service"
+  instance_group_name = "lb-instance-group"
+  https_url_map_name = "https-load-balancer"
+  http_url_map_name = "http-load-balancer"
+  address_name = "lb-address"
+  https_global_forwarding_rule_name = "lb-https-forwarding-rule"
+  http_global_forwarding_rule_name = "lb-http-forwarding-rule"
+  https_proxy_name = "lb-https-proxy"
+  http_proxy_name = "lb-http-proxy"
+
+  ssl_policy_name = "lb-ssl-policy"
+  graphql_certificate_name = "graphql-certificate"
 }
 
 module "gce_container_spec" {
@@ -70,27 +85,10 @@ resource "google_project_iam_member" "image_creator_service_account_permissions"
   member = "serviceAccount:${google_service_account.graphql_service_account.email}"
 }
 
-resource "google_compute_address" "datahost_instance_address" {
-  name = "datahost-address"
-  address_type = "EXTERNAL"
-}
-
-data "aws_route53_zone" "gss_zone" {
-  name = "gss-data.org.uk"
-}
-
-resource "aws_route53_record" "graphql_record" {
-  zone_id = data.aws_route53_zone.gss_zone.zone_id
-  name = "graphql-prototype.gss-data.org.uk"
-  type = "A"
-  ttl = 300
-  records = [google_compute_address.datahost_instance_address.address]
-}
-
 resource "google_compute_instance" "datahost_instance" {
   name = "tf-datahost-graphql"
   machine_type = "e2-small"
-  zone = "europe-west2-b"
+  zone = local.gcloud_zone
 
   boot_disk {
     initialize_params {
@@ -102,7 +100,8 @@ resource "google_compute_instance" "datahost_instance" {
   network_interface {
     network = "default"
     access_config {
-      nat_ip = google_compute_address.datahost_instance_address.address
+      # ephemeral public ip
+      # TODO: remove public ip and access only via load balancer
     }
   }
 
@@ -124,4 +123,113 @@ resource "google_compute_instance" "datahost_instance" {
     email = google_service_account.graphql_service_account.email
     scopes = ["cloud-platform"]
   }
+}
+
+# load balancer
+# backend
+resource "google_compute_health_check" "lb_health_check" {
+  name = local.health_check_name
+  http_health_check {
+    port = "80"
+    request_path = "/ide"
+  }
+}
+
+resource "google_compute_instance_group" "muttnik_instance_group" {
+  name = local.instance_group_name
+  zone = local.gcloud_zone
+
+  instances = [google_compute_instance.datahost_instance.self_link]
+
+  named_port {
+    name = "http"
+    port = "80"
+  }
+}
+
+resource "google_compute_backend_service" "backend_service" {
+  name = local.backend_service_name
+  health_checks = [google_compute_health_check.lb_health_check.id]
+  protocol = "HTTP"
+  port_name = "http"
+  connection_draining_timeout_sec = 150
+  session_affinity = "CLIENT_IP"
+
+  backend {
+    group = google_compute_instance_group.muttnik_instance_group.self_link
+  }
+}
+
+# frontend
+resource "google_compute_global_address" "lb_address" {
+  name = local.address_name
+}
+
+resource "google_compute_url_map" "https_url_map" {
+  name = local.https_url_map_name
+  default_service = google_compute_backend_service.backend_service.id
+}
+
+resource "google_compute_url_map" "http_url_map" {
+  name = local.http_url_map_name
+  default_url_redirect {
+    https_redirect = true
+    strip_query = false
+  }
+}
+
+resource "google_compute_target_https_proxy" "https_proxy" {
+  name = local.https_proxy_name
+  url_map = google_compute_url_map.https_url_map.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.ssl_certificate.id]
+  ssl_policy = google_compute_ssl_policy.lb_ssl_policy.id
+}
+
+resource "google_compute_target_http_proxy" "http_proxy" {
+  name = local.http_proxy_name
+  url_map = google_compute_url_map.http_url_map.id
+}
+
+resource "google_compute_global_forwarding_rule" "https_load_balancer" {
+  name = local.https_global_forwarding_rule_name
+  ip_protocol = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  port_range = "443"
+  target = google_compute_target_https_proxy.https_proxy.id
+  ip_address = google_compute_global_address.lb_address.id
+}
+
+resource "google_compute_global_forwarding_rule" "http_load_balancer" {
+  name = local.http_global_forwarding_rule_name
+  ip_protocol = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  port_range = "80"
+  target = google_compute_target_http_proxy.http_proxy.id
+  ip_address = google_compute_global_address.lb_address.id
+}
+
+# ssl
+resource "google_compute_ssl_policy" "lb_ssl_policy" {
+  name = local.ssl_policy_name
+  profile = "MODERN"
+  min_tls_version = "TLS_1_2"
+}
+
+resource "google_compute_managed_ssl_certificate" "ssl_certificate" {
+  name = local.graphql_certificate_name
+  managed {
+    domains = [aws_route53_record.graphql_record.name]
+  }
+}
+
+data "aws_route53_zone" "gss_zone" {
+  name = "gss-data.org.uk"
+}
+
+resource "aws_route53_record" "graphql_record" {
+  zone_id = data.aws_route53_zone.gss_zone.zone_id
+  name = "graphql-prototype.gss-data.org.uk"
+  type = "A"
+  ttl = 300
+  records = [google_compute_global_address.lb_address.address]
 }


### PR DESCRIPTION
Issue #32 - Add HTTP(S) load balancers in front of the datahost server and update the DNS to point to it instead of the server.

Add the CircleCI service account to the compute.loadBalancerAdmin role so it can create and update load balancer components.