### PR TITLE
Add Release schemas

### DIFF
--- a/datahost-ld-openapi/deps.edn
+++ b/datahost-ld-openapi/deps.edn
@@ -15,8 +15,8 @@
         metosin/ring-http-response {:mvn/version "0.9.3"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
         duratom/duratom {:mvn/version "0.5.8"}
-        camel-snake-kebab {:mvn/version "0.4.3"}
-				scicloj/tablecloth {:mvn/version "7.000-beta-50"}}
+        camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
+        scicloj/tablecloth {:mvn/version "7.000-beta-50"}}
 
  :aliases
  {:run {:main-opts ["-m" "tpximpact.datahost.ldapi"]}
@@ -49,12 +49,11 @@
                               :source-paths ["src"]}]
                      :plugins [:kaocha.plugin/profiling :kaocha.plugin/junit-xml]
                      :kaocha.plugin.junit-xml/target-file "test-results/kaocha/results.xml"
-                     :reporter kaocha.report/documentation
-                     }}
+                     :reporter kaocha.report/documentation}}
   :test-watch {:extra-deps {lambdaisland/kaocha {:mvn/version "1.85.1342"}}
                :exec-fn kaocha.runner/exec-fn
                :exec-args {:watch? true
-	                       :skip-meta :slow
+	                       :skip-meta :pending
 	                       :fail-fast? true}}
 
   :dev {:extra-paths ["env/dev/src" "env/test/resources" "test"]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release_schema.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release_schema.clj
@@ -24,7 +24,7 @@
       (models.shared/validate-context $ base-entity)
       (assoc $ "@type" "dh:TableSchema"
              ;;"@type" "dh:DimensionColumn"
-             "datahost:appliesToRelease" (format "/data/%s/release/%s" 
+             "datahost:appliesToRelease" (format "/data/%s/releases/%s"
                                                  (URLEncoder/encode series-slug "UTF-8") 
                                                  (URLEncoder/encode release-slug "UTF-8"))
              "appropriate-csvw:modeling-of-dialect" "UTF-8,RFC4180")
@@ -68,6 +68,6 @@
            (models.release/upsert-release api-params 
                                           (assoc (get db release-key)
                                                  "datahost:hasSchema"
-                                                 (format "/data/%s/release/%s/schemas/%s"
+                                                 (format "/data/%s/releases/%s/schemas/%s"
                                                          series-slug release-slug schema-slug)))))
      assoc :op op)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release_schema.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release_schema.clj
@@ -1,0 +1,73 @@
+(ns tpximpact.datahost.ldapi.models.release-schema
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]
+   [tpximpact.datahost.ldapi.schemas.common :refer [registry]]
+   [tpximpact.datahost.ldapi.schemas.release-schema :as s.release-schema]
+   [tpximpact.datahost.ldapi.models.release :as models.release]
+   [tpximpact.datahost.ldapi.models.shared :as models.shared])
+  (:import [java.net URLEncoder]))
+
+(defn normalise-schema
+  [base-entity api-params jsonld-doc]
+  (when-not (s.release-schema/api-params-valid? api-params)
+    (throw (ex-info "Invalid API parameters"
+                    {:type :validation-error
+                     :validation-error (-> (m/explain s.release-schema/ApiParams
+                                                      api-params
+                                                      {:registry registry})
+                                           (me/humanize))})))
+  (let [{:keys [series-slug release-slug]} api-params]
+    (as-> jsonld-doc $
+      (models.shared/merge-params-with-doc api-params $)
+      (models.shared/validate-id release-slug $)
+      (models.shared/validate-context $ base-entity)
+      (assoc $ "@type" "dh:TableSchema"
+             ;;"@type" "dh:DimensionColumn"
+             "datahost:appliesToRelease" (format "/data/%s/release/%s" 
+                                                 (URLEncoder/encode series-slug "UTF-8") 
+                                                 (URLEncoder/encode release-slug "UTF-8"))
+             "appropriate-csvw:modeling-of-dialect" "UTF-8,RFC4180")
+      (update $ "dh:columns" (fn [cols]
+                               (mapv (fn [col]
+                                       (if (= "dh:DimensionColumn" (get col "@type"))
+                                         col
+                                         (assoc col "@type" "dh:DimensionColumn")))
+                                     cols))))))
+
+(def InsertApiParams
+  [:map
+   [:op.upsert/keys [:map
+                     [:series :any]
+                     [:release :any]
+                     [:release-schema :any]]]])
+
+(def ^:private insert-api-params-valid? (m/validator InsertApiParams))
+
+(defn insert-schema
+  "Potentially adds a schema and updates the release with a reference to
+  the schema.
+
+  Returned meta data will contain `:op` key."
+  [db api-params incoming-jsonld-doc]
+  {:pre [(insert-api-params-valid? api-params)]}
+  (let [{:keys [series-slug release-slug schema-slug]
+         {series-key :series 
+          release-key :release
+          schema-key :release-schema} :op.upsert/keys} api-params
+        base (-> db (get series-key) (get "dh:baseEntity"))
+        schema (get db schema-key)
+        op (models.shared/infer-upsert-op [] api-params schema incoming-jsonld-doc)]
+    (vary-meta
+     (if (some? schema)
+       db
+       (-> db
+           (assoc schema-key (normalise-schema base 
+                                               api-params 
+                                               incoming-jsonld-doc))
+           (models.release/upsert-release api-params 
+                                          (assoc (get db release-key)
+                                                 "datahost:hasSchema"
+                                                 (format "/data/%s/release/%s/schemas/%s"
+                                                         series-slug release-slug schema-slug)))))
+     assoc :op op)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -21,6 +21,12 @@
 (defn release-key [series-slug release-slug]
   (str (dataset-series-key series-slug) "/releases/" release-slug))
 
+(defn release-schema-key
+  ([{:keys [series-slug release-slug schema-slug]}]
+   (release-schema-key series-slug release-slug schema-slug))
+  ([series-slug release-slug schema-slug]
+   (str (release-key series-slug release-slug) "/schemas/" schema-slug)))
+
 (defn revision-key [series-slug release-slug revision-id]
   (str (release-key series-slug release-slug) "/revisions/" revision-id))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -113,6 +113,11 @@
       {:get (release-routes/get-release-route-config db)
        :put (release-routes/put-release-route-config db)}]
 
+     ["/:series-slug/releases/:release-slug/schemas"
+      {:get (release-routes/get-release-ld-schema-config db)}]
+     ["/:series-slug/releases/:release-slug/schemas/:schema-slug"
+      {:post (release-routes/put-release-ld-schema-config db)}]
+
      ["/:series-slug/releases/:release-slug/revisions"
       {:post (revision-routes/post-revision-route-config db)}]
      ["/:series-slug/releases/:release-slug/revisions/:revision-id"

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/copy.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/copy.clj
@@ -11,4 +11,7 @@
 (def put-release-200-desc "Release already existed and was successfully updated")
 (def put-release-201-desc "Release did not exist previously and was successfully created")
 
+(def get-release-schema-summary "Retrieve release schema")
+(def put-release-schema-summary "Create schema for a release") 
+
 (def internal-server-error-desc "Internal server error")

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/copy.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/copy.clj
@@ -12,6 +12,10 @@
 (def put-release-201-desc "Release did not exist previously and was successfully created")
 
 (def get-release-schema-summary "Retrieve release schema")
-(def put-release-schema-summary "Create schema for a release") 
+(def get-release-schema-200-desc "Retrieve release schema")
+(def put-release-schema-summary "Create schema for a release")
+(def put-release-schema-200-desc "Schema already exists.")
+(def put-release-schema-201-desc "Schema successfully created")
+
 
 (def internal-server-error-desc "Internal server error")

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -1,5 +1,6 @@
 (ns tpximpact.datahost.ldapi.routes.release
   (:require
+   [malli.util :as mu]
    [tpximpact.datahost.ldapi.handlers :as handlers]
    [tpximpact.datahost.ldapi.routes.copy :as copy]
    [tpximpact.datahost.ldapi.routes.shared :as routes-shared]
@@ -28,3 +29,32 @@
                     :body [:map
                            [:status [:enum "error"]]
                            [:message string?]]}}})
+
+(defn get-release-ld-schema-config
+  [db]
+  {:summary copy/get-release-schema-summary
+   :handler (partial handlers/get-release-schema db)
+   :parameters {:path {:series-slug :string
+                       :release-slug :string}}
+   :responses {200 {:description "TODO"
+                    :body map?}
+               404 {:body [:map
+                           [:status [:enum "error"]]
+                           [:message :string]]}}})
+
+(defn put-release-ld-schema-config
+  [db]
+  {:summary copy/put-release-schema-summary
+   :handler (partial handlers/put-release-schema db)
+   :parameters {:body routes-shared/LdSchemaInput
+                :path {:series-slug :string
+                       :release-slug :string
+                       :schema-slug :string}}
+   :responses {200 {:description copy/put-release-200-desc
+                    :body map?}
+               201 {:description copy/put-release-201-desc
+                    :body map?}
+               500 {:description copy/internal-server-error-desc
+                    :body [:map
+                           [:status [:enum "error"]]
+                           [:message :string]]}}})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -36,7 +36,7 @@
    :handler (partial handlers/get-release-schema db)
    :parameters {:path {:series-slug :string
                        :release-slug :string}}
-   :responses {200 {:description "TODO"
+   :responses {200 {:description copy/get-release-schema-200-desc
                     :body map?}
                404 {:body [:map
                            [:status [:enum "error"]]
@@ -50,9 +50,9 @@
                 :path {:series-slug :string
                        :release-slug :string
                        :schema-slug :string}}
-   :responses {200 {:description copy/put-release-200-desc
+   :responses {200 {:description copy/put-release-schema-200-desc
                     :body map?}
-               201 {:description copy/put-release-201-desc
+               201 {:description copy/put-release-schema-201-desc
                     :body map?}
                500 {:description copy/internal-server-error-desc
                     :body [:map

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -1,13 +1,34 @@
-(ns tpximpact.datahost.ldapi.routes.shared)
+(ns tpximpact.datahost.ldapi.routes.shared
+  (:require [malli.core :as m]
+            [malli.util :as mu]))
+
+
+(def JsonLdBase
+  "Common entries in JSON-LD documents."
+  [:map {:closed false}
+   ["dcterms:title" {:optional true} string?]
+   ["dcterms:description" {:optional true} string?]
+   ["@type" {:optional true} string?]
+   ["@id" {:optional true} string?]
+   ["@context" [:or :string
+                [:tuple :string [:map
+                                 ["@base" string?]]]]]])
 
 (def JsonLdSchema
-  [:maybe
+  "Datahost specific JSON-LD documents"
+  (:maybe
+   (mu/merge
+    JsonLdBase
+    [:map
+     ["dh:baseEntity" {:optional true} string?]])))
+
+(def LdSchemaInput
+  "Schema for new schema documents"
+  (mu/merge
+   JsonLdBase
    [:map {:closed false}
-    ["dcterms:title" {:optional true} string?]
-    ["dcterms:description" {:optional true} string?]
-    ["@type" {:optional true} string?]
-    ["@id" {:optional true} string?]
-    ["dh:baseEntity" {:optional true} string?]
-    ["@context" [:or :string
-                 [:tuple :string [:map
-                                  ["@base" string?]]]]]]])
+    ["dh:columns" [:repeat {:min 1} 
+                   [:map 
+                    ["csvw:datatype" :string]
+                    ["csvw:name" :string]
+                    ["csvw:titles" [:sequential :string]]]]]]))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/release_schema.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/release_schema.clj
@@ -1,0 +1,21 @@
+(ns tpximpact.datahost.ldapi.schemas.release-schema
+  (:require
+   [malli.core :as m]
+   [malli.util :as mu]
+   [tpximpact.datahost.ldapi.schemas.release :as s.release]
+   [tpximpact.datahost.ldapi.schemas.common :refer [registry]]))
+
+
+;;; ---- API SCHEMA
+
+(def ApiQueryParams
+  ;; changes to schema not supported
+  [:map])
+
+(def ApiParams
+  (mu/merge ApiQueryParams s.release/ApiPathParams))
+
+(def api-params-valid? (m/validator ApiParams))
+
+;;; ---- MODEL SCHEMA
+

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
@@ -17,7 +17,7 @@
                                           {"@base" "https://example.org/data/"}],
                               "dcterms:title" "My series"
                               "dcterms:identifier" (format "some-identifier-%s" n)}}))
-    (PUT (format "/data/my-series-%s/release/release-%s" n n)
+    (PUT (format "/data/my-series-%s/releases/release-%s" n n)
          (prepare-req {:content-type :json
                        :body {"@context" ["https://publishmydata.com/debf/datahost/context"
                                           {"@base" (format "https://example.org/data/my-series-%s/" n)}]
@@ -31,7 +31,7 @@
                {"@base" (format "https://example.org/data/my-series-%s/" tag)}]
    "@type" "dh:TableSchema"
    "appropriate-csvw:modeling-of-dialect" "UTF-8,RFC4180"
-   "datahost:appliesToRelease" (format "/data/my-series-%s/release/release-%s" tag tag)
+   "datahost:appliesToRelease" (format "/data/my-series-%s/releases/release-%s" tag tag)
    "dcterms:title" "Fun schema"
    "dh:columns" [{"@type" "dh:DimensionColumn"
                   "csvw:datatype" "string"
@@ -51,7 +51,7 @@
                                          "csvw:name" col-name
                                          "csvw:titles" titles})]
     (testing "Creating a schema"
-      (let [schema-path (format "/data/my-series-%s/release/release-%s/schemas/schema-%s" n n n)
+      (let [schema-path (format "/data/my-series-%s/releases/release-%s/schemas/schema-%s" n n n)
             response (POST schema-path
                            {:content-type :json
                             :body (json/write-str
@@ -67,11 +67,11 @@
         (is (= expected-doc resp-body))
 
         (testing "The release was updated with a reference to the schema"
-          (let [{body :body} (GET (format "/data/my-series-%s/release/release-%s" n n))
+          (let [{body :body} (GET (format "/data/my-series-%s/releases/release-%s" n n))
                 body (json/read-str body)]
             (is (= schema-path (get body "datahost:hasSchema")))))
 
         (testing "The schema can be retrieved"
-          (let [{body :body} (GET (format "/data/my-series-%s/release/release-%s/schemas" n n))
+          (let [{body :body} (GET (format "/data/my-series-%s/releases/release-%s/schemas" n n))
                 body (json/read-str body)]
             (is (= expected-doc body))))))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
@@ -1,0 +1,77 @@
+(ns tpximpact.datahost.ldapi.models.release-schema-test
+  (:require 
+   [clojure.data.json :as json]
+   [clojure.test :refer [deftest testing is] :as t]
+   [tpximpact.datahost.ldapi.models.release :as sut]
+   [tpximpact.test-helpers :as th]))
+
+(def http-client :tpximpact.datahost.ldapi.test/http-client)
+
+(defn setup-release
+  [n]
+  (let [{:keys [PUT]} (get @th/*system* http-client)
+        prepare-req (fn [m] (update m :body json/write-str))]
+    (PUT (str "/data/my-series-" n)
+         (prepare-req {:content-type :json
+                       :body {"@context" ["https://publishmydata.com/def/datahost/context"
+                                          {"@base" "https://example.org/data/"}],
+                              "dcterms:title" "My series"
+                              "dcterms:identifier" (format "some-identifier-%s" n)}}))
+    (PUT (format "/data/my-series-%s/release/release-%s" n n)
+         (prepare-req {:content-type :json
+                       :body {"@context" ["https://publishmydata.com/debf/datahost/context"
+                                          {"@base" (format "https://example.org/data/my-series-%s/" n)}]
+                              "dcterms:title" "Release 1"}}))))
+
+(t/use-fixtures :each th/with-system-fixture)
+
+(defn schema-doc
+  [tag]
+  {"@context" ["https://publishmydata.com/def/datahost/context"
+               {"@base" (format "https://example.org/data/my-series-%s/" tag)}]
+   "@type" "dh:TableSchema"
+   "appropriate-csvw:modeling-of-dialect" "UTF-8,RFC4180"
+   "datahost:appliesToRelease" (format "/data/my-series-%s/release/release-%s" tag tag)
+   "dcterms:title" "Fun schema"
+   "dh:columns" [{"@type" "dh:DimensionColumn"
+                  "csvw:datatype" "string"
+                  "csvw:name" "foo_bar"
+                  "csvw:titles" ["Foo Bar"]}
+                 {"@type" "dh:DimensionColumn"
+                  "csvw:datatype" "string"
+                  "csvw:name" "height"
+                  "csvw:titles" ["Height"]}]})
+
+(deftest round-tripping-release-schema-test
+  (let [n (format "%03d" (rand-int 100))
+        _ (setup-release n)
+        {db :tpximpact.datahost.ldapi.db/db} @th/*system*
+        {:keys [GET POST]} (get @th/*system* http-client)
+        csvw-type (fn [col-name titles] {"csvw:datatype" "string"
+                                         "csvw:name" col-name
+                                         "csvw:titles" titles})]
+    (testing "Creating a schema"
+      (let [schema-path (format "/data/my-series-%s/release/release-%s/schemas/schema-%s" n n n)
+            response (POST schema-path
+                           {:content-type :json
+                            :body (json/write-str
+                                   {"@context" ["https://publishmydata.com/debf/datahost/context"
+                                                {"@base" (format "https://example.org/data/my-series-%s/" n)}]
+                                    "dcterms:title" "Fun schema"
+                                    "dh:columns" [(csvw-type "foo_bar" ["Foo Bar"])
+                                                  (csvw-type "height" ["Height"])]})})
+            resp-body (json/read-str (:body response))
+            expected-doc (schema-doc n)]
+        (is (= 201 (:status response)))
+        (is (= :create (-> @db meta :op)))
+        (is (= expected-doc resp-body))
+
+        (testing "The release was updated with a reference to the schema"
+          (let [{body :body} (GET (format "/data/my-series-%s/release/release-%s" n n))
+                body (json/read-str body)]
+            (is (= schema-path (get body "datahost:hasSchema")))))
+
+        (testing "The schema can be retrieved"
+          (let [{body :body} (GET (format "/data/my-series-%s/release/release-%s/schemas" n n))
+                body (json/read-str body)]
+            (is (= expected-doc body))))))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -1,7 +1,6 @@
 (ns tpximpact.datahost.ldapi.models.series-test
   (:require
    [clojure.data.json :as json]
-   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [grafter.matcha.alpha :as matcha]
    [grafter.vocabularies.dcterms :refer [dcterms:title]]


### PR DESCRIPTION
Adding/Retrieving release schemas.

- add API endpoints to GET & PUT schema
- adding a schema updates the associated release with a reference to the schema (key: `datahost:hasSchema`)

Closes #79 