### PR TITLE
Move series and releases into models dir

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
@@ -1,0 +1,13 @@
+(ns tpximpact.datahost.ldapi.models.release)
+
+;; (defn upsert-release [db {:keys [api-params jsonld-doc] :as new-release}]
+;;     ;[db {:keys [series-slug release-slug] :as api-params} jsonld-doc]
+;;    (let [{:keys [series-slug release-slug]} api-params
+;;          release-path (str (.getPath series/ld-root) series-slug "/" release-slug)
+;;          series-path (str (.getPath series/ld-root) series-slug)
+;;          series (get db series-path)
+;;          base-entity (get series "dh:baseEntity")]
+
+;;      (if-let [old-release (get db release-path)]
+;;        (update db release-path update-release base-entity new-release)
+;;        (assoc db release-path (normalise-release base-entity new-release)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -1,4 +1,4 @@
-(ns tpximpact.datahost.ldapi.series
+(ns tpximpact.datahost.ldapi.models.series
   (:require
    [clojure.set :as set]
    [clojure.tools.logging :as log]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -1,4 +1,4 @@
-(ns tpximpact.datahost.ldapi.series-test
+(ns tpximpact.datahost.ldapi.models.series-test
   (:require
    [clj-http.client :as http]
    [clojure.test :refer [deftest is testing]]


### PR DESCRIPTION
Just another minor change shuffling files around in preparation for work on releases, merging now rather than later to avoid merge conflicts.