### PR TITLE
Search string argument in faceted search

### DIFF
--- a/datahost-graphql/resources/catql/catalog.graphql
+++ b/datahost-graphql/resources/catql/catalog.graphql
@@ -74,6 +74,9 @@ interface Endpoint {
 interface Facet {
   id: ID
   label: String
+  """
+  Should the facet be enabled for user interaction?
+  """
   enabled: Boolean
 }
 

--- a/datahost-graphql/src/tpximpact/catql/schema.clj
+++ b/datahost-graphql/src/tpximpact/catql/schema.clj
@@ -110,7 +110,7 @@
                    :tpximpact.catql.schema.facet-by-id/description]))
 
 (defn -facet-enabled?
-  "Returns whether the facet
+  "Returns whether the facet should be enabled or not.
 
   - text-search-fn - fn taking a collection of records and returning a
     boolean


### PR DESCRIPTION
The search string was not taken into consideration when setting the `enable` field on facets.

I updated the `make-facet` to use the search string and added appropriate tests.

Fixes #65 