### PR TITLE
Release timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@
 *.iml
 *.swp
 .envrc
+.justfile
 .rebl
 datahost-ld-openapi/tmp
 .datahost-*-db.edn
+
 

--- a/datahost-ld-openapi/deps.edn
+++ b/datahost-ld-openapi/deps.edn
@@ -26,7 +26,7 @@
                             "-Dcom.sun.management.jmxremote.authenticate=false"
                             "-Dcom.sun.management.jmxremote.port=3007"
                             ;;"-Dlog4j.configuration=log4j2-docker.xml"
-                            ;"-Dlog4j2.debug=true"
+                            ;;"-Dlog4j2.debug=true"
                             ]
 
                  :main-opts ["-m" "tpximpact.datahost.ldapi"]}
@@ -40,7 +40,7 @@
           :ns-default build}
 
   :test {:extra-paths ["test" "env/test/resources"]
-         :extra-deps {lambdaisland/kaocha {:mvn/version "1.82.1306"}
+         :extra-deps {lambdaisland/kaocha {:mvn/version "1.85.1342"}
                       lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}}
          :exec-fn kaocha.runner/exec-fn
          :exec-args {:tests [{:id :unit
@@ -50,6 +50,11 @@
                      :kaocha.plugin.junit-xml/target-file "test-results/kaocha/results.xml"
                      :reporter kaocha.report/documentation
                      }}
+  :test-watch {:extra-deps {lambdaisland/kaocha {:mvn/version "1.85.1342"}}
+               :exec-fn kaocha.runner/exec-fn
+               :exec-args {:watch? true
+	                       :skip-meta :slow
+	                       :fail-fast? true}}
 
   :dev {:extra-paths ["env/dev/src" "env/test/resources" "test"]
         :extra-deps {integrant/repl {:mvn/version "0.3.2"}

--- a/datahost-ld-openapi/env/test/resources/test-system.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system.edn
@@ -1,6 +1,6 @@
-{:tpximpact.datahost.ldapi.jetty/http-port 3400
- 
- :tpximpact.datahost.ldapi.test/http-client 
+{:tpximpact.datahost.ldapi.jetty/http-port #int #or [#env "LD_API_HTTP_PORT" "3400"]
+
+ :tpximpact.datahost.ldapi.test/http-client
  {:port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port}
 
  :tpximpact.datahost.ldapi.db/db {:opts {:file-path ".datahost-test-db.edn"}}

--- a/datahost-ld-openapi/env/test/resources/test-system.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system.edn
@@ -1,8 +1,10 @@
 {:tpximpact.datahost.ldapi.jetty/http-port #int #or [#env "LD_API_HTTP_PORT" "3400"]
+ :tpximpact.datahost.ldapi.native-datastore.repo/data-directory #or [#env "LD_API_TEST_DATA_DIR" "/tmp/ld-test-db"]
 
  :tpximpact.datahost.ldapi.test/http-client
  {:port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port}
 
  :tpximpact.datahost.ldapi.db/db {:opts {:file-path ".datahost-test-db.edn"}}
 
- :tpximpact.datahost.ldapi.native-datastore/repo {:data-directory "/tmp/ld-test-db"}}
+ :tpximpact.datahost.ldapi.native-datastore/repo 
+ {:data-directory #ig/ref :tpximpact.datahost.ldapi.native-datastore.repo/data-directory}}

--- a/datahost-ld-openapi/env/test/resources/test-system.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system.edn
@@ -1,7 +1,8 @@
-{:tpximpact.datahost.ldapi.jetty/runnable-service {:port 3400}
+{:tpximpact.datahost.ldapi.jetty/http-port 3400
+ 
+ :tpximpact.datahost.ldapi.test/http-client 
+ {:port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port}
 
  :tpximpact.datahost.ldapi.db/db {:opts {:file-path ".datahost-test-db.edn"}}
 
- :tpximpact.datahost.ldapi.native-datastore/repo {:data-directory "/tmp/ld-test-db"}
-
- }
+ :tpximpact.datahost.ldapi.native-datastore/repo {:data-directory "/tmp/ld-test-db"}}

--- a/datahost-ld-openapi/resources/ldapi/base-system.edn
+++ b/datahost-ld-openapi/resources/ldapi/base-system.edn
@@ -1,8 +1,9 @@
 {:tpximpact.datahost.ldapi/default-catalog-id "http://gss-data.org.uk/catalog/datasets"
  :tpximpact.datahost.ldapi/drafter-base-uri "https://idp-beta-drafter.publishmydata.com/"
+ :tpximpact.datahost.ldapi.jetty/http-port 3000
 
  :tpximpact.datahost.ldapi.jetty/runnable-service {:host "localhost"
-                                                   :port 3000
+                                                   :port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port;;3000
                                                    :handler #ig/ref :tpximpact.datahost.ldapi.router/handler
                                                    :ide-path "/ld-api"
                                                    :default-subscriptions-path "/ws"}

--- a/datahost-ld-openapi/resources/ldapi/base-system.edn
+++ b/datahost-ld-openapi/resources/ldapi/base-system.edn
@@ -2,15 +2,17 @@
  :tpximpact.datahost.ldapi/drafter-base-uri "https://idp-beta-drafter.publishmydata.com/"
  :tpximpact.datahost.ldapi.jetty/http-port 3000
 
- :tpximpact.datahost.ldapi.jetty/runnable-service {:host "localhost"
-                                                   :port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port;;3000
-                                                   :handler #ig/ref :tpximpact.datahost.ldapi.router/handler
-                                                   :ide-path "/ld-api"
-                                                   :default-subscriptions-path "/ws"}
+ :tpximpact.datahost.ldapi.jetty/runnable-service 
+ {:host "localhost"
+  :port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port
+  :handler #ig/ref :tpximpact.datahost.ldapi.router/handler
+  :ide-path "/ld-api"
+  :default-subscriptions-path "/ws"}
 
  :tpximpact.datahost.ldapi.native-datastore/repo {:data-directory "/tmp/ld-dev-db"}
 
- :tpximpact.datahost.ldapi.router/handler {:triplestore #ig/ref :tpximpact.datahost.ldapi.native-datastore/repo
-                                           :db #ig/ref :tpximpact.datahost.ldapi.db/db}
+ :tpximpact.datahost.ldapi.router/handler 
+ {:triplestore #ig/ref :tpximpact.datahost.ldapi.native-datastore/repo
+  :db #ig/ref :tpximpact.datahost.ldapi.db/db}
 
  :tpximpact.datahost.ldapi.db/db {:opts {:file-path ".datahost-dev-db.edn"}}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi.clj
@@ -28,6 +28,8 @@
 
 (derive :tpximpact.datahost.ldapi.jetty/http-port ::const)
 
+(derive :tpximpact.datahost.ldapi.native-datastore.repo/data-directory ::const)
+
 (def system nil)
 
 (defn stop-system! []

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi.clj
@@ -26,6 +26,8 @@
 
 (derive ::default-catalog-id ::const)
 
+(derive :tpximpact.datahost.ldapi.jetty/http-port ::const)
+
 (def system nil)
 
 (defn stop-system! []

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -2,10 +2,13 @@
   (:require
    [duratom.core :as da]
    [integrant.core :as ig]
+   [malli.core :as m]
    [meta-merge.core :as mm]
    [tpximpact.datahost.ldapi.models.shared :as models-shared]
    [tpximpact.datahost.ldapi.models.series :as series]
-   [tpximpact.datahost.ldapi.models.release :as release])
+   [tpximpact.datahost.ldapi.models.release :as release]
+   [tpximpact.datahost.ldapi.schemas.release :as s.release]
+   [tpximpact.datahost.ldapi.schemas.series :as s.series])
   (:import
    [java.time ZoneId ZonedDateTime]))
 
@@ -29,10 +32,18 @@
   (let [key (models-shared/release-key series-slug release-slug)]
     (get @db key)))
 
+(def UpsertInernalParams
+  [:map
+   [:op.upsert/keys
+    [:or s.series/UpsertKeys s.release/UpsertKeys]]])
+
+(def upsert-internal-params-valid? (m/validator UpsertInernalParams))
+
 (defn- upsert-doc!
   "Applies upsert of the JSON-LD document and mutates the db-ref.
   Returns the value of the db-ref after the upsert."
   [db-ref update-fn api-params incoming-jsonld-doc]
+  {:pre [(upsert-internal-params-valid? api-params)]}
   (let [ts (ZonedDateTime/now (ZoneId/of "UTC"))]
     (swap! db-ref
            update-fn
@@ -43,6 +54,7 @@
   "Returns a map {:op ... :jdonld-doc ...}"
   [db {:keys [series-slug] :as api-params} incoming-jsonld-doc]
   (let [series-key (models-shared/dataset-series-key series-slug)
+        api-params (assoc api-params :op.upsert/keys {:series series-key})
         updated-db (upsert-doc! db series/upsert-series api-params incoming-jsonld-doc)]
     {:op (-> updated-db meta :op)
      :jsonld-doc (get updated-db series-key)}))
@@ -51,6 +63,9 @@
   "Returns a map {:op ... :jsonld-doc ...}"
   [db {:keys [series-slug release-slug] :as api-params} incoming-jsonld-doc]
   (let [release-key (models-shared/release-key series-slug release-slug)
+        api-params (assoc api-params :op.upsert/keys 
+                          {:series (models-shared/dataset-series-key series-slug)
+                           :release release-key})
         updated-db (upsert-doc! db release/upsert-release api-params incoming-jsonld-doc)]
     {:op (-> updated-db meta :op)
      :jsonld-doc (get updated-db release-key)}))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -29,12 +29,6 @@
   (let [key (models-shared/release-key series-slug release-slug)]
     (get @db key)))
 
-(defn exists? [db key]
-  (get @db key))
-
-(defn get-op [db key]
-  (if (exists? db key) :update :create))
-
 (defn- upsert-doc!
   "Applies upsert of the JSON-LD document and mutates the db-ref.
   Returns the value of the db-ref after the upsert."
@@ -49,19 +43,14 @@
   "Returns a map {:op ... :jdonld-doc ...}"
   [db {:keys [series-slug] :as api-params} incoming-jsonld-doc]
   (let [series-key (models-shared/dataset-series-key series-slug)
-        ;; TODO: could handle this more nicely after
-        ;; https://github.com/Swirrl/datahost-prototypes/issues/57
-        ;; by comparing modified/issued times..
-        op (get-op db series-key)
         updated-db (upsert-doc! db series/upsert-series api-params incoming-jsonld-doc)]
-    {:op op
+    {:op (-> updated-db meta :op)
      :jsonld-doc (get updated-db series-key)}))
 
 (defn upsert-release! 
   "Returns a map {:op ... :jsonld-doc ...}"
   [db {:keys [series-slug release-slug] :as api-params} incoming-jsonld-doc]
   (let [release-key (models-shared/release-key series-slug release-slug)
-        op (get-op db release-key)
         updated-db (upsert-doc! db release/upsert-release api-params incoming-jsonld-doc)]
-    {:op op
+    {:op (-> updated-db meta :op)
      :jsonld-doc (get updated-db release-key)}))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -42,12 +42,12 @@
   (let [key (models-shared/release-key series-slug release-slug)]
     (get @db key)))
 
-(def ^:private UpsertInernalParams
+(def ^:private UpsertInternalParams
   [:map
    [:op.upsert/keys
     [:or s.series/UpsertKeys s.release/UpsertKeys]]])
 
-(def ^:private upsert-internal-params-valid? (m/validator UpsertInernalParams))
+(def ^:private upsert-internal-params-valid? (m/validator UpsertInternalParams))
 
 (defn- upsert-doc!
   "Applies upsert of the JSON-LD document and mutates the db-ref.

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -1,6 +1,8 @@
 (ns tpximpact.datahost.ldapi.handlers
   (:require
-   [tpximpact.datahost.ldapi.db :as db]))
+   [malli.core :as m]
+   [tpximpact.datahost.ldapi.db :as db]
+   [tpximpact.datahost.ldapi.schemas.api :as s.api]))
 
 (def not-found-response
   {:status 404
@@ -15,15 +17,25 @@
      :body series}
     not-found-response))
 
+(defn op->response-code
+  "Takes [s.api/UpsertOp] and returns a HTTP status code (number)."
+  [op]
+  {:pre [(s.api/upsert-op-valid? op)]}
+  (case op
+    :create 201
+    :update 200
+    :noop   200))
+
 (defn put-dataset-series [db {:keys [body-params] :as request}]
-  (let [api-params (get-api-params request)
-        incoming-jsonld-doc body-params
-        {:keys [op jsonld-doc]} (db/upsert-series! db api-params incoming-jsonld-doc)
-        response-code (case op
-                        :create 201
-                        :update 200)]
-    {:status response-code
-     :body jsonld-doc}))
+  (try
+    (let [api-params (get-api-params request)
+          incoming-jsonld-doc body-params
+          {:keys [op jsonld-doc]} (db/upsert-series! db api-params incoming-jsonld-doc)]
+      {:status (op->response-code op)
+       :body jsonld-doc})
+
+    (catch Throwable e
+      (error-response e))))
 
 (defn get-release [db {{:keys [series-slug release-slug]} :path-params :as path-params}]
   (if-let [release (db/get-release db series-slug release-slug)]
@@ -33,15 +45,19 @@
 
 (defn put-release [db {{:keys [series-slug]} :path-params
                        body-params :body-params :as request}]
-  (if-let [_series (db/get-series db series-slug)]
-    (let [api-params (get-api-params request)
-          incoming-jsonld-doc body-params
-          {:keys [op jsonld-doc]} (db/upsert-release! db api-params incoming-jsonld-doc)
-          response-code (case op
-                          :create 201
-                          :update 200)]
-      {:status response-code
-       :body jsonld-doc})
+  (try
+    (if-let [_series (db/get-series db series-slug)]
+      (try
+        (let [api-params (get-api-params request)
+              incoming-jsonld-doc body-params
+              {:keys [op jsonld-doc]} (db/upsert-release! db api-params incoming-jsonld-doc)]
+          {:status (op->response-code op)
+           :body jsonld-doc})
+
+        (catch Throwable e
+          (error-response e)))
+      {:status 422
+       :body "Series does not exist"})
 
     {:status 422
      :body "Series does not exist"}))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -27,15 +27,11 @@
     :noop   200))
 
 (defn put-dataset-series [db {:keys [body-params] :as request}]
-  (try
-    (let [api-params (get-api-params request)
-          incoming-jsonld-doc body-params
-          {:keys [op jsonld-doc]} (db/upsert-series! db api-params incoming-jsonld-doc)]
-      {:status (op->response-code op)
-       :body jsonld-doc})
-
-    (catch Throwable e
-      (error-response e))))
+  (let [api-params (get-api-params request)
+        incoming-jsonld-doc body-params
+        {:keys [op jsonld-doc]} (db/upsert-series! db api-params incoming-jsonld-doc)]
+    {:status (op->response-code op)
+     :body jsonld-doc}))
 
 (defn get-release [db {{:keys [series-slug release-slug]} :path-params :as path-params}]
   (if-let [release (db/get-release db series-slug release-slug)]
@@ -45,19 +41,11 @@
 
 (defn put-release [db {{:keys [series-slug]} :path-params
                        body-params :body-params :as request}]
-  (try
-    (if-let [_series (db/get-series db series-slug)]
-      (try
-        (let [api-params (get-api-params request)
-              incoming-jsonld-doc body-params
-              {:keys [op jsonld-doc]} (db/upsert-release! db api-params incoming-jsonld-doc)]
-          {:status (op->response-code op)
-           :body jsonld-doc})
-
-        (catch Throwable e
-          (error-response e)))
-      {:status 422
-       :body "Series does not exist"})
-
+  (if-let [_series (db/get-series db series-slug)]
+    (let [api-params (get-api-params request)
+          incoming-jsonld-doc body-params
+          {:keys [op jsonld-doc]} (db/upsert-release! db api-params incoming-jsonld-doc)]
+      {:status (op->response-code op)
+       :body jsonld-doc})
     {:status 422
      :body "Series does not exist"}))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
@@ -51,9 +51,7 @@
   {:pre [(s.release/upsert-args-valid? [db api-params jsonld-doc])]
    :post [(models-shared/validate-issued-unchanged jsonld-doc %)
           (models-shared/validate-modified-changed jsonld-doc %)]}
-  (let [{:keys [series-slug release-slug]} api-params
-        release-key (models-shared/release-key series-slug release-slug)
-        series-key (models-shared/dataset-series-key series-slug)
+  (let [{{series-key :series release-key :release} :op.upsert/keys} api-params
         series (get db series-key)
         base-entity (get series "dh:baseEntity")
         old-release (get db release-key)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
@@ -40,13 +40,17 @@
                            "dcat:inSeries" (str "../" series-slug))]
       final-doc)))
 
-(defn- update-release [_old-release base-entity api-params jsonld-doc]
+(defn- update-release [old-release base-entity api-params jsonld-doc]
   (log/info "Updating release " (:series-slug api-params) "/" (:release-slug api-params))
-  (normalise-release base-entity api-params jsonld-doc))
+  (->> jsonld-doc
+       (normalise-release base-entity api-params)
+       (models-shared/issued+modified-dates api-params old-release)))
 
 (defn- create-release [base-entity api-params jsonld-doc]
   (log/info "Creating release " (:series-slug api-params) "/" (:release-slug api-params))
-  (normalise-release base-entity api-params jsonld-doc))
+  (->> jsonld-doc 
+       (normalise-release base-entity api-params)
+       (models-shared/issued+modified-dates api-params nil)))
 
 (defn upsert-release [db api-params jsonld-doc]
   (let [{:keys [series-slug release-slug]} api-params

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
@@ -3,6 +3,7 @@
    [clojure.tools.logging :as log]
    [malli.core :as m]
    [malli.error :as me]
+   [tpximpact.datahost.ldapi.models.schema :refer [registry]]
    [tpximpact.datahost.ldapi.models.shared :as models-shared]))
 
 (def ReleaseApiParams [:map
@@ -16,12 +17,12 @@
         _ (assert base-entity "Expected base entity to be set")]
     (when-not (m/validate ReleaseApiParams
                           api-params
-                          {:registry models-shared/registry})
+                          {:registry registry})
       (throw (ex-info "Invalid API parameters"
                       {:type :validation-error
                        :validation-error (-> (m/explain ReleaseApiParams
                                                         api-params
-                                                        {:registry models-shared/registry})
+                                                        {:registry registry})
                                              (me/humanize))})))
 
     (let [cleaned-doc (models-shared/merge-params-with-doc api-params jsonld-doc)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
@@ -6,18 +6,20 @@
    [tpximpact.datahost.ldapi.models.schema :refer [registry]]
    [tpximpact.datahost.ldapi.models.shared :as models-shared]))
 
-(def ReleaseApiParams [:map
-                       [:series-slug :datahost/slug-string]
-                       [:release-slug :datahost/slug-string]
-                       [:title {:optional true} :string]
-                       [:description {:optional true} :string]])
+(def ReleaseApiParams 
+  (m/schema [:map
+             [:series-slug :datahost/slug-string]
+             [:release-slug :datahost/slug-string]
+             [:title {:optional true} :string]
+             [:description {:optional true} :string]]
+            {:registry registry}))
+
+(def api-params-valid? (m/validator ReleaseApiParams))
 
 (defn normalise-release [base-entity api-params jsonld-doc]
   (let [{:keys [series-slug release-slug]} api-params
         _ (assert base-entity "Expected base entity to be set")]
-    (when-not (m/validate ReleaseApiParams
-                          api-params
-                          {:registry registry})
+    (when-not (api-params-valid? api-params)
       (throw (ex-info "Invalid API parameters"
                       {:type :validation-error
                        :validation-error (-> (m/explain ReleaseApiParams

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/schema.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/schema.clj
@@ -1,0 +1,37 @@
+(ns tpximpact.datahost.ldapi.models.schema
+  "Shared schema for data handled by datahost."
+  (:require
+   ;;[clojure.set :as set]
+   [malli.core :as m])
+  (:import
+   [java.net URI URISyntaxException]
+   [java.time ZonedDateTime]))
+
+(def ^:private custom-registry-keys
+  (let [slug-error-msg "should contain alpha numeric characters and hyphens only."]
+    {:datahost/slug-string [:and 
+                            :string 
+                            [:re {:error/message slug-error-msg}
+                             #"^[a-z,A-Z,\-,0-9]+$"]]
+     :datahost/url-string (m/-simple-schema
+                           {:type :url-string
+                            :pred (fn url-string-pred [x]
+                                    (and (string? x)
+                                         (try (URI. x)
+                                              true
+                                              (catch URISyntaxException _ex
+                                                false))))})
+     :datahost/timestamp (let [utc-tz (java.time.ZoneId/of "UTC")]
+                           (m/-simple-schema
+                            {:type :datahost/timestamp
+                             :pred (fn timestamp-pred [ts]
+                                     (and (instance? java.time.ZonedDateTime ts)
+                                          (= (.getZone ^ZonedDateTime ts) utc-tz)))}))}))
+
+(def registry
+  (merge
+   (m/class-schemas)
+   (m/comparator-schemas)
+   (m/base-schemas)
+   (m/type-schemas)
+   custom-registry-keys))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/schema.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/schema.clj
@@ -1,7 +1,6 @@
 (ns tpximpact.datahost.ldapi.models.schema
   "Shared schema for data handled by datahost."
   (:require
-   ;;[clojure.set :as set]
    [malli.core :as m])
   (:import
    [java.net URI URISyntaxException]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -5,9 +5,7 @@
    [malli.error :as me]
    [malli.util :as mu]
    [tpximpact.datahost.ldapi.models.schema :refer [registry]]
-   [tpximpact.datahost.ldapi.models.shared :as models-shared])
-  (:import
-   [java.time ZonedDateTime]))
+   [tpximpact.datahost.ldapi.models.shared :as models-shared]))
 
 (def SeriesPathParams
   (m/schema

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -87,10 +87,13 @@
     :post [(models-shared/validate-issued-unchanged jsonld-doc %)
            (models-shared/validate-modified-changed jsonld-doc %)]}
    (let [series-key (models-shared/dataset-series-key (:series-slug api-params))
-         old-series (get db series-key)]
-     (case (models-shared/infer-upsert-op api-query-params-keys api-params 
-                                          old-series jsonld-doc)
-       :noop db
-       :update (update db series-key update-series api-params
-                       (or jsonld-doc old-series))
-       :create (assoc db series-key (create-series api-params jsonld-doc))))))
+         old-series (get db series-key)
+         op (models-shared/infer-upsert-op api-query-params-keys api-params 
+                                           old-series jsonld-doc)]
+     (vary-meta
+      (case op
+        :noop db
+        :update (update db series-key update-series api-params
+                        (or jsonld-doc old-series))
+        :create (assoc db series-key (create-series api-params jsonld-doc)))
+      assoc :op op))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -26,6 +26,8 @@
    SeriesPathParams
    SeriesQueryParams))
 
+(def api-params-valid? (m/validator SeriesApiParams))
+
 (def ^:private date-formatter
   java.time.format.DateTimeFormatter/ISO_OFFSET_DATE_TIME)
 
@@ -75,6 +77,8 @@
   {:pre [(instance? java.time.ZonedDateTime timestamp)]}
   (-issued+modified-dates api-params old-doc new-doc))
 
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn normalise-series
   "Takes api params and an optional json-ld document of metadata, and
@@ -84,9 +88,7 @@
   ([api-params]
    (normalise-series api-params nil))
   ([{:keys [series-slug] :as api-params} jsonld-doc]
-   (when-not (m/validate SeriesApiParams
-                         api-params
-                         {:registry registry})
+   (when-not (api-params-valid? api-params)
      (throw (ex-info "Invalid API parameters"
                      {:type :validation-error
                       :validation-error (-> (m/explain SeriesApiParams

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -86,7 +86,7 @@
    {:pre [(s.series/upsert-args-valid? [db api-params jsonld-doc])]
     :post [(models-shared/validate-issued-unchanged jsonld-doc %)
            (models-shared/validate-modified-changed jsonld-doc %)]}
-   (let [series-key (models-shared/dataset-series-key (:series-slug api-params))
+   (let [{{series-key :series} :op.upsert/keys} api-params
          old-series (get db series-key)
          op (models-shared/infer-upsert-op api-query-params-keys api-params 
                                            old-series jsonld-doc)]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/series.clj
@@ -4,6 +4,7 @@
    [malli.core :as m]
    [malli.error :as me]
    [malli.util :as mu]
+   [tpximpact.datahost.ldapi.models.schema :refer [registry]]
    [tpximpact.datahost.ldapi.models.shared :as models-shared])
   (:import
    [java.time ZonedDateTime]))
@@ -12,7 +13,7 @@
   (m/schema
    [:map
     [:series-slug :datahost/slug-string]]
-   {:registry models-shared/registry}))
+   {:registry registry}))
 
 (def SeriesQueryParams
   (m/schema
@@ -85,12 +86,12 @@
   ([{:keys [series-slug] :as api-params} jsonld-doc]
    (when-not (m/validate SeriesApiParams
                          api-params
-                         {:registry models-shared/registry})
+                         {:registry registry})
      (throw (ex-info "Invalid API parameters"
                      {:type :validation-error
                       :validation-error (-> (m/explain SeriesApiParams
                                                        api-params
-                                                       {:registry models-shared/registry})
+                                                       {:registry registry})
                                             (me/humanize))})))
    (let [cleaned-doc (models-shared/merge-params-with-doc api-params jsonld-doc)
          validated-doc (-> (models-shared/validate-id series-slug cleaned-doc)
@@ -126,7 +127,7 @@
   (let [db-schema [:map {}]
         api-params-schema (m/schema [:map
                                      [:op/timestamp :datahost/timestamp]]
-                                    {:registry models-shared/registry})
+                                    {:registry registry})
         input-jsonld-doc-schema [:maybe [:map {}]]]
     [:catn
      [:db db-schema]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.set :as set]
    [malli.core :as m]
-   [tpximpact.datahost.ldapi.util :as util])
+   [tpximpact.datahost.ldapi.util :as util]
+   [tpximpact.datahost.ldapi.schemas.api :as s.api])
   (:import
    [java.net URI]
    [java.time ZonedDateTime]))
@@ -94,15 +95,15 @@
         (let [renamed (rename-query-params-to-common-keys query-changes)]
           (not= renamed (select-keys old-doc (keys renamed)))))))
 
-(def infer-upsert-op-return-val-valid? (m/validator [:enum :noop :update :create]))
-
 (defn infer-upsert-op
-  "Returns an `[:enum :noop :update :create].
+  "Returns an `[:enum :noop :update :create]`.
 
   The returned value indicates what the semantics of upset operation
-  should be."
+  should be.
+
+  See: [tpximpact.datahost.ldapi.schemas.api/UpsertOp]."
   [params-keys api-params old-doc new-doc]
-  {:post [(infer-upsert-op-return-val-valid? %)]}
+  {:post [(s.api/upsert-op-valid? %)]}
   (cond
     (and old-doc
          (nil? new-doc)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -5,18 +5,23 @@
    [tpximpact.datahost.ldapi.util :as util]
    [tpximpact.datahost.ldapi.errors :as api-errors])
   (:import
-   [java.net URI]))
+   [java.net URI]
+   [java.time ZonedDateTime]))
 
 (def ld-root
   "For the prototype this item will come from config or be derived from
   it. It should have a trailing slash."
   (URI. "https://example.org/data/"))
 
+;;; ---- KEY CTORS
+
 (defn dataset-series-key [series-slug]
   (str (.getPath ld-root) series-slug))
 
 (defn release-key [series-slug release-slug]
   (str (dataset-series-key series-slug) "/" release-slug))
+
+;;; ---- CONTEXT OPS
 
 (defn normalise-context [ednld base]
   (let [normalised-context ["https://publishmydata.com/def/datahost/context"
@@ -44,6 +49,8 @@
                :expected-value base
                :actual-value base-in-doc})))
     (update ednld "@context" normalise-context base)))
+
+;;; ---- DOCUMENT OPS
 
 (def query-params->common-keys
   {:title "dcterms:title"
@@ -78,3 +85,39 @@
                       {:type ::api-errors/validation-failure
                        :supplied-id id-in-doc
                        :expected-id slug})))))
+
+
+;;; ---- ISSUED+MODIFIED DATES
+
+(def ^:private date-formatter
+  java.time.format.DateTimeFormatter/ISO_OFFSET_DATE_TIME)
+
+(defmulti -issued+modified-dates
+  "Adjusts the 'dcterms:issued' and 'dcterms:modified' of the document.
+  Ensures that the new document does not modify the issue date.
+
+  Behaviour differs when issuing a new seris and when modifying an
+  existing one."
+  (fn [_api-params old-doc _new-doc]
+    (case (some? old-doc)
+      false :issue
+      true  :modify)))
+
+(defmethod -issued+modified-dates :issue
+  [{^ZonedDateTime timestamp :op/timestamp} _ new-doc]
+  (let [ts-string (.format timestamp date-formatter)]
+    (assoc new-doc
+           "dcterms:issued" ts-string
+           "dcterms:modified" ts-string)))
+
+(defmethod -issued+modified-dates :modify
+  [{^ZonedDateTime timestamp :op/timestamp} old-doc new-doc]
+  (assoc new-doc
+         "dcterms:issued" (get old-doc "dcterms:issued")
+         "dcterms:modified" (.format timestamp date-formatter)))
+
+(defn issued+modified-dates
+  [{timestamp :op/timestamp :as api-params} old-doc new-doc]
+  {:pre [(instance? java.time.ZonedDateTime timestamp)]}
+  (-issued+modified-dates api-params old-doc new-doc))
+

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -89,6 +89,11 @@
 
 
 (defn query-param-changes?
+  "Returns true if the values that can be passed in query params changed
+  compared to corresponding values in the old document.
+
+  Only keys in params-keys are checked, caller should ideally obtain
+  them from a schema."
   [params-keys api-params old-doc]
   (let [query-changes (select-keys api-params params-keys)]
     (or (empty? query-changes)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -2,7 +2,8 @@
   (:require
    [tpximpact.datahost.ldapi.handlers :as handlers]
    [tpximpact.datahost.ldapi.routes.copy :as copy]
-   [tpximpact.datahost.ldapi.routes.shared :as routes-shared]))
+   [tpximpact.datahost.ldapi.routes.shared :as routes-shared]
+   [tpximpact.datahost.ldapi.schemas.release :as schema]))
 
 (defn get-release-route-config [db]
   {:summary copy/get-release-summary
@@ -18,13 +19,7 @@
    :parameters {:body routes-shared/JsonLdSchema
                 :path {:series-slug string?
                        :release-slug string?}
-                :query [:map
-                        [:title {:title "Title"
-                                 :description "Title of release"
-                                 :optional true} string?]
-                        [:description {:title "Description"
-                                       :description "Description of release"
-                                       :optional true} string?]]}
+                :query schema/ApiQueryParams}
    :responses {200 {:description copy/put-release-200-desc
                     :body map?}
                201 {:description copy/put-release-201-desc

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
@@ -2,7 +2,8 @@
   (:require
    [tpximpact.datahost.ldapi.handlers :as handlers]
    [tpximpact.datahost.ldapi.routes.copy :as copy]
-   [tpximpact.datahost.ldapi.routes.shared :as routes-shared]))
+   [tpximpact.datahost.ldapi.routes.shared :as routes-shared]
+   [tpximpact.datahost.ldapi.schemas.series :as schema]))
 
 (defn get-series-route-config [db]
   {:summary copy/get-series-summary
@@ -17,13 +18,7 @@
    :handler (partial handlers/put-dataset-series db)
    :parameters {:body routes-shared/JsonLdSchema
                 :path {:series-slug string?}
-                :query [:map
-                        [:title {:title "Title"
-                                 :description "Title of dataset series"
-                                 :optional true} string?]
-                        [:description {:title "Description"
-                                       :description "Description of dataset series"
-                                       :optional true} string?]]}
+                :query schema/ApiQueryParams}
    :responses {200 {:description "Series already existed and was successfully updated"
                     :body routes-shared/JsonLdSchema}
                201 {:description "Series did not exist previously and was successfully created"

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/api.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/api.clj
@@ -1,0 +1,13 @@
+(ns tpximpact.datahost.ldapi.schemas.api
+  "API specific schemas"
+  (:require
+   [malli.core :as m]))
+
+(def UpsertOp 
+  "Enum for semantics of the upsert operation.
+
+  Motivation: we may wanto to convey to the client what actaully
+  happened (in a form of meaningful HTTP status code, for example)."
+  [:enum :noop :create :update])
+
+(def upsert-op-valid? (m/validator UpsertOp))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
@@ -1,4 +1,4 @@
-(ns tpximpact.datahost.ldapi.models.schema
+(ns tpximpact.datahost.ldapi.schemas.common
   "Shared schema for data handled by datahost."
   (:require
    [malli.core :as m])

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/release.clj
@@ -30,10 +30,16 @@
 
 ;;; ---- MODEL SCHEMA
 
+(def UpsertKeys
+  [:map
+   [:series :string]
+   [:release :string]])
+
 (def UpsertArgs
   (let [db-schema [:map {}]
         api-params-schema (m/schema [:map
-                                     [:op/timestamp :datahost/timestamp]]
+                                     [:op/timestamp :datahost/timestamp]
+                                     [:op.upsert/keys UpsertKeys]]
                                     {:registry registry})
         input-jsonld-doc-schema [:maybe [:map {}]]]
     [:catn

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/release.clj
@@ -1,0 +1,44 @@
+(ns tpximpact.datahost.ldapi.schemas.release
+  (:require
+   [malli.core :as m]
+   [malli.util :as mu]
+   [tpximpact.datahost.ldapi.schemas.common :refer [registry]]))
+
+;;; ---- API SCHEMA
+
+(def ApiPathParams
+  (m/schema [:map 
+             [:series-slug :datahost/slug-string]
+             [:release-slug :datahost/slug-string]]
+            {:registry registry}))
+
+(def ApiQueryParams
+  [:map
+   [:title {:title "Title"
+            :description "Title of release"
+            :optional true} string?]
+   [:description {:title "Description"
+                  :description "Description of release"
+                  :optional true} string?]])
+
+(def ApiParams
+  (mu/merge
+   ApiPathParams
+   ApiQueryParams))
+
+(def api-params-valid? (m/validator ApiParams))
+
+;;; ---- MODEL SCHEMA
+
+(def UpsertArgs
+  (let [db-schema [:map {}]
+        api-params-schema (m/schema [:map
+                                     [:op/timestamp :datahost/timestamp]]
+                                    {:registry registry})
+        input-jsonld-doc-schema [:maybe [:map {}]]]
+    [:catn
+     [:db db-schema]
+     [:api-params api-params-schema]
+     [:jsonld-doc input-jsonld-doc-schema]]))
+
+(def upsert-args-valid? (m/validator UpsertArgs))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/series.clj
@@ -1,0 +1,46 @@
+(ns tpximpact.datahost.ldapi.schemas.series
+  (:require
+   [malli.core :as m]
+   [malli.util :as mu]
+   [tpximpact.datahost.ldapi.schemas.common :refer [registry]]))
+
+;;; ---- API SCHEMA
+
+(def ApiPathParams
+  (m/schema
+   [:map
+    [:series-slug :datahost/slug-string]]
+   {:registry registry}))
+
+(def ApiQueryParams
+  "Query parameters to the series endpoint"
+  [:map
+   [:title {:title "Title"
+            :description "Title of dataset series"
+            :optional true} string?]
+   [:description {:title "Description"
+                  :description "Description of dataset series"
+                  :optional true} string?]])
+
+(def ApiParams
+  "API params of the series endpoint."
+  (mu/merge
+   ApiPathParams
+   ApiQueryParams))
+
+;;; ---- MODEL SCHEMA
+
+(def UpsertArgs
+  (let [db-schema [:map {}]
+        api-params-schema (mu/merge
+                           ApiParams
+                           (m/schema [:map  
+                                      [:op/timestamp :datahost/timestamp]]
+                                     {:registry registry}))
+        input-jsonld-doc-schema [:maybe [:map {}]]]
+    [:catn
+     [:db db-schema]
+     [:api-params api-params-schema]
+     [:jsonld-doc input-jsonld-doc-schema]]))
+
+(def upsert-args-valid? (m/validator UpsertArgs))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/series.clj
@@ -30,12 +30,17 @@
 
 ;;; ---- MODEL SCHEMA
 
+(def UpsertKeys
+  [:map
+   [:series :string]])
+
 (def UpsertArgs
   (let [db-schema [:map {}]
         api-params-schema (mu/merge
                            ApiParams
                            (m/schema [:map  
-                                      [:op/timestamp :datahost/timestamp]]
+                                      [:op/timestamp :datahost/timestamp]
+                                      [:op.upsert/keys UpsertKeys]]
                                      {:registry registry}))
         input-jsonld-doc-schema [:maybe [:map {}]]]
     [:catn

--- a/datahost-ld-openapi/src/tpximpact/datahost/sys.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/sys.clj
@@ -1,13 +1,28 @@
 (ns tpximpact.datahost.sys
   (:require [clojure.java.io :as io]
             [meta-merge.core :as mm]
-            [integrant.core :as ig]))
+            [integrant.core :as ig])
+  (:import (java.net URI)))
+
+(defn get-env [s]
+  (System/getenv (str s)))
+
+(def readers
+  {'env get-env
+   ;; naive `or`; only takes 2 args
+   'or (fn [pair]
+         (apply #(or %1 %2) pair))
+   'uri (fn [v] (URI. v))
+   'int (fn [v]
+          (Integer/parseInt v))
+   'resource (fn [v] (io/resource v))
+   'regex (fn [r] (re-pattern r))})
 
 (defn load-system-config [config]
   (if config
-    (-> config
-        slurp
-        ig/read-string)
+    (->> config
+         slurp
+         (ig/read-string {:readers readers}))
     {}))
 
 (defn load-configs [configs]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -7,21 +7,22 @@
    [tpximpact.datahost.ldapi.models.release :as sut])
   (:import (clojure.lang ExceptionInfo)))
 
-(defn- put-series []
+(defn- put-series [put-fn]
   (let [jsonld {"@context"
                 ["https://publishmydata.com/def/datahost/context"
                  {"@base" "https://example.org/data/"}]
                 "dcterms:title" "A title"}]
-    (http/put
-     "http://localhost:3400/data/new-series"
-     {:content-type :json
-      :body (json/write-str jsonld)})))
+    (put-fn "/data/new-series"
+            {:content-type :json
+             :body (json/write-str jsonld)})))
 
 (deftest round-tripping-release-test
-  (th/with-system-and-clean-up sys
+  (th/with-system-and-clean-up {{:keys [GET PUT]} :tpximpact.datahost.ldapi.test/http-client
+                                :as sys}
     (testing "Fetching a release for a series that does not exist returns 'not found'"
       (try
-        (http/get "http://localhost:3400/data/does-not-exist/release/release-1")
+        
+        (GET "/data/does-not-exist/release/release-1")
 
         (catch Throwable ex
           (let [{:keys [status body]} (ex-data ex)]
@@ -30,7 +31,7 @@
 
     (testing "Fetching a release that does not exist returns 'not found'"
       (try
-        (http/get "http://localhost:3400/data/new-series/release/release-1")
+        (GET "/data/new-series/release/release-1")
 
         (catch Throwable ex
           (let [{:keys [status body]} (ex-data ex)]
@@ -39,20 +40,20 @@
 
     (testing "Creating a release for a series that is not found fails gracefully"
       (let [jsonld {"@context"
-                    ["https://publishmydata.com/def/datahost/context"
+                    ["https://publishmydata.com/debf/datahost/context"
                      {"@base" "http://example.org/data/"}]
                     "dcterms:title" "Example Release"}]
         (try
-          (http/put "http://localhost:3400/data/new-series/release/release-1"
-                    {:content-type :json
-                     :body (json/write-str jsonld)})
+          (PUT "/data/new-series/release/release-1"
+               {:content-type :json
+                :body (json/write-str jsonld)})
 
           (catch Throwable ex
             (let [{:keys [status body]} (ex-data ex)]
               (is (= 422 status))
               (is (= "Series does not exist" body)))))))
 
-    (put-series)
+    (put-series PUT)
 
     (let [request-ednld {"@context"
                          ["https://publishmydata.com/def/datahost/context"
@@ -67,23 +68,35 @@
                             "dcat:inSeries" "../new-series"}]
 
       (testing "Creating a release for a series that does exist works"
-        (let [response (http/put "http://localhost:3400/data/new-series/release/release-1"
-                                 {:content-type :json
-                                  :body (json/write-str request-ednld)})]
+        (let [response (PUT "/data/new-series/release/release-1"
+                            {:content-type :json
+                             :body (json/write-str request-ednld)})
+              body (json/read-str (:body response))]
           (is (= 201 (:status response)))
-          (is (= normalised-ednld (json/read-str (:body response))))))
+          (is (= normalised-ednld (dissoc body "dcterms:issued" "dcterms:modified")))
+          (is (contains? body "dcterms:issued"))
+          (is (contains? body "dcterms:modified"))))
 
       (testing "Fetching a release that does exist works"
-        (let [response (http/get "http://localhost:3400/data/new-series/release/release-1 ")]
+        (let [response (GET "/data/new-series/release/release-1 ")
+              body (json/read-str (:body response))]
           (is (= 200 (:status response)))
-          (is (= normalised-ednld (json/read-str (:body response))))))
+          (is (= normalised-ednld (dissoc body "dcterms:issued" "dcterms:modified")))))
 
       (testing "A release can be updated, query params take precedence"
-        (let [response (http/put "http://localhost:3400/data/new-series/release/release-1?title=A%20new%20title"
-                                 {:content-type :json
-                                  :body (json/write-str request-ednld)})]
+        (let [{body-str-before :body} (GET "/data/new-series/release/release-1 ")
+              {:keys [body] :as response} (PUT (str "/data/new-series"
+                                                    "/release/release-1?title=A%20new%20title")
+                                               {:content-type :json
+                                                :body (json/write-str request-ednld)})
+              body-before (json/read-str body-str-before)
+              body (json/read-str body)]
           (is (= 200 (:status response)))
-          (is (= "A new title" (-> response :body json/read-str (get "dcterms:title")))))))))
+          (is (= "A new title" (get body "dcterms:title")))
+          (is (= (get body-before "dcterms:issued")
+                 (get body "dcterms:issued")))
+          (is (not= (get body "dcterms:modified")
+                    (get body-before "dcterms:modified"))))))))
 
 (deftest normalise-release-test
   (testing "invalid cases"

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -1,6 +1,5 @@
 (ns tpximpact.datahost.ldapi.models.series-test
   (:require
-   [clj-http.client :as http]
    [clojure.data.json :as json]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
@@ -34,7 +33,6 @@
                           {"@base" "https://example.org/data/"}],
                          "dcterms:title" "A title"
                          "dcterms:identifier" "foobar"}
-          timestamp-str (format-date-time (java.time.ZonedDateTime/now (java.time.ZoneId/of "UTC")))
           normalised-ednld {"@context"
                             ["https://publishmydata.com/def/datahost/context"
                              {"@base" "https://example.org/data/"}],
@@ -51,11 +49,6 @@
               resp-body (json/read-str (:body response))]
           (is (= 201 (:status response)))
           (is (= normalised-ednld (dissoc resp-body "dcterms:issued" "dcterms:modified")))
-
-          (is (= (th/truncate-string (get resp-body "dcterms:issued") 15)
-                 (th/truncate-string (get resp-body "dcterms:modified") 15)
-                 (th/truncate-string timestamp-str 15)))
-
           (is (= (get resp-body "dcterms:issued")
                  (get resp-body "dcterms:modified")))))
 
@@ -81,7 +74,17 @@
                     (get resp-body "dcterms:modified")))
           (is (= "foobar" (get resp-body "dcterms:identifier"))
               "The identifier should be left untouched.")
-          (is (= (get resp-body "dcterms:title") "A new title")))))))
+          (is (= (get resp-body "dcterms:title") "A new title"))
+
+          (testing "No update when query params same as in existing doc"
+            (let [{body' :body :as response} (PUT "/data/new-series?title=A%20new%20title"
+                                                  {:content-type :json :body nil})
+                  body' (json/read-str body')]
+              (is (= 200 (:status response)))
+              (is (= "A new title" (get body' "dcterms:title")))
+              (is (= (select-keys resp-body ["dcterms:issued" "dcterms:modified"])
+                     (select-keys body' ["dcterms:issued" "dcterms:modified"]))
+                  "The document shouldn't be modified"))))))))
 
 (deftest normalise-context-test
   (let [expected-context ["https://publishmydata.com/def/datahost/context"
@@ -106,11 +109,6 @@
 (defn canonicalisation-idempotent? [api-params jsonld]
   (let [canonicalised-form (sut/normalise-series api-params jsonld)]
     (= canonicalised-form (sut/normalise-series api-params canonicalised-form))))
-
-(defn subject= [expected-s]
-  (fn [s]
-    (comp #(= (URI. expected-s) s)
-          :s)))
 
 (deftest normalise-series-test
   (testing "Invalid cases"

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/test_util/http_client.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/test_util/http_client.clj
@@ -1,0 +1,25 @@
+(ns tpximpact.datahost.ldapi.test-util.http-client
+  "Conveniencve http-client relying on `clj-http.client` library."
+  (:require [clj-http.client :as http]))
+
+(defn- http-request
+  [method-fn base-url path & args]
+  (assert (not (.endsWith base-url "/")))
+  (apply method-fn (str base-url path) args))
+
+(defn make-client
+  "Returns a map `{:keys [GET PUT POST DELETE HEAD]}` where each value
+  is a function accepting the path string and remaining arguments.
+
+  Example
+  ```clj
+  (let [{put :PUT} (make-client {:port 8080})]
+    (put \"/data/series/my-series\"))
+  ```"
+  [{:keys [port]}]
+  (let [base-url (format "http://localhost:%s" port)]
+    {:GET (partial http-request http/get base-url)
+     :PUT (partial http-request http/put base-url)
+     :POST (partial http-request http/post base-url)
+     :DELETE (partial http-request http/delete base-url)
+     :HEAD (partial http-request http/head base-url)}))

--- a/datahost-ld-openapi/test/tpximpact/ldapi_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/ldapi_test.clj
@@ -5,8 +5,8 @@
     [tpximpact.test-helpers :as th]))
 
 (deftest service-sanity-test
-  (th/with-system sys
+  (th/with-system {{:keys [GET]} :tpximpact.datahost.ldapi.test/http-client :as _sys}
     (testing "LD API service starts and handles query requests to the datastore"
-      (let [response (http/get "http://localhost:3400/triplestore-query")]
+      (let [response (GET "/triplestore-query")]
         (is (= (:status response) 200))
         (is (= (:body response) "Datasets"))))))

--- a/datahost-ld-openapi/test/tpximpact/test_helpers.clj
+++ b/datahost-ld-openapi/test/tpximpact/test_helpers.clj
@@ -2,7 +2,11 @@
   (:require [clojure.test :refer :all]
             [integrant.core :as ig]
             [duratom.core :as da]
-            [tpximpact.datahost.sys :as sys]))
+            [tpximpact.datahost.sys :as sys]
+            [tpximpact.datahost.ldapi.test-util.http-client :as http-client]))
+
+(defmethod ig/init-key :tpximpact.datahost.ldapi.test/http-client [_ {:keys [port] :as config}]
+  (http-client/make-client config))
 
 (defn clean-up-database! [system]
   (when-let [db (get system :tpximpact.datahost.ldapi.db/db)]


### PR DESCRIPTION
Recent PR added `dc:issued` and `dc:modified` fields to series. This PR extends that change to releases.

Most important changes:

- extracted the common logic for timestamps
- new namespace prefix: *.datahost.ldapi.schemas - for common schemas
- logic for inferring upsert  (located in `t.d.ldapi.models.shared`)
- move [series|release]-key ctors out of update fns - they rely on hardcoded URI
- remove potential race condition on when returning http status (the existing code did a 'check then do')
  -  we now rely on a status stored in the metadata of the atom value
- data readers to pull environment variables into integrant configuration (by @scottlowe)
- integrant config for a test HTTP client - no more using hardcoded port
