### PR TITLE
LD API: add env config reader

### DIFF
--- a/datahost-ld-openapi/env/test/resources/test-system.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system.edn
@@ -1,6 +1,6 @@
-{:tpximpact.datahost.ldapi.jetty/http-port 3400
- 
- :tpximpact.datahost.ldapi.test/http-client 
+{:tpximpact.datahost.ldapi.jetty/http-port #int #or [#env "LD_API_HTTP_PORT" "3400"]
+
+ :tpximpact.datahost.ldapi.test/http-client
  {:port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port}
 
  :tpximpact.datahost.ldapi.db/db {:opts {:file-path ".datahost-test-db.edn"}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/sys.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/sys.clj
@@ -1,13 +1,28 @@
 (ns tpximpact.datahost.sys
   (:require [clojure.java.io :as io]
             [meta-merge.core :as mm]
-            [integrant.core :as ig]))
+            [integrant.core :as ig])
+  (:import (java.net URI)))
+
+(defn get-env [s]
+  (System/getenv (str s)))
+
+(def readers
+  {'env get-env
+   ;; naive `or`; only takes 2 args
+   'or (fn [pair]
+         (apply #(or %1 %2) pair))
+   'uri (fn [v] (URI. v))
+   'int (fn [v]
+          (Integer/parseInt v))
+   'resource (fn [v] (io/resource v))
+   'regex (fn [r] (re-pattern r))})
 
 (defn load-system-config [config]
   (if config
-    (-> config
-        slurp
-        ig/read-string)
+    (->> config
+         slurp
+         (ig/read-string {:readers readers}))
     {}))
 
 (defn load-configs [configs]


### PR DESCRIPTION
In addition to `#env`, I also through in a few other readers that we tend to need in other projects e.g. `#uri`, `#int`, a naive `#or`, `#resource`, `#regex`.