### PR TITLE
ld-openapi: split 'util' into distinct namespaces

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.set :as set]
    [malli.core :as m]
-   [tpximpact.datahost.ldapi.util :as util]
+   [tpximpact.datahost.ldapi.util.collections :as util.colls]
    [tpximpact.datahost.ldapi.schemas.api :as s.api])
   (:import
    [java.net URI]
@@ -80,7 +80,7 @@
   [api-params jsonld-doc]
   (-> jsonld-doc
       (merge (rename-query-params-to-common-keys api-params))
-      (util/dissoc-by-key keyword?)))
+      (util.colls/dissoc-by-key keyword?)))
 
 (defn validate-id
   "Returns unchanged doc or throws.

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/collections.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/collections.clj
@@ -1,0 +1,9 @@
+(ns tpximpact.datahost.ldapi.util.collections
+  "Utilities for dealing with collections.")
+
+(defn dissoc-by-key [m pred]
+  (reduce (fn [acc k]
+            (if (pred k)
+              (dissoc acc k)
+              acc))
+          m (keys m)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/rdf.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/rdf.clj
@@ -1,14 +1,10 @@
-(ns tpximpact.datahost.ldapi.util
+(ns tpximpact.datahost.ldapi.util.rdf
   (:require
    [grafter-2.rdf4j.io :as rio])
-  (:import [com.github.jsonldjava.core JsonLdProcessor RDFDatasetUtils JsonLdTripleCallback]))
-
-(defn dissoc-by-key [m pred]
-  (reduce (fn [acc k]
-            (if (pred k)
-              (dissoc acc k)
-              acc))
-          m (keys m)))
+  (:import [com.github.jsonldjava.core
+            JsonLdProcessor
+            JsonLdTripleCallback
+            RDFDatasetUtils]))
 
 (defn ednld->rdf
   "Takes a JSON-LD map as an EDN datastructure and converts it into RDF

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -6,7 +6,7 @@
    [grafter.vocabularies.dcterms :refer [dcterms:title]]
    [tpximpact.datahost.ldapi.models.series :as sut]
    [tpximpact.datahost.ldapi.models.shared :as models-shared]
-   [tpximpact.datahost.ldapi.util :as util]
+   [tpximpact.datahost.ldapi.util.rdf :as util.rdf]
    [tpximpact.test-helpers :as th])
   (:import
     (clojure.lang ExceptionInfo)
@@ -172,7 +172,7 @@
                ednld))
 
         (testing "as RDF"
-          (let [triples (matcha/index-triples (util/ednld->rdf ednld))]
+          (let [triples (matcha/index-triples (util.rdf/ednld->rdf ednld))]
             (testing "All emitted triples have the same expected subject"
               (is (matcha/ask [[(URI. "https://example.org/data/my-dataset-series") dcterms:title ?o]] triples))
               ;; TODO add some more tests

--- a/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/scratch/model_test.clj
@@ -7,7 +7,7 @@
    [grafter.vocabularies.core :refer [prefixer]]
    [grafter.vocabularies.dcat :refer [dcat]]
    [grafter.vocabularies.dcterms :refer [dcterms:title]]
-   [tpximpact.datahost.ldapi.util :as util]
+   [tpximpact.datahost.ldapi.util.rdf :as util.rdf]
    [tpximpact.datahost.ldapi.models.release :as release]
    [tpximpact.datahost.ldapi.models.series :as series]
    [tpximpact.datahost.ldapi.models.shared :as models.shared])
@@ -21,7 +21,7 @@
 (defn db->matcha [db]
   (->> db
        vals
-       (mapcat util/ednld->rdf)
+       (mapcat util.rdf/ednld->rdf)
        (matcha/index-triples)))
 
 (def dh (prefixer "https://publishmydata.com/def/datahost/"))


### PR DESCRIPTION
Slight code organisation change: split the `tpximpact.datahost.ldapi.util`  namespace into separate namespaces under shared prefix to avoid a grab bag of random functions.