### PR TITLE
LDAPI: Allow only 1 change per revision using transaction

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -390,8 +390,7 @@
            [:bind ['(coalesce (+ ?highest 1) 1) '?next]]]})
 
 (defn- select-max-n-query [parent-uri child-pred]
-  {:prefixes {:dh "<https://publishmydata.com/def/datahost/>"
-              :xsd "<http://www.w3.org/2001/XMLSchema#>"}
+  {:prefixes (select-keys default-prefixes [:dh :xsd])
    :select ['?n]
    :where [[:where {:select '[[(max (:xsd/integer (replace (str ?child) "^.*/([^/]*)$" "$1"))) ?highest]]
                     :where [[parent-uri child-pred '?child]]}]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -228,7 +228,8 @@
                                                      :body (json/write-str change-ednld)})
                     new-change-resource-location (-> change-api-response :headers (get "Location"))]
 
-                (is (= 201 (:status change-api-response) ))
+                
+                (is (= 201 (:status change-api-response)))
                 (is (= (str new-revision-location "/changes/1")
                        new-change-resource-location)
                     "Created with the resource URI provided in the Location header")
@@ -251,7 +252,7 @@
                                                      :content-type "application/json"
                                                      :body (json/write-str change-ednld)})
                     new-change-resource-location (-> change-api-response :headers (get "Location"))]
-                (is (= (:status change-api-response) 422))
+                (is (= 422 (:status change-api-response)))
                 (is (nil? new-change-resource-location))))
 
             (testing "Fetching Revision as CSV with multiple CSV append changes"
@@ -288,7 +289,7 @@
                                                        :multipart-params {:appends multipart-temp-file-part}
                                                        :content-type "application/json"
                                                        :body (json/write-str change-3-ednld)})]
-                  (is (= (:status change-api-response) 201))
+                  (is (= 201 (:status change-api-response)))
                   (is (str/ends-with? (get (json/read-str (:body change-api-response)) "@id")
                                       "/changes/1"))))
 


### PR DESCRIPTION
We generate new id (an int) for a change but we currently do only an unsafe check if a change is already associated with the revision. To ensure correctness we should do a conditional insert using a transaction. `NativeStore` and `MemoryStore` support transactions.