### PR TITLE
Add ChangeStore protocol for storing change data

### DIFF
--- a/datahost-ld-openapi/env/docker/resources/ldapi/env.edn
+++ b/datahost-ld-openapi/env/docker/resources/ldapi/env.edn
@@ -3,5 +3,5 @@
  :tpximpact.datahost.ldapi.jetty/runnable-service {:host "0.0.0.0" ;; bind to all network interfaces
                                                    :port 80}
  :tpximpact.datahost.ldapi.native-datastore/repo {:data-directory "/cache/native-datastore"}
- :tpximpact.datahost.ldapi.store.file/store {:directory "/cache/file-store"}
+ :tpximpact.datahost.ldapi.store.file/store {:directory "/files/file-store"}
  }

--- a/datahost-ld-openapi/env/docker/resources/ldapi/env.edn
+++ b/datahost-ld-openapi/env/docker/resources/ldapi/env.edn
@@ -3,4 +3,5 @@
  :tpximpact.datahost.ldapi.jetty/runnable-service {:host "0.0.0.0" ;; bind to all network interfaces
                                                    :port 80}
  :tpximpact.datahost.ldapi.native-datastore/repo {:data-directory "/cache/native-datastore"}
+ :tpximpact.datahost.ldapi.store.file/store {:directory "/cache/file-store"}
  }

--- a/datahost-ld-openapi/env/test/resources/test-system.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system.edn
@@ -7,4 +7,11 @@
  :tpximpact.datahost.ldapi.native-datastore/repo 
  {:data-directory #ig/ref :tpximpact.datahost.ldapi.native-datastore.repo/data-directory}
 
- :tpximpact.datahost.time/system-clock {}}
+ :tpximpact.datahost.time/system-clock {}
+
+ :tpximpact.datahost.ldapi.store.temp-file-store/store {}
+
+ :tpximpact.datahost.ldapi.router/handler
+ {:triplestore #ig/ref :tpximpact.datahost.ldapi.native-datastore/repo
+  :clock #ig/ref :tpximpact.datahost.time/system-clock
+  :change-store #ig/ref :tpximpact.datahost.ldapi.store.temp-file-store/store}}

--- a/datahost-ld-openapi/resources/ldapi/base-system.edn
+++ b/datahost-ld-openapi/resources/ldapi/base-system.edn
@@ -10,10 +10,12 @@
   :default-subscriptions-path "/ws"}
 
  :tpximpact.datahost.ldapi.native-datastore/repo {:data-directory "/tmp/ld-dev-db"}
+ :tpximpact.datahost.ldapi.store.file/store {:directory "/tmp/file-store"}
 
  :tpximpact.datahost.ldapi.router/handler 
  {:triplestore #ig/ref :tpximpact.datahost.ldapi.native-datastore/repo
-  :clock #ig/ref :tpximpact.datahost.time/system-clock}
+  :clock #ig/ref :tpximpact.datahost.time/system-clock
+  :change-store #ig/ref :tpximpact.datahost.ldapi.store.file/store}
 
  :tpximpact.datahost.time/system-clock {}
  }

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/files.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/files.clj
@@ -1,0 +1,20 @@
+(ns tpximpact.datahost.ldapi.files
+  (:import [java.io File]
+           [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn delete-dir [^File dir]
+  (doseq [f (.listFiles dir)]
+    (cond (.isFile f)
+          (.delete f)
+
+          (.isDirectory f)
+          (delete-dir f)
+
+          :else
+          nil))
+  (.delete dir))
+
+(defn create-temp-directory [prefix]
+  (let [dir-path (Files/createTempDirectory prefix (make-array FileAttribute 0))]
+    (.toFile dir-path)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/revision.clj
@@ -4,25 +4,15 @@
     [tablecloth.api :as tc]
     [tpximpact.datahost.ldapi.compact :as cmp]
     [tpximpact.datahost.ldapi.db :as db]
-    [tpximpact.datahost.ldapi.resource :as resource])
-  (:import (java.io ByteArrayInputStream)))
+    [tpximpact.datahost.ldapi.resource :as resource]
+    [tpximpact.datahost.ldapi.store :as store]))
 
-(defn string->stream
-  ([s] (string->stream s "UTF-8"))
-  ([s encoding]
-   (-> s
-       (.getBytes encoding)
-       (ByteArrayInputStream.))))
+(defn input-stream->dataset [is]
+  (tc/dataset is {:file-type :csv}))
 
-(defn csv-str->dataset [str]
-  (some-> str
-          (string->stream)
-          (tc/dataset {:file-type :csv})))
-
-(defn csv-file-locations->dataset [triplestore appends-file-locations]
-  (some->> appends-file-locations
-           (map #(csv-str->dataset (db/get-file-contents triplestore %)))
-           (remove nil?)
+(defn csv-file-locations->dataset [change-store append-keys]
+  (some->> append-keys
+           (map #(input-stream->dataset (store/get-append change-store %)))
            (apply tc/concat)))
 
 (defn write-to-outputstream [tc-dataset]
@@ -30,22 +20,22 @@
    (fn [out-stream]
      (tc/write! tc-dataset out-stream {:file-type :csv}))))
 
-(defn revision->csv-stream [triplestore revision]
-  (when-let [merged-datasets (csv-file-locations->dataset triplestore
+(defn revision->csv-stream [triplestore change-store revision]
+  (when-let [merged-datasets (csv-file-locations->dataset change-store
                                                           (db/revision-appends-file-locations triplestore revision))]
     (write-to-outputstream merged-datasets)))
 
-(defn change->csv-stream [triplestore change]
+(defn change->csv-stream [change-store change]
   (let [appends (resource/get-property1 change (cmp/expand :dh/appends))]
-    (when-let [dataset (csv-file-locations->dataset triplestore [appends])]
+    (when-let [dataset (csv-file-locations->dataset change-store [appends])]
       (write-to-outputstream dataset))))
 
-(defn release->csv-stream [triplestore release]
+(defn release->csv-stream [triplestore change-store release]
   ;; TODO: loading of appends file locations could be done in one query
   (let [revision-uris (resource/get-property release (cmp/expand :dh/hasRevision))
         appends-file-keys (some->> revision-uris
                                    (map #(db/get-revision triplestore %))
                                    (map (partial db/revision-appends-file-locations triplestore))
                                    (flatten))]
-    (when-let [merged-datasets (csv-file-locations->dataset triplestore appends-file-keys)]
+    (when-let [merged-datasets (csv-file-locations->dataset change-store appends-file-keys)]
       (write-to-outputstream merged-datasets))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -7,9 +7,9 @@
 
 (def internal-server-error-desc "Internal server error")
 
-(defn get-release-route-config [triplestore]
+(defn get-release-route-config [triplestore change-store]
   {:summary "Retrieve metadata for an existing release"
-   :handler (partial handlers/get-release triplestore)
+   :handler (partial handlers/get-release triplestore change-store)
    :coercion (rcm/create {:transformers {}, :validate false})
    :parameters {:path {:series-slug string?
                        :release-slug string?}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -5,10 +5,10 @@
     [tpximpact.datahost.ldapi.handlers :as handlers]
     [tpximpact.datahost.ldapi.routes.shared :as routes-shared]))
 
-(defn get-revision-route-config [triplestore]
+(defn get-revision-route-config [triplestore change-store]
   {:summary "Retrieve metadata or CSV contents for an existing revision"
    :coercion (rcm/create {:transformers {}, :validate false})
-   :handler (partial handlers/get-revision triplestore)
+   :handler (partial handlers/get-revision triplestore change-store)
    :parameters {:path {:series-slug string?
                        :release-slug string?
                        :revision-id int?}}
@@ -40,9 +40,9 @@
                            [:status [:enum "error"]]
                            [:message string?]]}}})
 
-(defn post-revision-changes-route-config [triplestore]
+(defn post-revision-changes-route-config [triplestore change-store]
   {:summary "Add changes to a Revision via a CSV file."
-   :handler (partial handlers/post-change triplestore)
+   :handler (partial handlers/post-change triplestore change-store)
    :parameters {:multipart [:map [:appends reitit.ring.malli/temp-file-part]]
                 :path {:series-slug string?
                        :release-slug string?
@@ -56,10 +56,10 @@
                            [:status [:enum "error"]]
                            [:message string?]]}}})
 
-(defn get-revision-changes-route-config [triplestore]
+(defn get-revision-changes-route-config [triplestore change-store]
   {:summary "Retrieve CSV contents for an existing change"
    :coercion (rcm/create {:transformers {}, :validate false})
-   :handler (partial handlers/get-change triplestore)
+   :handler (partial handlers/get-change triplestore change-store)
    :parameters {:path {:series-slug string?
                        :release-slug string?
                        :revision-id int?

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
@@ -1,0 +1,17 @@
+(ns tpximpact.datahost.ldapi.store)
+
+(defprotocol ChangeStore
+  "Represents a repository for document changes"
+  (insert-append [this file]
+    "Inserts a ring file upload into this store. Returns a key value which
+     can be used to retrieve the append data from this store using get-append.
+
+     The file parameter should be a map with at least the following keys:
+     :tempfile - An IOFactory instance containing the append data
+     :filename - The name of the uploaded file on teh request")
+
+  (get-append [this append-key]
+    "Retrieves append data using the key returned by insert-append. If the
+    key is found in this store, an input stream positioned at the start of the
+    append data is returned."))
+

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
@@ -8,7 +8,7 @@
 
      The file parameter should be a map with at least the following keys:
      :tempfile - An IOFactory instance containing the append data
-     :filename - The name of the uploaded file on teh request")
+     :filename - The name of the uploaded file on the request")
 
   (get-append [this append-key]
     "Retrieves append data using the key returned by insert-append. If the

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/file.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/file.clj
@@ -1,0 +1,68 @@
+(ns tpximpact.datahost.ldapi.store.file
+  "Namespace for implementing a store for change data which uses the file system"
+  (:require
+    [clojure.java.io :as io]
+    [integrant.core :as ig]
+    [tpximpact.datahost.ldapi.store :as store])
+  (:import [java.io InputStream]
+           [java.security DigestInputStream MessageDigest]
+           [java.util HexFormat]
+           [java.io File]))
+
+(defn- consume-input-stream
+  "Reads an input stream to the end"
+  [^InputStream is]
+  (let [buf (byte-array 2048)]
+    (loop []
+      (let [bytes-read (.read is buf)]
+        (when-not (= -1 bytes-read)
+          (recur))))))
+
+(defn- file->digest
+  "Computes a file digest as a string for a file with the named digest
+   algorithm"
+  [file digest-alg]
+  (let [digest (MessageDigest/getInstance digest-alg)]
+    (with-open [is (DigestInputStream. (io/input-stream file) digest)]
+      (consume-input-stream is)
+      (let [^bytes bytes (.digest digest)]
+        (.formatHex (HexFormat/of) bytes)))))
+
+(defn- file-location
+  "Returns the location of a file with the given digest within the file store"
+  [root-dir ^String digest-str]
+  (if (> (.length digest-str) 2)
+    (let [dir (.substring digest-str 0 2)
+          file (.substring digest-str 2)]
+      (io/file root-dir dir file))
+    (throw (ex-info "Invalid digest" {:digest digest-str}))))
+
+(defrecord FileChangeStore [root-dir]
+  store/ChangeStore
+  (insert-append [_this {:keys [tempfile]}]
+    (let [file-digest (file->digest tempfile "SHA-1")
+          location (file-location root-dir file-digest)]
+      (when-not (.exists location)
+        (.mkdirs (.getParentFile location))
+        ;; copy input file into temp location within store then rename to
+        ;; final destination
+        (let [store-temp (File/createTempFile "filestore" nil root-dir)]
+          (io/copy tempfile store-temp)
+          (.renameTo store-temp location)))
+      file-digest))
+
+  (get-append [_this append-key]
+    (let [location (file-location root-dir append-key)]
+      (if (.exists location)
+        (io/input-stream location)
+        (throw (ex-info "Append not found for key" {:key append-key}))))))
+
+(defn get-root-dir
+  "Returns the root directory of a file store"
+  [fstore]
+  (:root-dir fstore))
+
+(defmethod ig/init-key ::store [_key {:keys [directory]}]
+  (let [dir (io/file directory)]
+    (.mkdirs dir)
+    (->FileChangeStore dir)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/triplestore.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/triplestore.clj
@@ -1,0 +1,41 @@
+(ns tpximpact.datahost.ldapi.store.triplestore
+  "Namespace implementing a store for changes data which uses a triplestore"
+  (:require
+    [grafter-2.rdf.protocols :as pr]
+    [grafter-2.rdf4j.repository :as repo]
+    [tpximpact.datahost.ldapi.compact :as compact]
+    [tpximpact.datahost.ldapi.db :as db]
+    [tpximpact.datahost.ldapi.models.shared :as models-shared]
+    [tpximpact.datahost.ldapi.resource :as resource]
+    [tpximpact.datahost.ldapi.store :as store])
+  (:import [java.io ByteArrayInputStream]))
+
+(defn string->stream
+  ([s] (string->stream s "UTF-8"))
+  ([s encoding]
+   (-> s
+       (.getBytes encoding)
+       (ByteArrayInputStream.))))
+
+(defrecord TriplestoreChangeStore [triplestore]
+  store/ChangeStore
+  (insert-append [_this {:keys [tempfile filename] :as _file}]
+    (let [append-data (slurp tempfile)
+          file-uri (models-shared/new-dataset-file-uri filename)
+          append-statements [(pr/->Triple file-uri
+                                          (compact/expand :dh/fileContents)
+                                          append-data)]]
+      (with-open [conn (repo/->connection triplestore)]
+        (pr/add conn append-statements))
+      file-uri))
+
+  (get-append [_this append-key]
+    (let [file-uri append-key
+          bgps [[file-uri :dh/fileContents '?contents]]
+          q {:prefixes  db/prefixes
+             :construct bgps
+             :where     bgps}
+          append-contents (-> (db/get-resource-by-construct-query triplestore q)
+                              (resource/get-property1 (compact/expand :dh/fileContents)))]
+      (string->stream append-contents))))
+

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -4,6 +4,7 @@
     [clojure.test :refer [deftest is testing] :as t]
     [grafter-2.rdf4j.repository :as repo]
     [tpximpact.datahost.ldapi.router :as router]
+    [tpximpact.datahost.ldapi.store.temp-file-store :as tfstore]
     [tpximpact.datahost.time :as time]
     [tpximpact.test-helpers :as th])
   (:import
@@ -20,81 +21,84 @@
    :body (json/write-str body)})
 
 (t/deftest put-series-create-test
-  (let [repo (repo/sail-repo)
-        t (time/parse "2023-06-29T10:11:07Z")
-        clock (time/manual-clock t)
-        handler (router/handler clock repo)
-        request (create-put-request "new-series" {"dcterms:title" "A title"
-                                                  "dcterms:description" "Description"})
-        {:keys [status body]} (handler request)
-        new-series-doc (json/read-str body)]
-    (t/is (= 201 status))
-    (t/is (= "A title" (get new-series-doc "dcterms:title")))
-    (t/is (= "Description" (get new-series-doc "dcterms:description")))
-    (t/is (= (str t) (get new-series-doc "dcterms:modified")))
-    (t/is (= (str t) (get new-series-doc "dcterms:issued")))
-    (t/is (= (get new-series-doc "dh:baseEntity") "https://example.org/data/new-series"))
+  (with-open [temp-store (tfstore/create-temp-file-store)]
+    (let [repo (repo/sail-repo)
+          t (time/parse "2023-06-29T10:11:07Z")
+          clock (time/manual-clock t)
+          handler (router/handler clock repo temp-store)
+          request (create-put-request "new-series" {"dcterms:title" "A title"
+                                                    "dcterms:description" "Description"})
+          {:keys [status body]} (handler request)
+          new-series-doc (json/read-str body)]
+      (t/is (= 201 status))
+      (t/is (= "A title" (get new-series-doc "dcterms:title")))
+      (t/is (= "Description" (get new-series-doc "dcterms:description")))
+      (t/is (= (str t) (get new-series-doc "dcterms:modified")))
+      (t/is (= (str t) (get new-series-doc "dcterms:issued")))
+      (t/is (= (get new-series-doc "dh:baseEntity") "https://example.org/data/new-series"))
 
-    ;; fetch created series
-    (let [request {:uri "/data/new-series"
-                   :request-method :get}
-          {:keys [status] :as response} (handler request)
-          series-doc (json/read-str (:body response))]
-      (t/is (= 200 status))
-      (t/is (= new-series-doc series-doc)))
-
-    (let [series2-slug "new-series-without-description"
-          request (create-put-request series2-slug {"dcterms:title" "Another title"})
-          {:keys [status]} (handler request)]
-      (t/is (= 201 status)
-            "Should create series without optional dcterms:description")
-
-      (let [request {:uri (str "/data/" series2-slug)
+      ;; fetch created series
+      (let [request {:uri "/data/new-series"
                      :request-method :get}
+            {:keys [status] :as response} (handler request)
+            series-doc (json/read-str (:body response))]
+        (t/is (= 200 status))
+        (t/is (= new-series-doc series-doc)))
+
+      (let [series2-slug "new-series-without-description"
+            request (create-put-request series2-slug {"dcterms:title" "Another title"})
             {:keys [status]} (handler request)]
-        (t/is (= 200 status)
-              "Should retrieve a series without optional dcterms:description")))))
+        (t/is (= 201 status)
+              "Should create series without optional dcterms:description")
+
+        (let [request {:uri (str "/data/" series2-slug)
+                       :request-method :get}
+              {:keys [status]} (handler request)]
+          (t/is (= 200 status)
+                "Should retrieve a series without optional dcterms:description"))))))
 
 (t/deftest put-series-update-test
-  (let [repo (repo/sail-repo)
-        t1 (time/parse "2023-06-30T11:36:18Z")
-        t2 (time/parse "2023-06-30T14:25:33Z")
-        clock (time/manual-clock t1)
-        handler (router/handler clock repo)
-        create-request (create-put-request "new-series" {"dcterms:title" "Initial Title"
-                                                         "dcterms:description" "Initial Description"})
-        _initial-response (handler create-request)
+  (with-open [temp-store (tfstore/create-temp-file-store)]
+    (let [repo (repo/sail-repo)
+          t1 (time/parse "2023-06-30T11:36:18Z")
+          t2 (time/parse "2023-06-30T14:25:33Z")
+          clock (time/manual-clock t1)
+          handler (router/handler clock repo temp-store)
+          create-request (create-put-request "new-series" {"dcterms:title" "Initial Title"
+                                                           "dcterms:description" "Initial Description"})
+          _initial-response (handler create-request)
 
-        _ (time/set-now clock t2)
-        update-request (create-put-request "new-series" {"dcterms:title" "Updated Title"
-                                                         "dcterms:description" "Updated Description"})
-        {:keys [status body] :as update-response} (handler update-request)
-        updated-doc (json/read-str body)]
-    (t/is (= 200 status))
-    (t/is (= "Updated Title" (get updated-doc "dcterms:title")))
-    (t/is (= "Updated Description" (get updated-doc "dcterms:description")))
-    (t/is (= (str t1) (get updated-doc "dcterms:issued")))
-    (t/is (= (str t2) (get updated-doc "dcterms:modified")))))
+          _ (time/set-now clock t2)
+          update-request (create-put-request "new-series" {"dcterms:title" "Updated Title"
+                                                           "dcterms:description" "Updated Description"})
+          {:keys [status body] :as update-response} (handler update-request)
+          updated-doc (json/read-str body)]
+      (t/is (= 200 status))
+      (t/is (= "Updated Title" (get updated-doc "dcterms:title")))
+      (t/is (= "Updated Description" (get updated-doc "dcterms:description")))
+      (t/is (= (str t1) (get updated-doc "dcterms:issued")))
+      (t/is (= (str t2) (get updated-doc "dcterms:modified"))))))
 
 (t/deftest put-series-no-changes-test
-  (let [repo (repo/sail-repo)
-        t1 (time/parse "2023-06-30T13:37:00Z")
-        t2 (time/parse "2023-06-30T15:08:03Z")
-        clock (time/manual-clock t1)
-        handler (router/handler clock repo)
+  (with-open [temp-store (tfstore/create-temp-file-store)]
+    (let [repo (repo/sail-repo)
+          t1 (time/parse "2023-06-30T13:37:00Z")
+          t2 (time/parse "2023-06-30T15:08:03Z")
+          clock (time/manual-clock t1)
+          handler (router/handler clock repo temp-store)
 
-        properties {"dcterms:title" "Title" "dcterms:description" "Description"}
-        create-request (create-put-request "new-series" properties)
-        create-response (handler create-request)
-        initial-doc (json/read-str (:body create-response))
+          properties {"dcterms:title" "Title" "dcterms:description" "Description"}
+          create-request (create-put-request "new-series" properties)
+          create-response (handler create-request)
+          initial-doc (json/read-str (:body create-response))
 
-        _ (time/set-now clock t2)
+          _ (time/set-now clock t2)
 
-        update-request (create-put-request "new-series" properties)
-        update-response (handler update-request)
-        updated-doc (json/read-str (:body update-response))]
+          update-request (create-put-request "new-series" properties)
+          update-response (handler update-request)
+          updated-doc (json/read-str (:body update-response))]
 
-    (t/is (= initial-doc updated-doc))))
+      (t/is (= initial-doc updated-doc)))))
 
 (deftest round-tripping-series-test
   (th/with-system-and-clean-up {{:keys [GET PUT]} :tpximpact.datahost.ldapi.test/http-client :as _sys}

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/router_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/router_test.clj
@@ -1,15 +1,20 @@
 (ns tpximpact.datahost.ldapi.router-test
-  (:require [clojure.test :as t]
-            [grafter-2.rdf4j.repository :as repo]
-            [reitit.ring :as ring]
-            [tpximpact.datahost.time :as time]
-            [tpximpact.datahost.ldapi.router :as sut]))
+  (:require
+    [clojure.java.io :as io]
+    [clojure.test :as t]
+    [grafter-2.rdf4j.repository :as repo]
+    [reitit.ring :as ring]
+    [tpximpact.datahost.ldapi.store.file :as fstore]
+    [tpximpact.datahost.ldapi.store.triplestore :as tstore]
+    [tpximpact.datahost.time :as time]
+    [tpximpact.datahost.ldapi.router :as sut]))
 
 (defn- get-test-router
   ([] (get-test-router time/system-clock))
   ([clock]
-   (let [triplestore (repo/sail-repo)]
-     (sut/router clock triplestore))))
+   (let [triplestore (repo/sail-repo)
+         change-store (fstore/->FileChangeStore (io/file "/Users/lee/data/filestore-tmp"))]
+     (sut/router clock triplestore change-store))))
 
 (t/deftest cors-preflight-request-test
   (let [router (get-test-router)

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/file_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/file_test.clj
@@ -1,0 +1,57 @@
+(ns tpximpact.datahost.ldapi.store.file-test
+  (:require [clojure.test :as t]
+            [tpximpact.datahost.ldapi.files :as files]
+            [tpximpact.datahost.ldapi.store :as store]
+            [tpximpact.datahost.ldapi.store.file :as fstore]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [clojure.test.check.clojure-test :refer [defspec]])
+  (:import [java.lang AutoCloseable]
+           [java.io File]))
+
+(defrecord TempFiles [files]
+  AutoCloseable
+  (close [_this]
+    (doseq [f @files]
+      (.delete f))))
+
+(defrecord TempDir [dir]
+  AutoCloseable
+  (close [_this]
+    (files/delete-dir dir)))
+
+(defn temp-dir []
+  (let [dir (files/create-temp-directory "datahost")]
+    (->TempDir dir)))
+
+(defn new-temp-file [{:keys [files]} prefix]
+  (let [f (File/createTempFile prefix nil)]
+    (swap! files conj f)
+    f))
+
+(defn temp-files []
+  (->TempFiles (atom [])))
+
+(defn- add-to-store [store files m contents]
+  (let [f (new-temp-file files "filestore-test")]
+    (spit f contents)
+    (let [key (store/insert-append store {:tempfile f :filename (.getName f)})]
+      (assoc m key contents))))
+
+(def file-contents-gen gen/string)
+
+(def prop-added-data-fetched-by-key
+  (prop/for-all [file-contents (gen/vector file-contents-gen)]
+    (with-open [temp-dir (temp-dir)]
+      (let [store (fstore/->FileChangeStore (:dir temp-dir))]
+        (with-open [fs (temp-files)]
+          (let [added (reduce (fn [acc contents]
+                                (add-to-store store fs acc contents))
+                              {}
+                              file-contents)
+                fetched (into {} (map (fn [k] [k (slurp (store/get-append store k))]) (keys added)))]
+            (= added fetched)))))))
+
+(defspec added-data-can-be-fetched-by-key
+  100
+  prop-added-data-fetched-by-key)

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/temp_file_store.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/temp_file_store.clj
@@ -1,0 +1,30 @@
+(ns tpximpact.datahost.ldapi.store.temp-file-store
+  (:require [clojure.test :as t]
+            [integrant.core :as ig]
+            [tpximpact.datahost.ldapi.files :as files]
+            [tpximpact.datahost.ldapi.store :as store]
+            [tpximpact.datahost.ldapi.store.file :as fstore])
+  (:import [java.lang AutoCloseable]))
+
+(defrecord TempFileStore [file-store]
+  store/ChangeStore
+  (insert-append [_this file]
+    (store/insert-append file-store file))
+  (get-append [_this append-key]
+    (store/get-append file-store append-key))
+
+  AutoCloseable
+  (close [_]
+    (let [dir (fstore/get-root-dir file-store)]
+      (files/delete-dir dir))))
+
+(defn create-temp-file-store []
+  (let [dir (files/create-temp-directory "tempfilestore")
+        fstore (fstore/->FileChangeStore dir)]
+    (->TempFileStore fstore)))
+
+(defmethod ig/init-key ::store [_key _opts]
+  (create-temp-file-store))
+
+(defmethod ig/halt-key! ::store [_key temp-store]
+  (.close temp-store))


### PR DESCRIPTION
Issue #152 - Add a ChangeStore protocol for storing and retrieving CSV change data. Move the existing implementation into the new store.triplestore namespace, and add a store.file implementation which stores change files on the filesystem. Files are stored in the file store in a location determined by the SHA-1 hash of their contents.

Update the change and revision handlers to require an implementation of the change store used to save and retreive change data. The key returned by the insert-append method is associated with the change (currently only append) record in the triplestore.

Add a test implementation of the file store in store.temp-file-store which deletes the file store directory on close. Define an integrant componemt which deletes the directory in the halt-key! method.

Update base, test and docker configuration files to define a suitable change store implmeentation for each environment.