### PR TITLE
Consistency in Release URLs, DB keys, routes & inverse triples.

### DIFF
--- a/datahost-ld-openapi/doc/data-model-example.ttl
+++ b/datahost-ld-openapi/doc/data-model-example.ttl
@@ -32,9 +32,9 @@ example:datasets
     datahost:base "http://www.example.org/life-expectancy"
     .
 
-# PUT       : ./release/2023
-# CONTROLLER: /data/:series/release/:release-slug
-<./release/2023>
+# PUT       : ./releases/2023
+# CONTROLLER: /data/:series/releases/:release-slug
+<./releases/2023>
     a datahost:Release ;
     dcterms:issued "T2" ;
     dcterms:title "2023" ;
@@ -42,15 +42,15 @@ example:datasets
     .
 
 # Note because of 1. we can now infer/add the following triple to our DatasetSeries, as 'managed metadata'
-# </> dcat:seriesMember <./release/2023> .
+# </> dcat:seriesMember <./releases/2023> .
 
 # POST      : ./schema/2023
-# CONTROLLER: /data/:series/release/:release-slug
+# CONTROLLER: /data/:series/releases/:release-slug
 
 <./schema/2023>
     a datahost:TableSchema ; # TODO details TBD by datahost Schema work
     dcterms:issued "T3" ;
-    datahost:appliesToRelease <./release/2023> ; # TODO come up with a better name for an @reverse of an underlying datahost:hasSchema predicate.
+    datahost:appliesToRelease <./releases/2023> ; # TODO come up with a better name for an @reverse of an underlying datahost:hasSchema predicate.
     appropriate-csvw:modeling-of-dialect "UTF-8,RFC4180"
     .
 
@@ -62,7 +62,7 @@ example:datasets
 # CONTROLLER: /data/:series/changesets
 # Server responds:
 #
-# 303 /data/life-expectancy/release/2023/changesets/:auto-increment-changeset-id
+# 303 /data/life-expectancy/releases/2023/changesets/:auto-increment-changeset-id
 #
 # API call then creates this resource in the database:
 </data/life-expectancy/changesets/1>
@@ -85,9 +85,9 @@ example:datasets
 #
 # DELETE's will look the same as POSTS just with the HTTP verb replaced
 
-# GET /data/life-expectancy/release/2023 Accept: application/json+ld
+# GET /data/life-expectancy/releases/2023 Accept: application/json+ld
 #
-# {"@id": "/data/life-expectancy/release/1",
+# {"@id": "/data/life-expectancy/releases/1",
 #  "@type": "datahost:Release"
 #  "dcterms:title": "2023",
 #  "rdfs:label": "Life Expectancy : 2023",
@@ -120,19 +120,19 @@ example:datasets
 
 
 
-# GET /data/life-expectancy/release/2023 Accept: text/csv
+# GET /data/life-expectancy/releases/2023 Accept: text/csv
 #
-# 303 /data/life-expectancy/release/2023.csv
-# GET /data/life-expectancy/release/2023.csv
+# 303 /data/life-expectancy/releases/2023.csv
+# GET /data/life-expectancy/releases/2023.csv
 #
 # W06000022,2004-01-01T00:00:00/P3Y,Female,80.7
 # W06000022,2004-01-01T00:00:00/P3Y,Male,78.3
 #
 
-# GET /data/life-expectancy/release/2023 Accept: application/csvm+json
+# GET /data/life-expectancy/releases/2023 Accept: application/csvm+json
 #
-# 302 /data/life-expectancy/release/2023.csv-metadata.json
-# GET /data/life-expectancy/release/2023.csv-metadata.json
+# 302 /data/life-expectancy/releases/2023.csv-metadata.json
+# GET /data/life-expectancy/releases/2023.csv-metadata.json
 #
 # {
 #  "@context": "http://www.w3.org/ns/csvw",

--- a/datahost-ld-openapi/env/test/resources/test-inputs/release/metadata-1.json
+++ b/datahost-ld-openapi/env/test/resources/test-inputs/release/metadata-1.json
@@ -3,4 +3,4 @@
  "@id": "2018",
  "dcterms:title": "2018",
 
- "dcat:inSeries": "../my-dataset-series"}
+ "dcat:inSeries": "/data/my-dataset-series"}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -71,7 +71,7 @@
           incoming-jsonld-doc body-params
           {:keys [_op jsonld-doc resource-id]} (db/insert-revision! db api-params incoming-jsonld-doc)]
       {:status 201
-       :headers {"Location" (str "/data/" series-slug "/release/" release-slug "/revisions/" resource-id)}
+       :headers {"Location" (str "/data/" series-slug "/releases/" release-slug "/revisions/" resource-id)}
        :body jsonld-doc})
 
     {:status 422
@@ -88,8 +88,8 @@
                          (update :revision-id parse-long))
           {:keys [_op resource-id jsonld-doc]} (db/insert-change! db api-params incoming-jsonld-doc appends)]
     {:status 201
-       ; /data/:series-slug/release/:release-slug/revisions/1/changes/:auto-incrementing-change-id
-       :headers {"Location" (str "/data/" series-slug "/release/" release-slug
+       ; /data/:series-slug/releases/:release-slug/revisions/1/changes/:auto-incrementing-change-id
+       :headers {"Location" (str "/data/" series-slug "/releases/" release-slug
                                  "/revisions/" revision-id "/changes/" resource-id)}
        :body jsonld-doc})
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/change.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/change.clj
@@ -39,7 +39,7 @@
                       "dcterms:issued" (-> (ZonedDateTime/now (ZoneId/of "UTC"))
                                            (.format models-shared/date-formatter))
                       "dh:appends" appends-file-key
-                      "dh:appliesToRevision" (str ".." (models-shared/revision-key series-slug release-slug revision-id)))]
+                      "dh:appliesToRevision" (models-shared/revision-key series-slug release-slug revision-id))]
       final-doc)))
 
 (def files-root-key "/data/files")

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/release.clj
@@ -28,7 +28,7 @@
                            ;; timestamps, and dcat:seriesMember <release> to series metadata
                            "@type" "dh:Release"
                            "@id" release-slug
-                           "dcat:inSeries" (str "../" series-slug))]
+                           "dcat:inSeries" (models-shared/dataset-series-key series-slug))]
       final-doc)))
 
 (defn- update-release [old-release base-entity api-params jsonld-doc]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/revision.clj
@@ -17,7 +17,7 @@
                         [:description {:optional true} :string]])
 
 (defn normalise-revision [base-entity api-params revision-id jsonld-doc]
-  (let [{:keys [release-slug]} api-params
+  (let [{:keys [series-slug release-slug]} api-params
         _ (assert base-entity "Expected base entity to be set")]
     (when-not (m/validate RevisionApiParams
                           api-params
@@ -34,10 +34,12 @@
           validated-doc (-> (models-shared/validate-id revision-id cleaned-doc)
                             (models-shared/validate-context base-entity))
 
+          release-key (models-shared/release-key series-slug release-slug)
+
           final-doc (assoc validated-doc
                       "@type" "dh:Revision"
                       "@id" revision-id
-                      "dh:appliesToRelease" (str "../" release-slug))]
+                      "dh:appliesToRelease" release-key)]
       final-doc)))
 
 (defn string->stream

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -19,7 +19,7 @@
   (str (.getPath ld-root) series-slug))
 
 (defn release-key [series-slug release-slug]
-  (str (dataset-series-key series-slug) "/" release-slug))
+  (str (dataset-series-key series-slug) "/releases/" release-slug))
 
 (defn revision-key [series-slug release-slug revision-id]
   (str (release-key series-slug release-slug) "/revisions/" revision-id))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -109,16 +109,16 @@
       {:get (series-routes/get-series-route-config db)
        :put (series-routes/put-series-route-config db)}]
 
-     ["/:series-slug/release/:release-slug"
+     ["/:series-slug/releases/:release-slug"
       {:get (release-routes/get-release-route-config db)
        :put (release-routes/put-release-route-config db)}]
 
-     ["/:series-slug/release/:release-slug/revisions"
+     ["/:series-slug/releases/:release-slug/revisions"
       {:post (revision-routes/post-revision-route-config db)}]
-     ["/:series-slug/release/:release-slug/revisions/:revision-id"
+     ["/:series-slug/releases/:release-slug/revisions/:revision-id"
       {:get (assoc (revision-routes/get-revision-route-config db)
               :muuntaja muuntaja-csv-format-instance)}]
-     ["/:series-slug/release/:release-slug/revisions/:revision-id/changes"
+     ["/:series-slug/releases/:release-slug/revisions/:revision-id/changes"
       {:post (revision-routes/post-revision-changes-route-config db)}]]]
 
 

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -17,7 +17,7 @@
       (testing "Fetching a release for a series that does not exist returns 'not found'"
         (try
 
-          (GET (str new-series-path "/release/release-1"))
+          (GET (str new-series-path "/releases/release-1"))
 
           (catch Throwable ex
             (let [{:keys [status body]} (ex-data ex)]
@@ -26,7 +26,7 @@
 
       (testing "Fetching a release that does not exist returns 'not found'"
         (try
-          (GET (str new-series-path "/release/release-1"))
+          (GET (str new-series-path "/releases/release-1"))
 
           (catch Throwable ex
             (let [{:keys [status body]} (ex-data ex)]
@@ -39,7 +39,7 @@
                        {"@base" "http://example.org/data/"}]
                       "dcterms:title" "Example Release"}]
           (try
-            (PUT (str new-series-path "/release/release-1")
+            (PUT (str new-series-path "/releases/release-1")
                  {:content-type :json
                   :body (json/write-str jsonld)})
 
@@ -69,7 +69,7 @@
                               "dcat:inSeries" (str "../" new-series-id)}]
 
         (testing "Creating a release for a series that does exist works"
-          (let [response (PUT (str new-series-path "/release/release-1")
+          (let [response (PUT (str new-series-path "/releases/release-1")
                               {:content-type :json
                                :body (json/write-str request-ednld)})
                 body (json/read-str (:body response))]
@@ -79,15 +79,15 @@
                    (get body "dcterms:modified")))))
 
         (testing "Fetching a release that does exist works"
-          (let [response (GET (str new-series-path "/release/release-1"))
+          (let [response (GET (str new-series-path "/releases/release-1"))
                 body (json/read-str (:body response))]
             (is (= 200 (:status response)))
             (is (= normalised-ednld (dissoc body "dcterms:issued" "dcterms:modified")))))
 
         (testing "A release can be updated, query params take precedence"
-          (let [{body-str-before :body} (GET (str new-series-path "/release/release-1"))
+          (let [{body-str-before :body} (GET (str new-series-path "/releases/release-1"))
                 {:keys [body] :as response} (PUT (str new-series-path
-                                                      "/release/release-1?title=A%20new%20title")
+                                                      "/releases/release-1?title=A%20new%20title")
                                                  {:content-type :json
                                                   :body (json/write-str request-ednld)})
                 body-before (json/read-str body-str-before)
@@ -101,7 +101,7 @@
 
             (testing "No update when query params same as in existing doc"
               (let [response (PUT (str new-series-path
-                                       "/release/release-1?title=A%20new%20title")
+                                       "/releases/release-1?title=A%20new%20title")
                                   {:content-type :json
                                    :body nil})
                     body' (-> response :body json/read-str)]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -66,7 +66,7 @@
                               "dcterms:title" "Example Release",
                               "@type" "dh:Release"
                               "@id" "release-1",
-                              "dcat:inSeries" (str "../" new-series-id)}]
+                              "dcat:inSeries" new-series-path}]
 
         (testing "Creating a release for a series that does exist works"
           (let [response (PUT (str new-series-path "/releases/release-1")
@@ -159,7 +159,7 @@
                  {"@base" "https://example.org/data/series-1"}]
                 "@id" "release-1"
                 "@type" "dh:Release"
-                "dcat:inSeries" "../my-dataset-series"}
+                "dcat:inSeries" "/data/my-dataset-series"}
                returned-value)))
 
       (testing "canonicalisation is idempotent"
@@ -175,7 +175,7 @@
                 "@id" "release-1"
                 "@type" "dh:Release"
                 "dcterms:title" "My Release"
-                "dcat:inSeries" "../my-dataset-series"}
+                "dcat:inSeries" "/data/my-dataset-series"}
                (sut/normalise-release "https://example.org/data/series-1"
                                       {:series-slug "my-dataset-series"
                                        :release-slug "release-1"}

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -34,7 +34,7 @@
       (testing "Creating a revision for an existing release and series"
         ;; RELEASE
         (let [release-id (str "release-" (UUID/randomUUID))
-              release-url (str "/data/" series-slug "/release/" release-id)
+              release-url (str "/data/" series-slug "/releases/" release-id)
               release-resp (PUT release-url
                                 {:content-type :json
                                  :body (json/write-str request-ednld)})]
@@ -54,7 +54,7 @@
                                         "dcterms:title" revision-title,
                                         "@type" "dh:Revision"
                                         "@id" 1,
-                                        "dh:appliesToRelease" (str "../" release-id)}
+                                        "dh:appliesToRelease" release-url}
 
                 revision-resp (POST revision-url
                                     {:content-type :json
@@ -78,11 +78,11 @@
             (testing "Associated Release gets the Revision inverse triple"
               (let [release-resp (GET release-url)
                     release (json/read-str (:body release-resp))]
-                (is (= (str "/data/my-lovely-series/" release-id "/revisions/" inserted-revision-id)
+                (is (= (str "/data/my-lovely-series/releases/" release-id "/revisions/" inserted-revision-id)
                        (first (get release "dh:hasRevision"))))))
 
             (testing "Changes resource created with CSV appends file"
-              ;"/:series-slug/release/:release-slug/revisions/:revision-id/changes"
+              ;"/:series-slug/releases/:release-slug/revisions/:revision-id/changes"
               (let [appends-file (io/file (io/resource csv-1-path))
                     change-ednld {"@context"
                                   ["https://publishmydata.com/def/datahost/context"
@@ -108,7 +108,7 @@
                     "Created with the resource URI provided in the Location header")))
 
             (testing "Second Changes resource created with CSV appends file"
-              ;"/:series-slug/release/:release-slug/revisions/:revision-id/changes"
+              ;"/:series-slug/releases/:release-slug/revisions/:revision-id/changes"
               (let [appends-file (io/file (io/resource csv-2-path))
                     change-ednld {"@context"
                                   ["https://publishmydata.com/def/datahost/context"
@@ -161,7 +161,7 @@
                                             "dcterms:title" revision-title-2,
                                             "@type" "dh:Revision"
                                             "@id" 2,
-                                            "dh:appliesToRelease" (str "../" release-id)}
+                                            "dh:appliesToRelease" release-url}
 
                   revision-resp-2 (POST revision-url-2
                                         {:content-type :json


### PR DESCRIPTION
This PR is mostly just changing Relase routes and DB keys from `/release/` to `/releases/`.

It also fixes the object value for the `dh:appliesToRelease` predicate to point at a proper Release URI instead of `../release-id`.

`dcat:inSeries` predicate also now points to a proper REST route and DB key.

/cc @robchamberspfc
