### PR TITLE
Make image publishing optional in the docker build task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       - checkout
       - run:
           name: "Deploy Open API docker image to registry"
-          command: "clojure -T:build docker :image-type :registry > ldapi_container_digest"
+          command: "clojure -T:build docker :image-type :registry :to :remote > ldapi_container_digest"
           working_directory: datahost-ld-openapi
           project-dir: datahost-ld-openapi
       - persist_to_workspace:


### PR DESCRIPTION
Issue #175 - Add an optional :to parameter to the docker build task which controls how built images are published. Only publish images to the public swirrl repository if this is set to :remote.

Update the deploy-ld-openapi-service CI task to supply this option so containers are published.

Add documentation to the docker task.