### PR TITLE
Create Terraform definition for ld-openapi application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,13 @@ jobs:
       - checkout
       - run:
           name: "Deploy Open API docker image to registry"
-          command: "cd datahost-ld-openapi && clojure -T:build docker :image-type :registry"
+          command: "clojure -T:build docker :image-type :registry > ldapi_container_digest"
+          working_directory: datahost-ld-openapi
           project-dir: datahost-ld-openapi
+      - persist_to_workspace:
+          root: datahost-ld-openapi
+          paths:
+            - ldapi_container_digest
 
   deploy-graphql-vm:
     parameters:
@@ -108,6 +113,40 @@ jobs:
       - run:
           command: terraform apply update.tfplan
           working_directory: deploy/terraform/graphql/environments/<< parameters.env >>
+
+  deploy-ldapi-vm:
+    parameters:
+      env:
+        type: string
+        description: Terraform environment to deploy
+    docker:
+      - image: cimg/base:2023.05
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - terraform/install:
+          terraform_version: 1.4.6
+      - aws-cli/setup:
+          role-arn: 'arn:aws:iam::557197822758:role/circleci-datahost'
+          session-duration: '900'
+      - gcp-cli/setup:
+          version: latest
+          use_oidc: true
+      - run:
+          command: gcloud version
+      - run:
+          command: terraform init
+          working_directory: deploy/terraform/ldapi/environments/<< parameters.env >>
+      - run:
+          command: terraform get
+          working_directory: deploy/terraform/ldapi/environments/<< parameters.env >>
+      - run:
+          command: terraform plan -out update.tfplan -var digest=$(cat /tmp/workspace/ldapi_container_digest)
+          working_directory: deploy/terraform/ldapi/environments/<< parameters.env >>
+      - run:
+          command: terraform apply update.tfplan
+          working_directory: deploy/terraform/ldapi/environments/<< parameters.env >>
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
@@ -157,6 +196,15 @@ workflows:
             - swirrl-ons-datahost-gcloud
           requires:
             - deploy-graphql-service
+          env: dev
+          filters:
+            branches:
+              only: main
+      - deploy-ldapi-vm:
+          context:
+            - swirrl-ons-datahost-gcloud
+          requires:
+            - deploy-ld-openapi-service
           env: dev
           filters:
             branches:

--- a/deploy/terraform/ldapi/environments/dev/.terraform.lock.hcl
+++ b/deploy/terraform/ldapi/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.0.1"
+  constraints = "5.0.1"
+  hashes = [
+    "h1:SB38lIGsF3yHKujEBnTSsH4VOAskn8XZNPpuCPuhJYw=",
+    "zh:006daf4060087b5f0c13562beed33f524a6f9e04ebd72a782bfe60502076368f",
+    "zh:0f49636550aadd373c7e5c710600901c2f153ddd71b6c50482e1afdbb3f8d95d",
+    "zh:1999d2fad0a7a884aab0d191507cf895df0ea7201369a2ef37529f4253ce1065",
+    "zh:1b51774866cddca5a2da5a09a316e9ca078fc821f47611a184245ca892e9335d",
+    "zh:2875579acceba1403563c4281c76a3a9b53b970ed6494e5370e27efb6430bb50",
+    "zh:349eb9ab7c026b72154ce55c7bf9a69ebb3c3a4745ecfdb0c593400762ed1b0c",
+    "zh:38f96c14db5b3beb80748010c0a97dd097a303b24c8478a1286ce1f48a1a0375",
+    "zh:3d212e6e4fc54584e47faeccf501e5a68266c7fe9e36d89ad787c2e1f0e86197",
+    "zh:3ea61ab960ef34ff66457319b9083c8645a9f801f7b5578e7e3f616e26945f90",
+    "zh:584db6d88a07cac639f746104ccd5ed5c517ed99f892a143dad3bb64023098fc",
+    "zh:653def88ffa17b628459f942e743d30ab9fc2194af464d88258a784d9282f9f9",
+    "zh:9737008fea7ffbf5782fceb0108a283e91992c47bfcb93ec55ef43deaa7e509d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ce3ba0cabc1704c584cc46bf1432b14ba1d34b1a30e03a5694b5940cf1673ab8",
+    "zh:de3e6d4e1defc6032359fc229000a1458d777adb07974293f194dde069adcc04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.64.0"
+  constraints = "4.64.0"
+  hashes = [
+    "h1:fA1kuAkOfuDLSdpcyKpeBPZinyPWLpmzBcRyNiaSxYc=",
+    "zh:097fcb0a45fa41c2476deeb7a9adeadf5142e35e4d1a9eeb7b1720900a06807c",
+    "zh:177e6e34f10efb5cec16b4106af5aef5240f20c33d91d40f3ea73fdc6ce9a24a",
+    "zh:3331b0f62f900f8f1447e654a7318f3db03723739ac5dcdc446f1a1b1bf5fd0b",
+    "zh:39e5a19693f8d598d35968660837d1b55ca82d7c314cd433fd957d1c2a5b6616",
+    "zh:44d09cb871e7ec242610d84f93367755d0c532f744e5871a032cdba430e39ec7",
+    "zh:77769c0f8ace0be3f85b702b7d4cc0fd43d89bfbea1493166c4f288338222f0a",
+    "zh:a83ca3e204a85d1d04ee7a6432fdabc7b7e2ef7f46513b6309d8e30ea9e855a3",
+    "zh:bbf1e983d24877a690886aacd48085b37c8c61dc65e128707f36b7ae6de11abf",
+    "zh:c359fcf8694af0ec490a1784575eeb355d6e5a922b225f49d5307a06e9715ad0",
+    "zh:f0df551e19cf8cc9a021a4148518a610b856a50a55938710837fa55b4fbd252f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb171d37178d46d711f3e09107492343f8356c1237bc6df23114920dc23c4528",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = "3.1.1"
+  hashes = [
+    "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/deploy/terraform/ldapi/environments/dev/main.tf
+++ b/deploy/terraform/ldapi/environments/dev/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  # S3 backend state configuration
+  backend "s3" {
+    bucket = "swirrl-terraform-states"
+    key = "datahost/dev/ldapi.tfstate"
+    region = "eu-west-2"
+
+    dynamodb_table = "swirrl-terraform-locks"
+    encrypt = true
+  }
+}
+
+module "dev" {
+  source = "../../modules/env"
+
+  gcloud_project = "swirrl-ons-datahost"
+  name = "dev"
+  digest = var.digest
+
+  gcloud_zone = "europe-west2-a"
+  dns = {
+    host = "ldapi-prototype"
+    zone = "gss-data.org.uk"
+  }
+}

--- a/deploy/terraform/ldapi/environments/dev/variables.tf
+++ b/deploy/terraform/ldapi/environments/dev/variables.tf
@@ -1,0 +1,4 @@
+variable "digest" {
+  type = string
+  description = "SHA256 digest of the ldapi application container to deploy"
+}

--- a/deploy/terraform/ldapi/modules/env/main.tf
+++ b/deploy/terraform/ldapi/modules/env/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "4.64.0"
+    }
+
+    null = {
+      source = "hashicorp/null"
+      version = "3.1.1"
+    }
+
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.0.1"
+    }
+  }
+}
+
+provider "google" {
+  project = var.gcloud_project
+  region = "europe-west2"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+module "server" {
+  source = "../server"
+  digest = var.digest
+  name = "${var.name}-ldapi"
+  zone = var.gcloud_zone
+}
+
+module "load_balancer" {
+  source = "../load_balancer"
+
+  env = var.name
+  dns = var.dns
+  server_zone = module.server.zone
+  server_self_link = module.server.self_link
+}

--- a/deploy/terraform/ldapi/modules/env/variables.tf
+++ b/deploy/terraform/ldapi/modules/env/variables.tf
@@ -1,0 +1,27 @@
+variable "gcloud_project" {
+  type = string
+  description = "GCloud project to host the environment"
+}
+
+variable "name" {
+  type = string
+  description = "Name of the environment"
+}
+
+variable "digest" {
+  type = string
+  description = "SHA256 digest of the ldapi application container to deploy"
+}
+
+variable "gcloud_zone" {
+  type = string
+  description = "Zone to host the server in"
+}
+
+variable "dns" {
+  type = object({
+    host = string,
+    zone = string
+  })
+  description = "DNS configuration for the graphql site"
+}

--- a/deploy/terraform/ldapi/modules/env/variables.tf
+++ b/deploy/terraform/ldapi/modules/env/variables.tf
@@ -23,5 +23,5 @@ variable "dns" {
     host = string,
     zone = string
   })
-  description = "DNS configuration for the graphql site"
+  description = "DNS configuration for the ldapi site"
 }

--- a/deploy/terraform/ldapi/modules/load_balancer/main.tf
+++ b/deploy/terraform/ldapi/modules/load_balancer/main.tf
@@ -11,7 +11,7 @@ locals {
   http_proxy_name = "${var.env}-ldapi-http-proxy"
 
   ssl_policy_name = "${var.env}-ldapi-ssl-policy"
-  graphql_certificate_name = "${var.env}-ldapi-certificate"
+  certificate_name = "${var.env}-ldapi-certificate"
 
   fqdn = "${var.dns.host}.${var.dns.zone}"
 }
@@ -106,18 +106,18 @@ resource "google_compute_ssl_policy" "lb_ssl_policy" {
 }
 
 resource "google_compute_managed_ssl_certificate" "ssl_certificate" {
-  name = local.graphql_certificate_name
+  name = local.certificate_name
   managed {
-    domains = [aws_route53_record.graphql_record.name]
+    domains = [aws_route53_record.ldapi_record.name]
   }
 }
 
-data "aws_route53_zone" "graphql_zone" {
+data "aws_route53_zone" "dns_zone" {
   name = var.dns.zone
 }
 
-resource "aws_route53_record" "graphql_record" {
-  zone_id = data.aws_route53_zone.graphql_zone.zone_id
+resource "aws_route53_record" "ldapi_record" {
+  zone_id = data.aws_route53_zone.dns_zone.zone_id
   name = local.fqdn
   type = "A"
   ttl = 300

--- a/deploy/terraform/ldapi/modules/load_balancer/main.tf
+++ b/deploy/terraform/ldapi/modules/load_balancer/main.tf
@@ -1,0 +1,125 @@
+locals {
+  health_check_name = "${var.env}-ldapi-health-check"
+  backend_service_name = "${var.env}-ldapi-backend-service"
+  instance_group_name = "${var.env}-ldapi-instance-group"
+  https_url_map_name = "${var.env}-ldapi-https-load-balancer"
+  http_url_map_name = "${var.env}-ldapi-http-load-balancer"
+  address_name = "${var.env}-ldapi-lb-address"
+  https_global_forwarding_rule_name = "${var.env}-ldapi-https-forwarding-rule"
+  http_global_forwarding_rule_name = "${var.env}-ldapi-http-forwarding-rule"
+  https_proxy_name = "${var.env}-ldapi-https-proxy"
+  http_proxy_name = "${var.env}-ldapi-http-proxy"
+
+  ssl_policy_name = "${var.env}-ldapi-ssl-policy"
+  graphql_certificate_name = "${var.env}-ldapi-certificate"
+
+  fqdn = "${var.dns.host}.${var.dns.zone}"
+}
+
+# backend
+resource "google_compute_health_check" "lb_health_check" {
+  name = local.health_check_name
+  http_health_check {
+    port = "80"
+    request_path = "/index.html"
+  }
+}
+
+resource "google_compute_instance_group" "instance_group" {
+  name = local.instance_group_name
+  zone = var.server_zone
+
+  instances = [var.server_self_link]
+
+  named_port {
+    name = "http"
+    port = "80"
+  }
+}
+
+resource "google_compute_backend_service" "backend_service" {
+  name = local.backend_service_name
+  health_checks = [google_compute_health_check.lb_health_check.id]
+  protocol = "HTTP"
+  port_name = "http"
+  connection_draining_timeout_sec = 150
+  session_affinity = "CLIENT_IP"
+
+  backend {
+    group = google_compute_instance_group.instance_group.self_link
+  }
+}
+
+# frontend
+resource "google_compute_global_address" "lb_address" {
+  name = local.address_name
+}
+
+resource "google_compute_url_map" "https_url_map" {
+  name = local.https_url_map_name
+  default_service = google_compute_backend_service.backend_service.id
+}
+
+resource "google_compute_url_map" "http_url_map" {
+  name = local.http_url_map_name
+  default_url_redirect {
+    https_redirect = true
+    strip_query = false
+  }
+}
+
+resource "google_compute_target_https_proxy" "https_proxy" {
+  name = local.https_proxy_name
+  url_map = google_compute_url_map.https_url_map.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.ssl_certificate.id]
+  ssl_policy = google_compute_ssl_policy.lb_ssl_policy.id
+}
+
+resource "google_compute_target_http_proxy" "http_proxy" {
+  name = local.http_proxy_name
+  url_map = google_compute_url_map.http_url_map.id
+}
+
+resource "google_compute_global_forwarding_rule" "https_load_balancer" {
+  name = local.https_global_forwarding_rule_name
+  ip_protocol = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  port_range = "443"
+  target = google_compute_target_https_proxy.https_proxy.id
+  ip_address = google_compute_global_address.lb_address.id
+}
+
+resource "google_compute_global_forwarding_rule" "http_load_balancer" {
+  name = local.http_global_forwarding_rule_name
+  ip_protocol = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  port_range = "80"
+  target = google_compute_target_http_proxy.http_proxy.id
+  ip_address = google_compute_global_address.lb_address.id
+}
+
+# ssl
+resource "google_compute_ssl_policy" "lb_ssl_policy" {
+  name = local.ssl_policy_name
+  profile = "MODERN"
+  min_tls_version = "TLS_1_2"
+}
+
+resource "google_compute_managed_ssl_certificate" "ssl_certificate" {
+  name = local.graphql_certificate_name
+  managed {
+    domains = [aws_route53_record.graphql_record.name]
+  }
+}
+
+data "aws_route53_zone" "graphql_zone" {
+  name = var.dns.zone
+}
+
+resource "aws_route53_record" "graphql_record" {
+  zone_id = data.aws_route53_zone.graphql_zone.zone_id
+  name = local.fqdn
+  type = "A"
+  ttl = 300
+  records = [google_compute_global_address.lb_address.address]
+}

--- a/deploy/terraform/ldapi/modules/load_balancer/variables.tf
+++ b/deploy/terraform/ldapi/modules/load_balancer/variables.tf
@@ -5,12 +5,12 @@ variable "env" {
 
 variable "server_self_link" {
   type = string
-  description = "Self link of the graphql server instance"
+  description = "Self link of the ldapi server instance"
 }
 
 variable "server_zone" {
   type = string
-  description = "Zone of the graphql server instance"
+  description = "Zone of the ldapi server instance"
 }
 
 variable "dns" {

--- a/deploy/terraform/ldapi/modules/load_balancer/variables.tf
+++ b/deploy/terraform/ldapi/modules/load_balancer/variables.tf
@@ -1,0 +1,21 @@
+variable "env" {
+  type = string
+  description = "Name of the environment"
+}
+
+variable "server_self_link" {
+  type = string
+  description = "Self link of the graphql server instance"
+}
+
+variable "server_zone" {
+  type = string
+  description = "Zone of the graphql server instance"
+}
+
+variable "dns" {
+  type = object({
+    host = string,
+    zone = string
+  })
+}

--- a/deploy/terraform/ldapi/modules/server/main.tf
+++ b/deploy/terraform/ldapi/modules/server/main.tf
@@ -1,0 +1,73 @@
+locals {
+  gcloud_zone = "europe-west2-a"
+  service_account_id = "${var.name}-account"
+}
+
+module "gce_container_spec" {
+  source = "terraform-google-modules/container-vm/google"
+  version = "~> 2.0"
+
+  container = {
+    image = "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-ld-openapi@sha256:${var.digest}"
+  }
+
+  restart_policy = "Always"
+}
+
+resource "null_resource" "image_digest" {
+  triggers = {
+    digest = var.digest
+  }
+}
+
+resource "google_service_account" "ldapi_service_account" {
+  account_id   = local.service_account_id
+  display_name = "Service account to run the ldapi server"
+}
+
+# service account needs to be able to read images from the swirrl-devops-infrastructure project
+resource "google_project_iam_member" "ldapi_service_account_permissions" {
+  project = "swirrl-devops-infrastructure-1"
+  role = "roles/artifactregistry.reader"
+  member = "serviceAccount:${google_service_account.ldapi_service_account.email}"
+}
+
+resource "google_compute_instance" "datahost_ldapi_instance" {
+  name = var.name
+  machine_type = "e2-small"
+  zone = var.zone
+
+  boot_disk {
+    initialize_params {
+      size = "10"
+      image = module.gce_container_spec.source_image
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      # ephemeral public ip
+      # TODO: remove public ip and access only via load balancer
+    }
+  }
+
+  tags = ["http-server", "https-server"]
+
+  labels = {
+    container-vm = module.gce_container_spec.vm_container_label
+  }
+
+  metadata = {
+    gce-container-declaration = module.gce_container_spec.metadata_value
+  }
+
+  lifecycle {
+    replace_triggered_by = [null_resource.image_digest]
+  }
+
+  service_account {
+    email = google_service_account.ldapi_service_account.email
+    scopes = ["cloud-platform"]
+  }
+}

--- a/deploy/terraform/ldapi/modules/server/outputs.tf
+++ b/deploy/terraform/ldapi/modules/server/outputs.tf
@@ -1,0 +1,9 @@
+output "self_link" {
+  description = "Self link of the graphql server instance"
+  value = google_compute_instance.datahost_ldapi_instance.self_link
+}
+
+output "zone" {
+  description = "GCloud zone of the graphql server"
+  value = google_compute_instance.datahost_ldapi_instance.zone
+}

--- a/deploy/terraform/ldapi/modules/server/outputs.tf
+++ b/deploy/terraform/ldapi/modules/server/outputs.tf
@@ -1,9 +1,9 @@
 output "self_link" {
-  description = "Self link of the graphql server instance"
+  description = "Self link of the ldapi server instance"
   value = google_compute_instance.datahost_ldapi_instance.self_link
 }
 
 output "zone" {
-  description = "GCloud zone of the graphql server"
+  description = "GCloud zone of the ldapi server"
   value = google_compute_instance.datahost_ldapi_instance.zone
 }

--- a/deploy/terraform/ldapi/modules/server/variables.tf
+++ b/deploy/terraform/ldapi/modules/server/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  type = string
+  description = "Name of the server to create"
+}
+
+variable "digest" {
+  type = string
+  description = "SHA256 digest of the ldapi application container to deploy"
+}
+
+variable "zone" {
+  type = string
+  description = "Zone to host the server in"
+}


### PR DESCRIPTION
Closes #108 - Define Terraform modules to define an environment for the ld-openapi application. This follows a similar structure to the graphql application:

* server module to define the server
* load_balancer module for the load balancer
* env module to define the entire environment

Update the CI build to automatically deploy the latest version to the `dev` environment for builds on the `main` branch.