### PR TITLE
Include  'dcterms:issued' and 'dcterms:modified' in documents

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -21,11 +21,11 @@
                                     (catch URISyntaxException ex
                                       false))))})
    :datahost/timestamp (let [utc-tz (java.time.ZoneId/of "UTC")]
-                               (m/-simple-schema
-                                {:type :datahost/timestamp
-                                 :pred (fn [ts]
-                                         (and (instance? java.time.ZonedDateTime ts)
-                                              (= (.getZone ^ZonedDateTime ts) utc-tz)))}))})
+                         (m/-simple-schema
+                          {:type :datahost/timestamp
+                           :pred (fn [ts]
+                                   (and (instance? java.time.ZonedDateTime ts)
+                                        (= (.getZone ^ZonedDateTime ts) utc-tz)))}))})
 
 (def registry
   (merge
@@ -37,8 +37,9 @@
 
 (def SeriesPathParams
   (m/schema
-   [:map {:registry custom-registry-keys}
-    [:series-slug ::series-slug-string]]))
+   [:map
+    [:series-slug ::series-slug-string]]
+   {:registry registry}))
 
 (def SeriesQueryParams
   (m/schema
@@ -171,8 +172,9 @@
 
 (def UpsertArgs
   (let [db-schema [:map {}]
-        api-params-schema (m/schema [:map {:registry custom-registry-keys}
-                                     [:op/timestamp :datahost/timestamp]])
+        api-params-schema (m/schema [:map
+                                     [:op/timestamp :datahost/timestamp]]
+                                    {:registry registry})
         input-jsonld-doc-schema [:maybe [:map {}]]]
     [:catn
      [:db db-schema]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -163,16 +163,11 @@
   document is updated."
   ([db api-params jsonld-doc]
    {:pre [(contains? api-params :op/timestamp)]
-    :post [;; (if-let [issued (get jsonld-doc "dcterms:issued")]
-           ;;   (= issued (get % "dcterms:issued"))
-           ;;   true)
-           (validate-issued-unchanged jsonld-doc %)
+    :post [(validate-issued-unchanged jsonld-doc %)
            (if (get jsonld-doc "dcterms:issued")
              (not= (get jsonld-doc "dcterms:modified")
                    (get % "dcterms:modified"))
              true)]}
-   ;; TODO: we need to guard against upserting "dcterms:issued"
-   ;; TODO: we need to guard against upserting "updating:modified"?
    (let [series-key (models-shared/dataset-series-key (:series-slug api-params))]
      (if-let [_old-series (get db series-key)]
        (update db series-key update-series api-params jsonld-doc)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -208,6 +208,8 @@
      (cond
        (and old-series 
             (nil? jsonld-doc)
+            ;; we don't want an update if the query-params' values are
+            ;; the same as the ones in the document already
             (let [query-changes (select-keys api-params api-query-params-keys)]
               (or (empty? query-changes)
                   (let [renamed (models-shared/rename-query-params-to-series-keys query-changes)]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -179,6 +179,8 @@
      [:api-params api-params-schema]
      [:jsonld-doc input-jsonld-doc-schema]]))
 
+(def upsert-args-valid? (m/validator UpsertArgs))
+
 (defn upsert-series
   "Takes a derefenced db state map with the shape {path jsonld} and
   upserts a new dataset series into it.
@@ -198,7 +200,7 @@
   For example a `dcterms:issued` time should not change after a
   document is updated."
   ([db api-params jsonld-doc]
-   {:pre [(m/validate UpsertArgs [db api-params jsonld-doc])]
+   {:pre [(upsert-args-valid? [db api-params jsonld-doc])]
     :post [(validate-issued-unchanged jsonld-doc %)
            (validate-modified-changed jsonld-doc %)]}
    (let [series-key (models-shared/dataset-series-key (:series-slug api-params))
@@ -218,4 +220,3 @@
        
        :else
        (assoc db series-key (create-series api-params jsonld-doc))))))
-

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -28,11 +28,8 @@
       normalised-context)))
 
 (defn merge-params-with-doc [api-params jsonld-doc]
-  (let [merged-doc (merge (set/rename-keys api-params
+  (let [merged-doc (merge jsonld-doc
+                          (set/rename-keys api-params
                                            {:title "dcterms:title"
-                                            :description "dcterms:description"})
-                          jsonld-doc)
-        cleaned-doc (-> merged-doc
-                        (util/dissoc-by-key keyword?))]
-
-    cleaned-doc))
+                                            :description "dcterms:description"}))]
+    (util/dissoc-by-key merged-doc keyword?)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -27,6 +27,14 @@
       ;; return normalised-context if none provided
       normalised-context)))
 
+(def query-params->series-keys
+  {:title "dcterms:title"
+   :description "dcterms:description"})
+
+(defn rename-query-params-to-series-keys
+  [m]
+  (set/rename-keys m query-params->series-keys))
+
 (defn merge-params-with-doc [api-params jsonld-doc]
   (let [merged-doc (merge jsonld-doc
                           (set/rename-keys api-params

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util.clj
@@ -28,6 +28,4 @@
                                                   (RDFDatasetUtils/toNQuads dataset sb)
                                                   (str sb))]
 
-                               (tap> nquad-string)
-
                                (rio/statements (java.io.StringReader. nquad-string) :format :nq))))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -15,7 +15,7 @@
 
 (defn format-date-time
   [dt]
-  (.format dt java.time.format.DateTimeFormatter/ISO_OFFSET_DATE_TIME))
+  (.format ^java.time.ZonedDateTime dt java.time.format.DateTimeFormatter/ISO_OFFSET_DATE_TIME))
 
 (deftest round-tripping-series-test
   (th/with-system-and-clean-up sys

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -68,7 +68,7 @@
           (is (= (:status response) 200)))
         
         (let [response (http/get "http://localhost:3400/data/new-series")
-              resp-body (-> response :body json/read-str )]
+              resp-body (-> response :body json/read-str)]
           (is (= (:status response) 200))
           (is (= (get resp-body "dcterms:title") "A new title"))
           (is (not= (get resp-body "dcterms:issued")

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -31,7 +31,8 @@
     (let [incoming-jsonld-doc {"@context"
                                ["https://publishmydata.com/def/datahost/context"
                                 {"@base" "https://example.org/data/"}],
-                               "dcterms:title" "A title"}
+                               "dcterms:title" "A title"
+                               "dcterms:identifier" "foobar"}
           timestamp (java.time.ZonedDateTime/now (java.time.ZoneId/of "UTC"))
           augmented-jsonld-doc (sut/normalise-series {:series-slug "new-series"
                                                       :op/timestamp timestamp}
@@ -65,13 +66,15 @@
       (testing "A series can be updated via the API"
         (let [response (http/put "http://localhost:3400/data/new-series?title=A%20new%20title")]
           (is (= (:status response) 200)))
-
+        
         (let [response (http/get "http://localhost:3400/data/new-series")
               resp-body (-> response :body json/read-str )]
           (is (= (:status response) 200))
           (is (= (get resp-body "dcterms:title") "A new title"))
           (is (not= (get resp-body "dcterms:issued")
-                    (get resp-body "dcterms:modified"))))))))
+                    (get resp-body "dcterms:modified")))
+          (is (= "foobar" (get resp-body "dcterms:identifier"))
+              "The identifier should be left untouched."))))))
 
 (deftest normalise-context-test
   (let [expected-context ["https://publishmydata.com/def/datahost/context"

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -47,11 +47,10 @@
       (is (matcha/ask [[example:my-dataset-series dcterms:title "My series"]] (db->matcha @db)))
 
       (testing "idempotent - upserting same request again is equivalent to inserting once"
-
         (let [start-state @db
               end-state (swap! db series/upsert-series
                                {:series-slug "my-dataset-series" 
-                                ;;:title "My series"
+                                :title "My series"
                                 :op/timestamp (java.time.ZonedDateTime/now (java.time.ZoneId/of "UTC"))} 
                                nil)]
           (is (= start-state end-state)))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -39,7 +39,9 @@
   (let [db (atom {})] ;; an empty database
     (testing "Constructing the series"
       ;; first make a series
-      (swap! db series/upsert-series {:series-slug "my-dataset-series" :title "My series"} {})
+      (swap! db series/upsert-series {:series-slug "my-dataset-series" 
+                                      :title "My series" 
+                                      :op/timestamp (java.time.ZonedDateTime/now (java.time.ZoneId/of "UTC"))} nil)
 
       (is (matcha/ask [[example:my-dataset-series dh:baseEntity ?o]] (db->matcha @db)))
       (is (matcha/ask [[example:my-dataset-series dcterms:title "My series"]] (db->matcha @db)))
@@ -48,12 +50,16 @@
 
         (let [start-state @db
               end-state (swap! db series/upsert-series
-                               {:series-slug "my-dataset-series" :title "My series"} {})]
+                               {:series-slug "my-dataset-series" 
+                                ;;:title "My series"
+                                :op/timestamp (java.time.ZonedDateTime/now (java.time.ZoneId/of "UTC"))} 
+                               nil)]
           (is (= start-state end-state)))))
 
     (testing "Constructing a release"
-      (swap! db release/upsert-release {:api-params {:series-slug "my-dataset-series" :release-slug "2018"}
-                                        :jsonld-doc {"dcterms:title" "2018"}})
+      (swap! db release/upsert-release
+	         {:api-params {:series-slug "my-dataset-series" :release-slug "2018"}
+              :jsonld-doc {"dcterms:title" "2018"}})
 
       (is (matcha/ask [[example:my-release ?p ?o]] (db->matcha @db)))
       (is (matcha/ask [[example:my-release dcterms:title "2018"]] (db->matcha @db)))


### PR DESCRIPTION
Documents should have `dcterms:modified` and `dcterms:issued` entries.

Achieving the above is simple, but requires extra handling to ensure:
- client can't update `dcterms:issued`
- client can't overwrite the existing document with empty document
- proper handling of `{}` and `nil` input documents

