### PR TITLE
Fix inlining for schemas with a single column

### DIFF
--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
@@ -75,3 +75,22 @@
                 body (json/read-str body)
                 [missing _extra _matching] (diff expected-doc body)]
             (is (= nil missing))))))))
+
+(t/deftest one-column-schema-test
+  (let [n (format "%03d" (rand-int 100))
+        _ (setup-release n)
+        {:keys [GET POST]} (get @th/*system* http-client)
+        schema-path (format "/data/my-series-%s/releases/release-%s/schemas/schema-%s" n n n)
+        schema {"dcterms:title" "Fun schema"
+                "dcterms:description" "Description"
+                "dh:columns" [{"csvw:datatype" "string"
+                               "csvw:name" "test"
+                               "csvw:titles" "Test"}]}
+        _create-response (POST schema-path
+                               {:content-type :json
+                                :body (json/write-str schema)})
+
+        fetch-response (GET (format "/data/my-series-%s/releases/release-%s/schemas" n n))
+        fetched-doc (json/read-str (:body fetch-response))
+        [missing _ _ ] (diff schema fetched-doc)]
+    (t/is (= nil missing))))


### PR DESCRIPTION
Issue #193 - Fix db/schema->response-body to handle schemas with a single column. When schemas have a single column, the dh:columns key contains a string instead of a single-element collection. Lift non-collection values into a single-valued collection before further processing.

Extract parsing the column number into its own function.