### PR TITLE
Store database on secondary volume

### DIFF
--- a/datahost-ld-openapi/env/docker/resources/ldapi/env.edn
+++ b/datahost-ld-openapi/env/docker/resources/ldapi/env.edn
@@ -3,6 +3,5 @@
  :tpximpact.datahost.ldapi.jetty/runnable-service {:host "0.0.0.0" ;; bind to all network interfaces
                                                    :port 80}
 
- ;; TODO: Needs to use a mounted persistent volume, once it's available
- :tpximpact.datahost.ldapi.db/db {:opts {:file-path ".datahost-prod-db.edn"}}
+ :tpximpact.datahost.ldapi.db/db {:opts {:file-path "/cache/datahost-prod-db.edn"}}
  }


### PR DESCRIPTION
Issue #44 - Attach a secondary data disk to the ldapi server and update the container configuration to format and attach the volume at /cache within the container. Update the Docker environment config to write the database to a file within this directory. Change db path in docker env config and attach data disk at that path