### PR TITLE
Revisions CSV / JSON format: Fix for default JSON format

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -42,16 +42,16 @@
                 (.getBytes data ^String charset))))))
 
 (def csv-format
-  {:decoder [decode-str]
-   :encoder [encode-str]})
+  (fc/map->Format
+    {:name "text/csv"
+     :decoder [decode-str]
+     :encoder [encode-str]}))
 
-(def muuntaja-csv-format-instance
+(def muuntaja-custom-instance
   (m/create
     (-> (assoc-in
           m/default-options
-          [:formats "text/csv"] csv-format)
-        ;; default would otherwise be application/json
-        (dissoc :default-format))))
+          [:formats "text/csv"] csv-format))))
 
 (defn query-example [triplestore request]
     ;; temporary code to facilitate end-to-end service wire up
@@ -121,8 +121,7 @@
      ["/:series-slug/releases/:release-slug/revisions"
       {:post (revision-routes/post-revision-route-config db)}]
      ["/:series-slug/releases/:release-slug/revisions/:revision-id"
-      {:get (assoc (revision-routes/get-revision-route-config db)
-              :muuntaja muuntaja-csv-format-instance)}]
+      {:get (revision-routes/get-revision-route-config db)}]
      ["/:series-slug/releases/:release-slug/revisions/:revision-id/changes"
       {:post (revision-routes/post-revision-changes-route-config db)}]]]
 
@@ -142,7 +141,7 @@
                        :default-values true
                        ;; malli options
                        :options nil})
-           :muuntaja m/instance
+           :muuntaja muuntaja-custom-instance
            :middleware [cors-middleware
                         ;; swagger & openapi
                         swagger/swagger-feature

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -1,11 +1,13 @@
 (ns tpximpact.datahost.ldapi.routes.revision
   (:require
     [reitit.ring.malli]
+    [reitit.coercion.malli :as rcm]
     [tpximpact.datahost.ldapi.handlers :as handlers]
     [tpximpact.datahost.ldapi.routes.shared :as routes-shared]))
 
 (defn get-revision-route-config [db]
   {:summary "Retrieve metadata for an existing revision"
+   :coercion (rcm/create {:transformers {}, :validate false})
    :handler (partial handlers/get-revision db)
    :parameters {:path {:series-slug string?
                        :release-slug string?

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -69,8 +69,8 @@
                    (str revision-url "/" inserted-revision-id))
                 "Created with the resource URI provided in the Location header")
 
-            (testing "Fetching an existing Revision as application/json works"
-              (let [response (GET new-revision-location {:headers {"accept" "application/json"}})]
+            (testing "Fetching an existing Revision as default application/json format works"
+              (let [response (GET new-revision-location)]
                 (is (= 200 (:status response)))
                 (is (= normalised-revision-ld (json/read-str (:body response)))
                     "responds with JSON")))
@@ -177,7 +177,7 @@
                   "Created with the resource URI provided in the Location header")
 
               (testing "Fetching a second existing revision works"
-                (let [response (GET new-revision-location-2 {:headers {"accept" "application/json"}})]
+                (let [response (GET new-revision-location-2)]
                   (is (= 200 (:status response)))
                   (is (= normalised-revision-ld-2 (json/read-str (:body response))))))))
           )))))


### PR DESCRIPTION
For the Revision GET route, one has to currently supply an `accepts` header, even if you'd like the default JSON, rather than CSV returned. This is because I couldn't get to the bottom of a coercion exception issue last week.

This patch disables coercion for this route.

/cc @robchamberspfc 