### PR TITLE
ldapi: more consistent param validation when creating or updating resources

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -13,8 +13,14 @@
 (defn dataset-series-uri [series-slug]
   (.resolve ld-root series-slug))
 
+(defn dataset-series-uri* [{:keys [series-slug]}]
+  (dataset-series-uri series-slug))
+
 (defn dataset-release-uri [^URI series-uri release-slug]
   (URI. (format "%s/releases/%s" series-uri release-slug)))
+
+(defn dataset-release-uri* [{:keys [series-slug release-slug]}]
+  (URI. (format "%s/releases/%s" (dataset-series-uri series-slug) release-slug)))
 
 (defn dataset-series-key [series-slug]
   (str (.getPath ld-root) series-slug))
@@ -40,6 +46,9 @@
 (defn dataset-revision-uri [^URI dataset-release-uri revision-id]
   (URI. (format "%s/revisions/%s" dataset-release-uri revision-id)))
 
+(defn dataset-revision-uri* [{:keys [series-slug release-slug revision-id]}]
+  (URI. (format "%s/releases/%s/revisions/%s" (dataset-series-uri series-slug) release-slug revision-id)))
+
 (defn revision-key [series-slug release-slug revision-id]
   (str (release-key series-slug release-slug) "/revisions/" revision-id))
 
@@ -51,3 +60,26 @@
 
 (defn change-uri [series-slug release-slug revision-id change-id]
   (.resolve ld-root (change-key series-slug release-slug revision-id change-id)))
+
+(defmulti -resource-uri
+  "Returns URI for the given resource."
+  (fn [resource _] resource))
+
+(defmethod -resource-uri :dh/DatasetSeries [_ params]
+  (dataset-series-uri* params))
+
+(defmethod -resource-uri :dh/Release [_ params]
+  (dataset-release-uri* params))
+
+(defmethod -resource-uri :dh/Revision [_ params]
+  (dataset-revision-uri* params))
+
+(defmethod -resource-uri :dh/Change [_ {:keys [series-slug release-slug revision-id change-id]}]
+  (change-uri series-slug release-slug revision-id change-id))
+
+(defn resource-uri
+  "Returns an uri for resource, where resource in
+  #{:dh/DatasetsSeries :dh/Release :dh/Revision} and params should
+  match the typical path params."
+  [resource params]
+  (-resource-uri resource params))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -53,9 +53,13 @@
 
 (def muuntaja-custom-instance
   (m/create
-    (-> (assoc-in
-          m/default-options
-          [:formats "text/csv"] csv-format))))
+   (-> (assoc-in
+        m/default-options
+        [:formats "text/csv"] csv-format)
+       (update :formats (fn [formats]
+                          (let [json-format (get formats "application/json")]
+                            (assoc formats "application/ld+json"
+                                   (assoc json-format :name "application/ld+json"))))))))
 
 (def leave-keys-alone-muuntaja-coercer
   (m/create
@@ -196,8 +200,6 @@
                         muuntaja/format-negotiate-middleware
                         ;; encoding response body
                         muuntaja/format-response-middleware
-                        ;; exception handling
-                        ldapi-errors/exception-middleware
                         ;; decoding request body
                         muuntaja/format-request-middleware
                         ;; coercing response bodies
@@ -206,6 +208,8 @@
                         coercion/coerce-request-middleware
                         ;; multipart
                         multipart/multipart-middleware
+                        ;; exception handling
+                        ldapi-errors/exception-middleware
 
                         (if auth
                           (basic-auth-middleware auth)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -1,0 +1,79 @@
+(ns tpximpact.datahost.ldapi.routes.middleware
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]
+   [tpximpact.datahost.ldapi.db :as db]
+   [tpximpact.datahost.ldapi.models.shared
+    :as models.shared
+    :refer [resource-uri]]))
+
+(defn json-only
+  "Middleware that requires the request to pass 'Content-Type: application/json'.
+  Returns 406 when content type does not match."
+  [handler _id]
+  (fn json-only-middleware* [request]
+    (let [content-type (get-in request [:muuntaja/request :raw-format] "")]
+      (if (or (= "application/json" content-type)
+              (= "application/ld+json" content-type))
+        (handler request)
+        {:status 406
+         :body "not acceptable"}))))
+
+(defn resource-exist?
+  [triplestore resource handler _id]
+  {:pre [(m/validate [:enum :dh/DatasetSeries :dh/Release :dh/Revision] resource)]}
+  (fn [{:keys [path-params] :as request}]
+    (if (not (db/resource-exists? triplestore (resource-uri resource path-params)))
+      {:status 404 :body "not found"}
+      (handler request))))
+
+(defn flag-resource-exists
+  "Adds a boolean flag to the request under resource-id, when
+  the given resource exists.
+
+  - resource: [:enum :dh/DatasetSeries :dh/Release :dh/Revision :dh/Change]"
+  [triplestore resource resource-id handler _id]
+  {:pre [(m/validate [:enum :dh/DatasetSeries :dh/Release :dh/Revision :dh/Change] resource)]}
+  (fn [{:keys [path-params] :as request}]
+    (handler (cond-> request
+               (db/resource-exists? triplestore (resource-uri resource path-params))
+               (assoc resource-id true)))))
+
+(defn validate-creation-body+query-params
+  "Tries to distinguish between update and creation of a resource
+  and validates the parameters accordingly based on that.
+
+  Explainers will be used to return the error message in the
+  respons (see [[malli.core/explainer]]).
+  
+  Motivation: on creation we usually require diffrent set of
+  parameters to be in the request, while updates can supply only a
+  subset (e.g. only the title).
+
+  See [[flag-resource-exists]] middleware."
+  [{:keys [resource-id body-explainer query-explainer]} handler _id]
+  (fn validate* [{:keys [query-params]
+                  {:keys [body]} :parameters
+                  req-body :body
+                  :as request}]
+    (let [body (or body (when (map? req-body) req-body))
+          exists? (get request resource-id)]
+      (cond
+        exists? ;; it's an update
+        (handler request)
+
+        (some? body)
+        (let [body-errors (me/humanize (body-explainer body))]
+          (when body-errors (tap> {:body-errors body-errors}))
+          (if body-errors
+            {:status 400
+             :body {:body  body-errors}}
+            (handler request)))
+
+        :else ;; create with query params only
+        (let [query-errors (me/humanize (query-explainer query-params))]
+          (if (some? query-errors)
+            {:status 400
+             :body {:query-params query-errors}}
+            (handler request)))))))
+

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -1,6 +1,8 @@
 (ns tpximpact.datahost.ldapi.routes.shared
-  (:require [malli.util :as mu]))
-
+  (:require
+   [malli.core :as m]
+   [malli.util :as mu]
+   [tpximpact.datahost.ldapi.schemas.common :as s.common]))
 
 (def JsonLdBase
   "Common entries in JSON-LD documents.
@@ -23,6 +25,38 @@
     [:map
      ["dh:baseEntity" {:optional true} string?]])])
 
+(def ^:private
+  required-input-fragment
+  (m/schema
+   [:map
+    ["dcterms:title" {:optional false} :title-string]
+    ["dcterms:description" {:optional false} :description-string]]
+   {:registry s.common/registry}))
+
+(def CreateSeriesInput
+  "Input schema for creaing a new series."
+  required-input-fragment)
+
+(def CreateReleaseInput
+  "Input schema for creating a new release."
+  required-input-fragment)
+
+(def CreateRevisionInput
+  "Input schema for creating new revision."
+  (m/schema
+   [:map
+    ["dcterms:title" {:optional false} :title-string]
+    ["dcterms:description" {:optional true} :description-string]]
+   {:registry s.common/registry}))
+
+(def CreateChangeInput
+  "Input schema for new Changes."
+  (m/schema
+   [:map
+    ["dcterms:title" {:optional true} :title-string]
+    ["dcterms:description" {:optional false} :description-string]]
+   {:registry s.common/registry}))
+
 (def LdSchemaInputColumn
   [:map 
    ["csvw:datatype" [:or
@@ -44,3 +78,29 @@
 ;; TODO: create better resource representation
 (def ResourceSchema
   [:string])
+
+(def explainers
+  {:put-series
+   {:body (m/explainer [:maybe CreateSeriesInput])
+    :query (m/explainer
+            (m/schema [:map
+                       ["title" :title-string]
+                       ["description" :description-string]]
+                      {:registry s.common/registry}))}
+
+   :put-release {:body (m/explainer [:maybe CreateReleaseInput])
+                 :query (m/explainer
+                         (m/schema [:map
+                                    ["title" :title-string]
+                                    ["description" :description-string]]
+                                   {:registry s.common/registry}))}
+   :post-revision {:body (m/explainer [:maybe CreateRevisionInput])
+                   :query (m/schema [:map
+                                     ["title" :title-string]
+                                     ["description" {:optional true} :description-string]]
+                                    {:registry s.common/registry})}
+   :post-revision-change {:body (m/explainer [:maybe CreateChangeInput])
+                          :query (m/schema [:map
+                                            ["title" {:optional true} :title-string]
+                                            ["description" :description-string]]
+                                           {:registry s.common/registry})}})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
@@ -25,7 +25,15 @@
                             {:type :datahost/timestamp
                              :pred (fn timestamp-pred [ts]
                                      (and (instance? ZonedDateTime ts)
-                                          (= (.getZone ^ZonedDateTime ts) utc-tz)))}))}))
+                                          (= (.getZone ^ZonedDateTime ts) utc-tz)))}))
+     
+     ;; swagger-ui complains when namespaced keys are used,
+     ;; so using non-namespaced
+     :title-string (let [regex (str #"^\w[\w\s\D]+$")]
+                     [:re {:error/message (format "Should match regex: %s" (str regex))} regex])
+     ;; description allows newlines
+     :description-string (let [regex #"^\w[\w\s\S\D]+$"]
+                           [:re {:error/message (format "Should match regex: %s" (str regex))} regex])}))
 
 (def registry
   (merge

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -212,7 +212,7 @@
 
             (testing "No update when query params same as in existing doc"
               (let [response (PUT (str release-1-path "?title=A%20new%20title")
-                                  {:content-type :json
+                                  {:content-type :application/json
                                    :body nil})
                     body' (-> response :body json/read-str)]
                 (is (= 200 (:status response)))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -163,9 +163,10 @@
         (let [release-slug (str "release-" (UUID/randomUUID))
               release-url (str "/data/" series-slug "/releases/" release-slug)
               release-resp (PUT release-url
-                                {:content-type :json
+                                {:content-type :application/json
                                  :body (json/write-str {"dcterms:title" "Release 34"
-                                                        "dcterms:description" "Description 34"})})
+                                                        "dcterms:description" "Description 34"
+                                                        })})
               schema-req-body {"dcterms:title" "Test schema"
                                "dh:columns"
                                (let [csvw-type (fn [col-name titles datatype]
@@ -196,7 +197,7 @@
                                         "dh:appliesToRelease" (str "https://example.org" release-url)}
 
                 revision-resp (POST revision-post-url
-                                    {:content-type :json
+                                    {:content-type :application/json
                                      :body (json/write-str revision-ednld)})
                 inserted-revision-id (get (json/read-str (:body revision-resp)) "@id")
                 new-revision-location (-> revision-resp :headers (get "Location"))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -49,7 +49,9 @@
         (t/is (= new-series-doc series-doc)))
 
       (let [series2-slug "new-series-without-description"
-            request (create-put-request series2-slug {"dcterms:title" "Another title"})
+            request (create-put-request series2-slug
+                                        {"dcterms:title" "Another title"
+                                         "dcterms:description" "Foo"})
             {:keys [status]} (handler request)]
         (t/is (= 201 status)
               "Should create series without optional dcterms:description")

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/router_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/router_test.clj
@@ -38,7 +38,8 @@
                  :headers {"content-type" "application/ld+json"
                            "origin" origin}
                  :body {"@context" {"dcterms" "http://wat"}
-                        "dcterms:title" "Test"}}
+                        "dcterms:title" "Test"
+                        "dcterms:description" "Test series"}}
         {:keys [status headers] :as _response} (handler request)]
     (t/is (= 201 status))
     (t/is (= origin (get headers "Access-Control-Allow-Origin")))))


### PR DESCRIPTION
Our current request parameter validation is inconsistent and allows creation of resources with missing fields. This PR fixes that by being more strict about the headers, body and query parameters. 

Summary:
- moved content-type verification to a middleware to stop processing request without set content-type
- middleware for verifying the existence of a resource (we can refactor some of our handlers to make use of it)
- middleware for validating params depending on whether it's an update or insert
- updated tests

Closes Issue #189