### PR TITLE
Include container image digests in server names

### DIFF
--- a/deploy/terraform/graphql/modules/env/main.tf
+++ b/deploy/terraform/graphql/modules/env/main.tf
@@ -5,11 +5,6 @@ terraform {
       version = "4.64.0"
     }
 
-    null = {
-      source = "hashicorp/null"
-      version = "3.1.1"
-    }
-
     aws = {
       source = "hashicorp/aws"
       version = "5.0.1"

--- a/deploy/terraform/graphql/modules/server/main.tf
+++ b/deploy/terraform/graphql/modules/server/main.tf
@@ -14,12 +14,6 @@ module "gce_container_spec" {
   restart_policy = "Always"
 }
 
-resource "null_resource" "image_digest" {
-  triggers = {
-    digest = var.digest
-  }
-}
-
 resource "google_service_account" "graphql_service_account" {
   account_id   = local.service_account_id
   display_name = "Service account to run the graphql server"
@@ -33,7 +27,7 @@ resource "google_project_iam_member" "image_creator_service_account_permissions"
 }
 
 resource "google_compute_instance" "datahost_instance" {
-  name = var.name
+  name = "${var.name}-${substr(var.digest, 0, 8)}"
   machine_type = "e2-small"
   zone = local.gcloud_zone
 
@@ -60,10 +54,6 @@ resource "google_compute_instance" "datahost_instance" {
 
   metadata = {
     gce-container-declaration = module.gce_container_spec.metadata_value
-  }
-
-  lifecycle {
-    replace_triggered_by = [null_resource.image_digest]
   }
 
   service_account {

--- a/deploy/terraform/ldapi/modules/env/main.tf
+++ b/deploy/terraform/ldapi/modules/env/main.tf
@@ -5,11 +5,6 @@ terraform {
       version = "4.64.0"
     }
 
-    null = {
-      source = "hashicorp/null"
-      version = "3.1.1"
-    }
-
     aws = {
       source = "hashicorp/aws"
       version = "5.0.1"

--- a/deploy/terraform/ldapi/modules/server/main.tf
+++ b/deploy/terraform/ldapi/modules/server/main.tf
@@ -32,12 +32,6 @@ module "gce_container_spec" {
   restart_policy = "Always"
 }
 
-resource "null_resource" "image_digest" {
-  triggers = {
-    digest = var.digest
-  }
-}
-
 resource "google_service_account" "ldapi_service_account" {
   account_id   = local.service_account_id
   display_name = "Service account to run the ldapi server"
@@ -58,7 +52,7 @@ resource "google_compute_disk" "datahost_ldapi_data" {
 }
 
 resource "google_compute_instance" "datahost_ldapi_instance" {
-  name = var.name
+  name = "${var.name}-${substr(var.digest, 0, 8)}"
   machine_type = "e2-small"
   zone = var.zone
 
@@ -91,10 +85,6 @@ resource "google_compute_instance" "datahost_ldapi_instance" {
 
   metadata = {
     gce-container-declaration = module.gce_container_spec.metadata_value
-  }
-
-  lifecycle {
-    replace_triggered_by = [null_resource.image_digest]
   }
 
   service_account {


### PR DESCRIPTION
Include a prefix of the graphql and ldapi container image digests in the corresponding server names. This ensures they will be re-created and added to the load balancer. Previously, the server names remained the same and had a lifecycle dependecy on a null resource containing the image digest. Terraform fails to detect any changes in the load balancer configuration in this case, so the new server is not re-added to the load balancer on construction.