### PR TITLE
Stop requiring schema-id (slug)

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -430,16 +430,16 @@
         (resource/set-properties param-properties)
         (resource/set-property1 (compact/expand :dh/appliesToRevision) revision-uri))))
 
-(defn- request->schema [{:keys [series-slug release-slug schema-slug] :as api-params} json-doc]
-  (let [schema-uri (models-shared/release-schema-uri series-slug release-slug schema-slug)
+(defn- request->schema [{:keys [series-slug release-slug] :as api-params} json-doc]
+  (let [schema-uri (models-shared/release-schema-uri series-slug release-slug)
         release-uri (models-shared/release-uri-from-slugs series-slug release-slug)
         schema-doc (annotate-json-resource json-doc schema-uri (compact/expand :dh/TableSchema))
         schema-doc (update schema-doc "dh:columns" (fn [cols]
-                                                     (map-indexed (fn [index col]
-                                                             (assoc col "@id" (str schema-uri "/columns/" (inc index))
-                                                                        "@type" "dh:DimensionColumn"
-                                                                        "csvw:number" (inc index)))
-                                                           cols)))
+                                                     (map-indexed (fn mapper [index col]
+                                                                    (assoc col "@id" (str schema-uri "/columns/" (inc index))
+                                                                           "@type" "dh:DimensionColumn"
+                                                                           "csvw:number" (inc index)))
+                                                                  cols)))
         schema-resource (resource/from-json-ld-doc schema-doc)]
     (-> schema-resource
         (resource/set-property1 (compact/expand :dh/appliesToRelease) release-uri)
@@ -484,6 +484,7 @@
   [(pr/->Triple (resource/get-property1 schema (compact/expand :dh/appliesToRelease))
                 (compact/expand :dh/hasSchema)
                 (resource/id schema))])
+
 (defn- insert-schema [clock triplestore schema]
   (let [new-schema (set-timestamps clock schema)]
     (with-open [conn (repo/->connection triplestore)]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -29,13 +29,13 @@
   (.resolve ld-root (release-key series-slug release-slug)))
 
 (defn release-schema-key
-  ([{:keys [series-slug release-slug schema-slug]}]
-   (release-schema-key series-slug release-slug schema-slug))
-  ([series-slug release-slug schema-slug]
-   (str (release-key series-slug release-slug) "/schemas/" schema-slug)))
+  ([{:keys [series-slug release-slug]}]
+   (release-schema-key series-slug release-slug))
+  ([series-slug release-slug]
+   (str (release-key series-slug release-slug) "/schema" )))
 
-(defn release-schema-uri [series-slug release-slug schema-slug]
-  (.resolve ld-root (release-schema-key series-slug release-slug schema-slug)))
+(defn release-schema-uri [series-slug release-slug]
+  (.resolve ld-root (release-schema-key series-slug release-slug)))
 
 (defn dataset-revision-uri [^URI dataset-release-uri revision-id]
   (URI. (format "%s/revisions/%s" dataset-release-uri revision-id)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -99,10 +99,9 @@
       {:get (release-routes/get-release-route-config triplestore change-store)
        :put (release-routes/put-release-route-config clock triplestore)}]
 
-     ["/:series-slug/releases/:release-slug/schemas"
-      {:get (release-routes/get-release-ld-schema-config triplestore)}]
-     ["/:series-slug/releases/:release-slug/schemas/:schema-slug"
-      {:post (release-routes/put-release-ld-schema-config clock triplestore)}]
+     ["/:series-slug/releases/:release-slug/schema"
+      {:get (release-routes/get-release-ld-schema-config triplestore)
+       :post (release-routes/put-release-ld-schema-config clock triplestore)}]
 
      ["/:series-slug/releases/:release-slug/revisions"
       {:post (revision-routes/post-revision-route-config triplestore)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -52,8 +52,7 @@
    :handler (partial handlers/put-release-schema clock triplestore)
    :parameters {:body routes-shared/LdSchemaInput
                 :path {:series-slug :string
-                       :release-slug :string
-                       :schema-slug :string}}
+                       :release-slug :string}}
    :responses {200 {:description "Schema already exists."
                     :body string?}
                201 {:description "Schema successfully created"

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
@@ -49,7 +49,7 @@
                                          "csvw:name" col-name
                                          "csvw:titles" titles})]
     (testing "Creating a schema"
-      (let [schema-path (format "/data/my-series-%s/releases/release-%s/schemas/schema-%s" n n n)
+      (let [schema-path (format "/data/my-series-%s/releases/release-%s/schema" n n)
             schema-uri (str "https://example.org" schema-path)
             response (POST schema-path
                            {:content-type :json
@@ -63,7 +63,7 @@
             expected-doc (schema-doc n)
             [missing _extra _matching] (diff expected-doc resp-body)]
         (is (= 201 (:status response)))
-        (t/is (= nil missing))
+        (is (= nil missing))
 
         (testing "The release was updated with a reference to the schema"
           (let [{body :body} (GET (format "/data/my-series-%s/releases/release-%s" n n))
@@ -71,7 +71,7 @@
             (is (= schema-uri (get body "dh:hasSchema")))))
 
         (testing "The schema can be retrieved"
-          (let [{body :body} (GET (format "/data/my-series-%s/releases/release-%s/schemas" n n))
+          (let [{body :body} (GET (format "/data/my-series-%s/releases/release-%s/schema" n n))
                 body (json/read-str body)
                 [missing _extra _matching] (diff expected-doc body)]
             (is (= nil missing))))))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -174,7 +174,7 @@
               _ (when-not (m/validate LdSchemaInput schema-req-body)
                   (throw (ex-info (str (me/humanize (m/explain LdSchemaInput schema-req-body)))
                                   {:schema schema-req-body})))
-              _ (POST (str release-url "/schemas/schema-1")
+              _ (POST (str release-url "/schema")
                       {:content-type :json
                        :body (json/write-str schema-req-body)})]
           (is (= 201 (:status release-resp)))


### PR DESCRIPTION
We no longer allow the user to specify the schema-slug; the schema is always accessible under `.../releases/$RELEASE/schema` path. 

Closes #166