### PR TITLE
Change validation

### DIFF
--- a/datahost-ld-openapi/env/test/resources/test-inputs/schemas/simple.json
+++ b/datahost-ld-openapi/env/test/resources/test-inputs/schemas/simple.json
@@ -1,0 +1,14 @@
+{"@context": ["https://publishmydata.com/def/datahost/context",
+              {"@base": "https://example.org/data/"}],
+ "dh:columns": [
+     {"csvw:name": "year",
+      "csvw:datatype": "integer",
+      "csvw:titles": "Year"},
+     {"csvw:name": "measure",
+      "csvw:datatype": "string",
+      "csvw:titles": ["Unit of Measure"]},
+     {"csvw:name": "uppper_confidence_interval",
+      "csvw:datatype": "double",
+      "csvw:required": true,
+      "csvw:titles": "Upper Confidence Interval"}
+ ]}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -104,6 +104,7 @@
   [triplestore release-uri]
   (let [q (get-release-schema-query release-uri)]
     (when-let [schema (get-resource-by-construct-query triplestore q)]
+      (assert (resource/id schema))
       (let [columns-query (get-schema-columns-query (resource/id schema))
             qs (f/format-query columns-query :pretty? true)
             column-statements (datastore/eager-query triplestore qs)]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -1,9 +1,13 @@
 (ns tpximpact.datahost.ldapi.handlers
   (:require
-    [tpximpact.datahost.ldapi.db :as db]
-    [tpximpact.datahost.ldapi.models.shared :as models-shared]
-    [tpximpact.datahost.ldapi.schemas.api :as s.api]
-    [tpximpact.datahost.ldapi.models.revision :as revision-model]))
+   [clojure.tools.logging :as log]
+   [malli.core :as m]
+   [malli.error :as me]
+   [tpximpact.datahost.ldapi.db :as db]
+   [tpximpact.datahost.ldapi.schemas.api :as s.api]
+   [tpximpact.datahost.ldapi.models.revision :as revision-model]
+   [tpximpact.datahost.ldapi.models.shared :as models.shared]
+   [tpximpact.datahost.ldapi.util.data-validation :as data-validation]))
 
 (def not-found-response
   {:status 404
@@ -59,9 +63,9 @@
 
 (defn put-release-schema
   [clock triplestore {{:keys [series-slug] :as params} :path-params
-       incoming-jsonld-doc :body-params
-       :as request}]
-  (if (not (db/get-series-by-slug triplestore series-slug))
+                      incoming-jsonld-doc :body-params
+                      :as request}]
+   (if (not (db/get-series-by-slug triplestore series-slug))
     not-found-response
 
     (let [{:keys [op jsonld-doc]} (db/upsert-release-schema! clock triplestore (get-api-params request) incoming-jsonld-doc)]
@@ -69,14 +73,14 @@
        :body jsonld-doc})))
 
 (defn get-release-schema
-  [triplestore {{:keys [series-slug release-slug] :as path-params} :path-params}]
-  (let [release-uri (models-shared/release-uri-from-slugs series-slug release-slug)]
-    (if-let [schema (db/get-release-schema triplestore release-uri)]
-      {:status 200
-       :body (db/schema->response-body schema)}
-      {:status 404
-       :body {:status "error"
-              :message "Not found"}})))
+    [triplestore {{:keys [series-slug release-slug] :as path-params} :path-params}]
+    (let [release-uri (models.shared/release-uri-from-slugs series-slug release-slug)]
+      (if-let [schema (db/get-release-schema triplestore release-uri)]
+        {:status 200
+         :body (db/schema->response-body schema)}
+        {:status 404
+         :body {:status "error"
+                :message "Not found"}})))
 
 (defn get-revision [triplestore {{:keys [series-slug release-slug revision-id]} :path-params
                         {:strs [accept]} :headers :as _request}]
@@ -105,6 +109,22 @@
     {:status 422
      :body   "Release for this revision does not exist"}))
 
+(defn- dataset-validation-error!
+  "Returns nill on success, error response on validation failure."
+  [release-schema appends]
+  (try
+    (let [dataset (data-validation/as-dataset (:tempfile appends) {})
+          schema (data-validation/make-row-schema release-schema)]
+      (data-validation/validate-dataset dataset schema {:fail-fast? true})
+      nil)
+    (catch Exception ex
+      (log/info "Change validation failure:" (ex-message ex))
+      (let [ex-type (-> ex ex-data :type)]
+        (if (= ex-type :dataset.validation/error)
+          {:status 400
+           :body (:explanation (ex-data ex))}
+          (throw (ex-info "Change validation failed" {:appends appends} ex)))))))
+
 (defn post-change [triplestore
                    {{:keys [series-slug release-slug revision-id]} :path-params
                     {{:keys [appends]} :multipart}                 :parameters
@@ -113,11 +133,20 @@
   (if-let [_revision (db/get-revision triplestore series-slug release-slug revision-id)]
     (let [api-params (get-api-params request)
           incoming-jsonld-doc body-params
-          {:keys [jsonld-doc resource-id]} (db/insert-change! triplestore api-params incoming-jsonld-doc appends)]
-      {:status  201
-       :headers {"Location" (str "/data/" series-slug "/releases/" release-slug
-                                 "/revisions/" revision-id "/changes/" resource-id)}
-       :body    jsonld-doc})
+          release-schema (db/get-release-schema triplestore (models.shared/release-uri-from-slugs series-slug release-slug))
+          validation-err (when (some? release-schema)
+                           (dataset-validation-error! release-schema appends))
+          {:keys [jsonld-doc resource-id]} (when-not validation-err
+                                             (db/insert-change! triplestore api-params
+                                                                incoming-jsonld-doc appends))]
+      (log/info (format "post-change: validation: found-schema? = %s change-valid? = "
+                        (some? release-schema) (nil? validation-err)))
+      (if validation-err
+        validation-err
+        {:status  201
+         :headers {"Location" (str "/data/" series-slug "/releases/" release-slug
+                                   "/revisions/" revision-id "/changes/" resource-id)}
+         :body    jsonld-doc}))
 
     {:status 422
      :body   "Revision for this change does not exist"}))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -22,16 +22,23 @@
     [:map
      ["dh:baseEntity" {:optional true} string?]])))
 
+(def LdSchemaInputColumn
+  [:map 
+   ["csvw:datatype" [:or
+                     [:enum :integer :string :double]
+                     ;; [:map]
+                     ]]
+   ["csvw:name" :string]
+   ["csvw:titles" [:or
+                   :string
+                   [:sequential :string]]]])
+
 (def LdSchemaInput
   "Schema for new schema documents"
   (mu/merge
    JsonLdBase
    [:map {:closed false}
-    ["dh:columns" [:repeat {:min 1}
-                   [:map
-                    ["csvw:datatype" :string]
-                    ["csvw:name" :string]
-                    ["csvw:titles" [:sequential :string]]]]]]))
+    ["dh:columns" [:repeat {:min 1} LdSchemaInputColumn]]]))
 
 ;; TODO: create better resource representation
 (def ResourceSchema

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
@@ -1,0 +1,200 @@
+(ns tpximpact.datahost.ldapi.util.data-validation
+  (:require
+   [clojure.set :as set]
+   [malli.core :as m]
+   [malli.error :as me]
+   [malli.util :as mu]
+   [clojure.tools.logging :as log]
+   [tablecloth.api :as tc]
+   [tech.v3.dataset :as ds]
+   [tpximpact.datahost.ldapi.resource :as resource])
+  (:import [java.net URI]))
+
+
+(def MakeRowSchemaOptions
+  [:map])
+
+(def ValidateOptions
+  [:map
+   [:fail-fast? {:default false :optional true} :boolean]])
+
+(def ^:private make-row-schema-options-valid? (m/validator MakeRowSchemaOptions))
+
+(def ^:private validate-dataset-options-valid? (m/validator ValidateOptions))
+
+(defn column-key
+  [k]
+  (case k
+    :datatype (URI. "http://www.w3.org/ns/csvw#datatype")
+    :titles (URI. "http://www.w3.org/ns/csvw#titles")
+    :required (URI. "http://www.w3.org/ns/csvw#required")))
+
+(defn- extract-column-datatype
+  "Returns a malli schema for column's value.
+
+  At the moment only the simplest cases are supported, and the
+  \"csvw:datatype\" field can be set to \"string\",\"double\",
+  \"integer\". Additionally, the schcema can contain
+  \"csvw:required\".
+
+  Example:
+  - {\"csvw:datatype\": \"string\"} -> [:string]
+  - {\"csvw:datatype\": \"double\", \"csvw:required\": false} -> [:maybe :double]
+
+  "
+  [csvw-col-schema]
+  (let [datatype (first (get csvw-col-schema (column-key :datatype)))
+        schema (get {"integer" :int "string" :string "double" :double} datatype datatype)]
+    (if-not (get csvw-col-schema (column-key :required))
+      [:maybe schema]
+      schema)))
+
+(defn- unpack-column-title
+  "Extracts column title from the schema."
+  [json-cols title]
+  (cond
+    ;;(string? title) title
+    
+    (and (set? title) (= 1 (count title)))
+    (first title)
+    
+    :default (throw (ex-info (format "Unsupported column name value: %s" title
+                                     {:title title
+                                      :columns json-cols})))))
+
+;;(set! *warn-on-reflection* true)
+
+(defn- schema-columns
+  [json-ld-schema]
+  (let [{subjects-map :subjects} json-ld-schema
+        ^URI id (resource/id json-ld-schema)
+        col-key (URI. "https://publishmydata.com/def/datahost/columns")
+        column-keys (get-in subjects-map [id col-key])]
+    (map subjects-map column-keys)))
+
+(defn make-row-schema
+  "Make a malli schema for a tuple of row values specified by
+  column-names. If column names were not specified, uses all columns
+  from JSON-LD schema."
+  ([json-ld-schema]
+   (make-row-schema json-ld-schema nil {}))
+  ([json-ld-schema column-names]
+   (make-row-schema json-ld-schema column-names {}))
+  ([json-ld-schema column-names options]
+   {:pre [(make-row-schema-options-valid? options)]
+    :post [(every? some? (next %))]}
+   (let [titles-key (column-key :titles)
+         json-cols (schema-columns json-ld-schema)
+         ;; NOTE: titles passed as a JS Array -> #{["foo" "bar"]} ?
+         ;; we throw if the array has more than one element.
+         fix-title (fn [schema] (update schema titles-key (partial unpack-column-title json-cols)))
+         indexed (set/index (into #{} (map fix-title) json-cols) [titles-key])
+         _ (assert (= (count json-cols) (count indexed))
+                   "column names in schema should be distinct")
+         m (reduce-kv (fn reducer [r k v]
+                        ;; we know there's only item per index key,
+                        ;; so we can safely unpack the value
+                        (let [col-name (get k titles-key)
+                              schema (extract-column-datatype (first v))]
+                          (assoc r col-name
+                                 (mu/update-properties schema assoc :dataset.column/name col-name))))
+                      {}
+                      indexed)]
+     (into [:tuple] (map #(get m %) (or column-names (keys m)))))))
+
+(defn row-schema->column-names
+  "Returns a seq of column names supported by the row schema."
+  [row-schema]
+  (map (comp :dataset.column/name m/properties) 
+       (m/children row-schema)))
+
+(defn- validate-found-columns
+  "Verifies that we could extract the required columns from the dataset.
+  Throws when it's not possible."
+  [schema column-names ds-column-names]
+  (let [schema-col-names (set column-names)
+        ds-col-names (set ds-column-names)]
+    (when (not= schema-col-names
+                (set/intersection ds-col-names schema-col-names))
+      (log/info "column mismatch" {:schema-column-names schema-col-names
+                                   :dataset-column-names ds-col-names})
+      (throw (ex-info "The expected columns are not in the dataset"
+                      {:schema-column-names schema-col-names
+                       :dataset-column-names ds-col-names
+                       :schema schema})))))
+
+(defn validate-dataset
+  "Validates a dataset row by row using the passed schema.
+
+  The `schema` parameter should be malli tuple schema, where each
+  component is a schema for appropriate column. Each component schema
+  should have `:dataset.column/name` in its
+  properties (see [[make-row-schema]], [[malli.core/properties]]).
+
+  Options:
+  
+  - :fail-fast? (boolean) - throw on first validation error? The
+  `ex-data` will contain :schema :and :columns (ordered as in
+  schema)."
+  [dataset schema {:keys [fail-fast?] :as options}]
+  (when-not (validate-dataset-options-valid? options)
+    (throw (ex-info "Invalid options" {:options options})))
+  (let [validator (m/validator schema)
+        column-names (row-schema->column-names schema)
+        validator-fn (if fail-fast?
+                       (fn [cols]
+                         (when-not (validator cols)
+                           (throw (ex-info "Invalid row" {:type :dataset.validation/error
+                                                          :schema schema
+                                                          :columns cols
+                                                          :explanation (-> (m/explain schema cols)
+                                                                           (me/humanize))}))))
+                       validator)]
+    (assert (every? some? column-names)
+            "Could not extract column names from row schema")
+    (validate-found-columns schema column-names (tc/column-names dataset))
+    (-> dataset
+        (tc/map-columns "valid"
+                        :boolean
+                        column-names
+                        (fn col-mapper [& args]
+                          (validator-fn (vec args))))
+        (ds/filter (fn [{:strs [valid]}] (not valid))))))
+
+(defmulti -as-dataset
+  "Coerce given value (e.g. CSV string or CSV java.io.File ) to a dataset"
+  (fn [v _opts] (type v)))
+
+(defn- slurpable->dataset
+  "If `slurp` can handle, so does this fn. Returns a dataset."
+  [v {:keys [file-type encoding]}]
+  (-> v
+      slurp
+      (.getBytes ^String encoding)
+      (java.io.ByteArrayInputStream.)
+      (tc/dataset {:file-type file-type})))
+
+(defmethod -as-dataset java.io.File [v opts]
+  (tc/set-dataset-name (slurpable->dataset v opts) (.getPath ^java.io.File v)))
+
+(defmethod -as-dataset java.net.URL [v opts]
+  (tc/set-dataset-name (slurpable->dataset v opts) (.getPath ^java.net.URL v)))
+
+(def AsDatasetOpts
+  [:map
+   [:file-type {:optional true} [:enum :csv]]
+   [:encoding {:optional true} [:enum "UTF-8"]]])
+
+(def ^:private as-dataset-opts-valid? (m/validator AsDatasetOpts))
+
+(defn as-dataset
+  "Tries to turn passed value into a dataset.
+
+  The value can be:
+  - `java.io.File`
+  - `java.net.URL` (e.g. a resource)
+  
+  See also: [[tc/dataset]]"
+  [v opts]
+  {:pre [(as-dataset-opts-valid? opts)]}
+  (-as-dataset v (merge {:file-type :csv :encoding "UTF-8"} opts)))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_validation_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_validation_test.clj
@@ -1,0 +1,61 @@
+(ns tpximpact.datahost.ldapi.util.data-validation-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.data.json :as json]
+   [clojure.java.io :as io]
+   [grafter-2.rdf4j.repository :as repo]
+   [malli.core :as m]
+   [malli.error :as me]
+   [malli.transform :as mt]
+   [tablecloth.api :as tc]
+   [tpximpact.datahost.ldapi.db :as db]
+   [tpximpact.datahost.ldapi.models.shared :as models.shared]
+   [tpximpact.datahost.ldapi.routes.shared :refer [LdSchemaInput] :as routes.shared]
+   [tpximpact.datahost.ldapi.util.data-validation :as util.data-validation]
+   [tpximpact.datahost.time :as time]))
+
+(defn- explain
+  "Returns nil on success, a value on validation error."
+  [v]
+  (-> (m/explain LdSchemaInput v) (me/humanize)))
+
+(deftest validation-test
+  (let [repo (repo/sail-repo)
+        t (time/parse "2023-07-20T11:00:00Z")
+        clock (time/manual-clock t)
+        slugs {:series-slug "s1" :release-slug "r1" :schema-slug "schema1"}
+
+        schema-json (-> (io/resource "test-inputs/schemas/simple.json")
+                       (slurp)
+                       (json/read-str {:keywordize? false}))
+        ld-schema (m/decode
+                   LdSchemaInput
+                   schema-json 
+                   (mt/transformer
+                    mt/json-transformer
+                    mt/string-transformer))]
+
+    (testing "Decoding malli schema from JSON-LD"
+      (is ld-schema))
+
+    (db/upsert-release-schema! clock repo slugs ld-schema)
+    
+    (let [schema (db/get-release-schema repo (models.shared/release-uri-from-slugs "s1" "r1"))]
+      (testing "Creating malli row schemas from JSON-LD schema"
+        (is (= ["Year" "Unit of Measure"]
+               (-> (util.data-validation/make-row-schema schema ["Year" "Unit of Measure"])
+                   (util.data-validation/row-schema->column-names)))))
+
+      (testing "Validating data"
+        (let [ds (util.data-validation/as-dataset (io/resource "test-inputs/revision/2020.csv") {})
+              row-schema (util.data-validation/make-row-schema schema)]
+          (is (thrown? Exception
+                       (util.data-validation/validate-dataset
+                        ds
+                        row-schema
+                        {:fail-fast? true})))
+
+          (is (some? (util.data-validation/validate-dataset
+                      ds
+                      row-schema
+                      {:fail-fast? false}))))))))


### PR DESCRIPTION
When a release has an associated schema, we want uploaded CSV to be validated against that schema. 

At the moment only the simple cases of JSON-LD schemas + datatypes are handled: "string", "double", "integer". A column can also be marked as optional by setting `"csvw:required": false`.