### PR TITLE
Shuffle shared route and model helpers into shared places

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -3,7 +3,8 @@
    [duratom.core :as da]
    [integrant.core :as ig]
    [meta-merge.core :as mm]
-   [tpximpact.datahost.ldapi.models.series :as series]))
+   [tpximpact.datahost.ldapi.models.series :as series]
+   [tpximpact.datahost.ldapi.models.shared :as models-shared]))
 
 (def db-defaults
   {:storage-type :local-file
@@ -18,7 +19,7 @@
     (da/duratom storage-type opts))
 
 (defn upsert-series! [db {:keys [series-slug] :as api-params} incoming-jsonld-doc]
-  (let [series-key (series/dataset-series-key series-slug)
+  (let [series-key (models-shared/dataset-series-key series-slug)
         ;; TODO: could handle this more nicely after
         ;; https://github.com/Swirrl/datahost-prototypes/issues/57
         ;; by comparing modified/issued times..

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -1,10 +1,10 @@
 (ns tpximpact.datahost.ldapi.handlers
   (:require
    [tpximpact.datahost.ldapi.db :as db]
-   [tpximpact.datahost.ldapi.models.series :as series]))
+   [tpximpact.datahost.ldapi.models.shared :as models-shared]))
 
 (defn get-dataset-series [db {{:keys [series-slug]} :path-params}]
-  (let [key (series/dataset-series-key series-slug)
+  (let [key (models-shared/dataset-series-key series-slug)
         jsonld-doc (get @db key)]
     (if jsonld-doc
       {:status 200
@@ -33,4 +33,9 @@
   {:status 200})
 
 (defn put-release [db params]
+  (try
+    (let []
+      {:status 200 ;; response-code
+       :body  "";; jsonld-doc
+       }))
   {:status 200})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
@@ -1,4 +1,6 @@
-(ns tpximpact.datahost.ldapi.models.release)
+(ns tpximpact.datahost.ldapi.models.release
+  (:require
+   [tpximpact.datahost.ldapi.models.series :as series]))
 
 ;; (defn upsert-release [db {:keys [api-params jsonld-doc] :as new-release}]
 ;;     ;[db {:keys [series-slug release-slug] :as api-params} jsonld-doc]
@@ -11,3 +13,30 @@
 ;;      (if-let [old-release (get db release-path)]
 ;;        (update db release-path update-release base-entity new-release)
 ;;        (assoc db release-path (normalise-release base-entity new-release)))))
+
+
+(defn normalise-release [base-entity {:keys [api-params jsonld-doc]}]
+  (let [{:keys [series-slug release-slug]} api-params
+        _ (assert base-entity "Expected base entity to be set")
+        context ["https://publishmydata.com/def/datahost/context"
+                 {"@base" base-entity}]]
+
+    (-> (series/merge-params-with-doc api-params jsonld-doc)
+        (assoc "@context" context
+               "@id" release-slug
+               "dcat:inSeries" (str "../" series-slug)))))
+
+(defn- update-release [_old-release base-entity {:keys [api-params _jsonld-doc] :as new-release}]
+  (log/info "Updating release " (:series-slug api-params) "/" (:release-slug api-params))
+  (normalise-release base-entity new-release))
+
+(defn upsert-release [db {:keys [api-params jsonld-doc] :as new-release}] ;[db {:keys [series-slug release-slug] :as api-params} jsonld-doc]
+  (let [{:keys [series-slug release-slug]} api-params
+        release-path (str (.getPath series/ld-root) series-slug "/" release-slug)
+        series-path (str (.getPath series/ld-root) series-slug)
+        series (get db series-path)
+        base-entity (get series "dh:baseEntity")]
+
+    (if-let [old-release (get db release-path)]
+      (update db release-path update-release base-entity new-release)
+      (assoc db release-path (normalise-release base-entity new-release)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
@@ -1,12 +1,13 @@
 (ns tpximpact.datahost.ldapi.models.release
   (:require
-   [tpximpact.datahost.ldapi.models.series :as series]))
+   [clojure.tools.logging :as log]
+   [tpximpact.datahost.ldapi.models.shared :as models-shared]))
 
 ;; (defn upsert-release [db {:keys [api-params jsonld-doc] :as new-release}]
 ;;     ;[db {:keys [series-slug release-slug] :as api-params} jsonld-doc]
 ;;    (let [{:keys [series-slug release-slug]} api-params
-;;          release-path (str (.getPath series/ld-root) series-slug "/" release-slug)
-;;          series-path (str (.getPath series/ld-root) series-slug)
+;;          release-path (str (.getPath models-shared/ld-root) series-slug "/" release-slug)
+;;          series-path (str (.getPath models-shared/ld-root) series-slug)
 ;;          series (get db series-path)
 ;;          base-entity (get series "dh:baseEntity")]
 
@@ -21,7 +22,7 @@
         context ["https://publishmydata.com/def/datahost/context"
                  {"@base" base-entity}]]
 
-    (-> (series/merge-params-with-doc api-params jsonld-doc)
+    (-> (models-shared/merge-params-with-doc api-params jsonld-doc)
         (assoc "@context" context
                "@id" release-slug
                "dcat:inSeries" (str "../" series-slug)))))
@@ -32,8 +33,8 @@
 
 (defn upsert-release [db {:keys [api-params jsonld-doc] :as new-release}] ;[db {:keys [series-slug release-slug] :as api-params} jsonld-doc]
   (let [{:keys [series-slug release-slug]} api-params
-        release-path (str (.getPath series/ld-root) series-slug "/" release-slug)
-        series-path (str (.getPath series/ld-root) series-slug)
+        release-path (str (.getPath models-shared/ld-root) series-slug "/" release-slug)
+        series-path (str (.getPath models-shared/ld-root) series-slug)
         series (get db series-path)
         base-entity (get series "dh:baseEntity")]
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -1,0 +1,38 @@
+(ns tpximpact.datahost.ldapi.models.shared
+  (:require
+   [clojure.set :as set]
+   [tpximpact.datahost.ldapi.util :as util])
+  (:import
+   [java.net URI]))
+
+(def ld-root
+  "For the prototype this item will come from config or be derived from
+  it. It should have a trailing slash."
+  (URI. "https://example.org/data/"))
+
+(defn dataset-series-key [series-slug]
+  (str (.getPath ld-root) series-slug))
+
+(defn normalise-context [ednld]
+  (let [normalised-context ["https://publishmydata.com/def/datahost/context"
+                            {"@base" (str ld-root)}]]
+    (if-let [context (get ednld "@context")]
+      (cond
+        (= context "https://publishmydata.com/def/datahost/context") normalised-context
+        (= context normalised-context) normalised-context
+
+        :else (throw (ex-info "Invalid @context" {:supplied-context context
+                                                  :valid-context normalised-context})))
+
+      ;; return normalised-context if none provided
+      normalised-context)))
+
+(defn merge-params-with-doc [api-params jsonld-doc]
+  (let [merged-doc (merge (set/rename-keys api-params
+                                           {:title "dcterms:title"
+                                            :description "dcterms:description"})
+                          jsonld-doc)
+        cleaned-doc (-> merged-doc
+                        (util/dissoc-by-key keyword?))]
+
+    cleaned-doc))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -1,13 +1,35 @@
 (ns tpximpact.datahost.ldapi.routes.release
   (:require
    [tpximpact.datahost.ldapi.handlers :as handlers]
-   [tpximpact.datahost.ldapi.routes.copy :as copy]))
+   [tpximpact.datahost.ldapi.routes.copy :as copy]
+   [tpximpact.datahost.ldapi.routes.shared :as routes-shared]))
 
 (defn get-release-route-config [db]
   {:summary copy/get-release-summary
-   :handler (partial handlers/get-release db)})
+   :handler (partial handlers/get-release db)
+   :parameters {:path {:series-slug string?
+                       :release-slug string?}}
+   :responses {200 {:body map?}
+               404 {:body [:re "Not found"]}}})
 
 (defn put-release-route-config [db]
   {:summary copy/put-release-summary
-   :handler (partial handlers/put-release db)}
-  )
+   :handler (partial handlers/put-release db)
+   :parameters {:body routes-shared/JsonLdSchema
+                :path {:series-slug string?
+                       :release-slug string?}
+                :query [:map
+                        [:title {:title "Title"
+                                 :description "Title of release"
+                                 :optional true} string?]
+                        [:description {:title "Description"
+                                       :description "Description of release"
+                                       :optional true} string?]]
+                :responses {200 {:description "Series already existed and was successfully updated"
+                                 :body map?}
+                            201 {:description "Series did not exist previously and was successfully created"
+                                 :body map?}
+                            500 {:description "Internal server error"
+                                 :body [:map
+                                        [:status [:enum "error"]]
+                                        [:message string?]]}}}})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
@@ -1,41 +1,33 @@
 (ns tpximpact.datahost.ldapi.routes.series
   (:require
    [tpximpact.datahost.ldapi.handlers :as handlers]
-   [tpximpact.datahost.ldapi.routes.copy :as copy]))
-
-(def JsonLdSchema
-  [:maybe
-   [:map
-    ["dcterms:title" {:optional true} string?]
-    ["dcterms:description" {:optional true} string?]
-    ["@context" [:or :string
-                 [:tuple :string [:map
-                                  ["@base" string?]]]]]]])
+   [tpximpact.datahost.ldapi.routes.copy :as copy]
+   [tpximpact.datahost.ldapi.routes.shared :as routes-shared]))
 
 (defn get-series-route-config [db]
   {:summary copy/get-series-summary
    :description copy/get-series-description
    :handler (partial handlers/get-dataset-series db)
    :parameters {:path {:series-slug string?}}
-   :responses {200 {:body JsonLdSchema}
-               404 {:body [:enum "Not found"]}}})
+   :responses {200 {:body routes-shared/JsonLdSchema}
+               404 {:body [:re "Not found"]}}})
 
 (defn put-series-route-config [db]
   {:summary copy/put-series-summary
    :handler (partial handlers/put-dataset-series db)
-   :parameters {:body JsonLdSchema
+   :parameters {:body routes-shared/JsonLdSchema
                 :path {:series-slug string?}
                 :query [:map
                         [:title {:title "Title"
-                                 :description "Title of dataset"
+                                 :description "Title of dataset series"
                                  :optional true} string?]
                         [:description {:title "Description"
-                                       :description "Description of dataset"
+                                       :description "Description of dataset series"
                                        :optional true} string?]]}
    :responses {200 {:description "Series already existed and was successfully updated"
-                    :body map?}
+                    :body routes-shared/JsonLdSchema}
                201 {:description "Series did not exist previously and was successfully created"
-                    :body map?}
+                    :body routes-shared/JsonLdSchema}
                500 {:description "Internal server error"
                     :body [:map
                            [:status [:enum "error"]]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -1,0 +1,13 @@
+(ns tpximpact.datahost.ldapi.routes.shared)
+
+(def JsonLdSchema
+  [:maybe
+   [:map {:closed false}
+    ["dcterms:title" {:optional true} string?]
+    ["dcterms:description" {:optional true} string?]
+    ["@type" {:optional true} string?]
+    ["@id" {:optional true} string?]
+    ["dh:baseEntity" {:optional true} string?]
+    ["@context" [:or :string
+                 [:tuple :string [:map
+                                  ["@base" string?]]]]]]])

--- a/datahost-ld-openapi/src/tpximpact/datahost/scratch/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/scratch/release.clj
@@ -1,7 +1,7 @@
 (ns tpximpact.datahost.scratch.release
   (:require
    [clojure.tools.logging :as log]
-   [tpximpact.datahost.ldapi.models.series :as series]))
+   [tpximpact.datahost.ldapi.models.shared :as models-shared]))
 
 (defn normalise-release [base-entity {:keys [api-params jsonld-doc]}]
   (let [{:keys [series-slug release-slug]} api-params
@@ -9,7 +9,7 @@
         context ["https://publishmydata.com/def/datahost/context"
                  {"@base" base-entity}]]
 
-    (-> (series/merge-params-with-doc api-params jsonld-doc)
+    (-> (models-shared/merge-params-with-doc api-params jsonld-doc)
         (assoc "@context" context
                "@id" release-slug
                "dcat:inSeries" (str "../" series-slug)))))
@@ -20,8 +20,8 @@
 
 (defn upsert-release [db {:keys [api-params jsonld-doc] :as new-release}] ;[db {:keys [series-slug release-slug] :as api-params} jsonld-doc]
   (let [{:keys [series-slug release-slug]} api-params
-        release-path (str (.getPath series/ld-root) series-slug "/" release-slug)
-        series-path (str (.getPath series/ld-root) series-slug)
+        release-path (str (.getPath models-shared/ld-root) series-slug "/" release-slug)
+        series-path (str (.getPath models-shared/ld-root) series-slug)
         series (get db series-path)
         base-entity (get series "dh:baseEntity")]
 

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -4,56 +4,56 @@
    [clojure.test :refer [deftest is testing]]
    [tpximpact.test-helpers :as th]))
 
-(deftest round-tripping-release-test
-  (th/with-system-and-clean-up sys
-    (testing "Creating a release for a series that is not found fails gracefully"
-      (try
-        (http/get "http://localhost:3400/data/does-not-exist/release/release-1")
+;; (deftest   round-tripping-release-test
+;;   (th/with-system-and-clean-up sys
+;;     (testing "Creating a release for a series that is not found fails gracefully"
+;;       (try
+;;         (http/get "http://localhost:3400/data/does-not-exist/release/release-1")
 
-        (catch Throwable ex
-          (let [{:keys [status body]} (ex-data ex)]
-            (is (= status 404))
-            (is (= body "Not found"))))))
+;;         (catch Throwable ex
+;;           (let [{:keys [status body]} (ex-data ex)]
+;;             (is (= status 404))
+;;             (is (= body "Not found"))))))
 
-    (testing "Fetching a release for a series that does not exist returns 'not found'")
+;;     (testing "Fetching a release for a series that does not exist returns 'not found'")
 
-    (testing "Fetching a release that does not exist returns 'not found'")
-    ;; (http/put)
-    )
-  ;; (th/with-system-and-clean-up sys
-  ;;   (testing "A series that does not exist returns 'not found'"
-  ;;     (try
-  ;;       (http/get "http://localhost:3400/data/does-not-exist")
+;;     (testing "Fetching a release that does not exist returns 'not found'")
+;;     ;; (http/put)
+;;     )
+;;   ;; (th/with-system-and-clean-up sys
+;;   ;;   (testing "A series that does not exist returns 'not found'"
+;;   ;;     (try
+;;   ;;       (http/get "http://localhost:3400/data/does-not-exist")
 
-  ;;       (catch Throwable ex
-  ;;         (let [{:keys [status body]} (ex-data ex)]
-  ;;           (is (= status 404))
-  ;;           (is (= body "Not found"))))))
+;;   ;;       (catch Throwable ex
+;;   ;;         (let [{:keys [status body]} (ex-data ex)]
+;;   ;;           (is (= status 404))
+;;   ;;           (is (= body "Not found"))))))
 
-  ;;   (let [incoming-jsonld-doc {"@context"
-  ;;                              ["https://publishmydata.com/def/datahost/context"
-  ;;                               {"@base" "https://example.org/data/"}],
-  ;;                              "dcterms:title" "A title"}
-  ;;         augmented-jsonld-doc (sut/normalise-series {:series-slug "new-series"}
-  ;;                                                    incoming-jsonld-doc)]
-  ;;     (testing "A series can be created and retrieved via the API"
+;;   ;;   (let [incoming-jsonld-doc {"@context"
+;;   ;;                              ["https://publishmydata.com/def/datahost/context"
+;;   ;;                               {"@base" "https://example.org/data/"}],
+;;   ;;                              "dcterms:title" "A title"}
+;;   ;;         augmented-jsonld-doc (sut/normalise-series {:series-slug "new-series"}
+;;   ;;                                                    incoming-jsonld-doc)]
+;;   ;;     (testing "A series can be created and retrieved via the API"
 
-  ;;       (let [response (http/put
-  ;;                       "http://localhost:3400/data/new-series"
-  ;;                       {:content-type :json
-  ;;                        :body (json/write-str incoming-jsonld-doc)})]
-  ;;         (is (= (:status response) 201))
-  ;;         (is (= (json/read-str (:body response)) augmented-jsonld-doc)))
+;;   ;;       (let [response (http/put
+;;   ;;                       "http://localhost:3400/data/new-series"
+;;   ;;                       {:content-type :json
+;;   ;;                        :body (json/write-str incoming-jsonld-doc)})]
+;;   ;;         (is (= (:status response) 201))
+;;   ;;         (is (= (json/read-str (:body response)) augmented-jsonld-doc)))
 
-  ;;       (let [response (http/get "http://localhost:3400/data/new-series")]
-  ;;         (is (= (:status response) 200))
-  ;;         (is (= (json/read-str (:body response)) augmented-jsonld-doc))))
+;;   ;;       (let [response (http/get "http://localhost:3400/data/new-series")]
+;;   ;;         (is (= (:status response) 200))
+;;   ;;         (is (= (json/read-str (:body response)) augmented-jsonld-doc))))
 
-  ;;     (testing "A series can be updated via the API"
-  ;;       (let [response (http/put "http://localhost:3400/data/new-series?title=A%20new%20title")]
-  ;;         (is (= (:status response) 200)))
+;;   ;;     (testing "A series can be updated via the API"
+;;   ;;       (let [response (http/put "http://localhost:3400/data/new-series?title=A%20new%20title")]
+;;   ;;         (is (= (:status response) 200)))
 
-  ;;       (let [response (http/get "http://localhost:3400/data/new-series")]
-  ;;         (is (= (:status response) 200))
-  ;;         (is (= (-> response :body json/read-str (get "dcterms:title")) "A new title"))))))
-  )
+;;   ;;       (let [response (http/get "http://localhost:3400/data/new-series")]
+;;   ;;         (is (= (:status response) 200))
+;;   ;;         (is (= (-> response :body json/read-str (get "dcterms:title")) "A new title"))))))
+;;   )

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -1,0 +1,59 @@
+(ns tpximpact.datahost.ldapi.models.release-test
+  (:require
+   [clj-http.client :as http]
+   [clojure.test :refer [deftest is testing]]
+   [tpximpact.test-helpers :as th]))
+
+(deftest round-tripping-release-test
+  (th/with-system-and-clean-up sys
+    (testing "Creating a release for a series that is not found fails gracefully"
+      (try
+        (http/get "http://localhost:3400/data/does-not-exist/release/release-1")
+
+        (catch Throwable ex
+          (let [{:keys [status body]} (ex-data ex)]
+            (is (= status 404))
+            (is (= body "Not found"))))))
+
+    (testing "Fetching a release for a series that does not exist returns 'not found'")
+
+    (testing "Fetching a release that does not exist returns 'not found'")
+    ;; (http/put)
+    )
+  ;; (th/with-system-and-clean-up sys
+  ;;   (testing "A series that does not exist returns 'not found'"
+  ;;     (try
+  ;;       (http/get "http://localhost:3400/data/does-not-exist")
+
+  ;;       (catch Throwable ex
+  ;;         (let [{:keys [status body]} (ex-data ex)]
+  ;;           (is (= status 404))
+  ;;           (is (= body "Not found"))))))
+
+  ;;   (let [incoming-jsonld-doc {"@context"
+  ;;                              ["https://publishmydata.com/def/datahost/context"
+  ;;                               {"@base" "https://example.org/data/"}],
+  ;;                              "dcterms:title" "A title"}
+  ;;         augmented-jsonld-doc (sut/normalise-series {:series-slug "new-series"}
+  ;;                                                    incoming-jsonld-doc)]
+  ;;     (testing "A series can be created and retrieved via the API"
+
+  ;;       (let [response (http/put
+  ;;                       "http://localhost:3400/data/new-series"
+  ;;                       {:content-type :json
+  ;;                        :body (json/write-str incoming-jsonld-doc)})]
+  ;;         (is (= (:status response) 201))
+  ;;         (is (= (json/read-str (:body response)) augmented-jsonld-doc)))
+
+  ;;       (let [response (http/get "http://localhost:3400/data/new-series")]
+  ;;         (is (= (:status response) 200))
+  ;;         (is (= (json/read-str (:body response)) augmented-jsonld-doc))))
+
+  ;;     (testing "A series can be updated via the API"
+  ;;       (let [response (http/put "http://localhost:3400/data/new-series?title=A%20new%20title")]
+  ;;         (is (= (:status response) 200)))
+
+  ;;       (let [response (http/get "http://localhost:3400/data/new-series")]
+  ;;         (is (= (:status response) 200))
+  ;;         (is (= (-> response :body json/read-str (get "dcterms:title")) "A new title"))))))
+  )

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -40,7 +40,7 @@
 
         (let [response (http/get "http://localhost:3400/data/new-series")]
           (is (= (:status response) 200))
-          (is (= (json/read-str (:body response)) incoming-jsonld-doc))))
+          (is (= (json/read-str (:body response)) augmented-jsonld-doc))))
 
       (testing "A series can be updated via the API"
         (let [response (http/put "http://localhost:3400/data/new-series?title=A%20new%20title")]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -1,13 +1,14 @@
 (ns tpximpact.datahost.ldapi.models.series-test
   (:require
    [clj-http.client :as http]
+   [clojure.data.json :as json]
    [clojure.test :refer [deftest is testing]]
    [grafter.matcha.alpha :as matcha]
    [grafter.vocabularies.dcterms :refer [dcterms:title]]
    [tpximpact.datahost.ldapi.models.series :as sut]
+   [tpximpact.datahost.ldapi.models.shared :as models-shared]
    [tpximpact.datahost.ldapi.util :as util]
-   [tpximpact.test-helpers :as th]
-   [clojure.data.json :as json])
+   [tpximpact.test-helpers :as th])
   (:import
    (clojure.lang ExceptionInfo)
    (java.net URI)))
@@ -56,15 +57,15 @@
 
     (testing "An empty @context is normalised"
       (is (= expected-context
-             (sut/normalise-context {}))))
+             (models-shared/normalise-context {}))))
 
     (testing "A declared context of 'https://publishmydata.com/def/datahost/context' is normalised"
       (is (= expected-context
-             (sut/normalise-context {"@context" "https://publishmydata.com/def/datahost/context"}))))
+             (models-shared/normalise-context {"@context" "https://publishmydata.com/def/datahost/context"}))))
 
     (testing "A normalised context is idempotent to itself"
       (is (= expected-context
-             (sut/normalise-context {"@context" ["https://publishmydata.com/def/datahost/context",
+             (models-shared/normalise-context {"@context" ["https://publishmydata.com/def/datahost/context",
                                                  {"@base" "https://example.org/data/"}]}))))))
 
 (defn canonicalisation-idempotent? [api-params jsonld]


### PR DESCRIPTION
Another small change, just extracting more shared things as releases are implemented but want to merge sooner rather than later in the interest of reducing merge conflicts.