### PR TITLE
API: Upload schema as file rather than request body

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -146,10 +146,9 @@
     {:status 422
      :body "Series for this release does not exist"}))
 
-(defn put-release-schema
+(defn post-release-schema
   [clock triplestore {{:keys [series-slug]} :path-params
-                      {{:keys [schema-file]} :multipart} :parameters
-                      body-params :body-params :as request}]
+                      {{:keys [schema-file]} :multipart} :parameters :as request}]
   (if (db/resource-exists? triplestore (models.shared/dataset-series-uri series-slug))
     (let [incoming-jsonld-doc (some-> schema-file :tempfile slurp json/read-str)
           {:keys [op jsonld-doc]} (db/upsert-release-schema! clock triplestore

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -165,7 +165,7 @@
 
       ["/:release-slug/schema"
        {:get (routes.rel/get-release-ld-schema-config triplestore)
-        :post (routes.rel/put-release-ld-schema-config clock triplestore)}]
+        :post (routes.rel/post-release-ld-schema-config clock triplestore)}]
 
       ["/:release-slug/revisions"
        ["" {:post (routes.rev/post-revision-route-config triplestore)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -58,10 +58,10 @@
                               {:body string?}}}
                404 {:body [:re "Not found"]}}})
 
-(defn put-release-ld-schema-config
+(defn post-release-ld-schema-config
   [clock triplestore]
   {:summary "Create schema for a release"
-   :handler (partial handlers/put-release-schema clock triplestore)
+   :handler (partial handlers/post-release-schema clock triplestore)
    :parameters {:multipart [:map [:schema-file reitit.ring.malli/temp-file-part]]
                 :path {:series-slug :string
                        :release-slug :string}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -1,5 +1,6 @@
 (ns tpximpact.datahost.ldapi.routes.release
   (:require
+   [reitit.ring.malli]
    [reitit.coercion.malli :as rcm]
    [tpximpact.datahost.ldapi.handlers :as handlers]
    [tpximpact.datahost.ldapi.routes.middleware :as middleware]
@@ -61,7 +62,7 @@
   [clock triplestore]
   {:summary "Create schema for a release"
    :handler (partial handlers/put-release-schema clock triplestore)
-   :parameters {:body routes-shared/LdSchemaInput
+   :parameters {:multipart [:map [:schema-file reitit.ring.malli/temp-file-part]]
                 :path {:series-slug :string
                        :release-slug :string}}
    :openapi {:security [{"basic" []}]}

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
@@ -1,9 +1,11 @@
 (ns tpximpact.datahost.ldapi.models.release-schema-test
   (:require
-    [clojure.data.json :as json]
-    [clojure.data :refer [diff]]
-    [clojure.test :refer [deftest testing is] :as t]
-    [tpximpact.test-helpers :as th]))
+   [clojure.data.json :as json]
+   [clojure.data :refer [diff]]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest testing is] :as t]
+   [tpximpact.test-helpers :as th])
+  (:import (java.io File)))
 
 (def http-client :tpximpact.datahost.ldapi.test/http-client)
 
@@ -41,25 +43,42 @@
                   "csvw:name" "height"
                   "csvw:titles" "Height"}]})
 
-(deftest round-tripping-release-schema-test
+(defn- build-json-multipart [json-path]
+  (let [json-file (io/file json-path)]
+    {:tempfile json-file
+     :size (.length json-file)
+     :filename (.getName json-file)
+     :content-type "application/json"}))
+
+(deftest round-tripping-release-schema-from-file-test
   (let [n (format "%03d" (rand-int 100))
         _ (setup-release n)
-        {:keys [GET POST]} (get @th/*system* http-client)
+        {{:keys [GET]} :tpximpact.datahost.ldapi.test/http-client
+         ld-api-app :tpximpact.datahost.ldapi.router/handler} @th/*system*
+
         csvw-type (fn [col-name titles] {"csvw:datatype" "string"
                                          "csvw:name" col-name
                                          "csvw:titles" titles
                                          "@type" "dh:DimensionColumn"})]
-    (testing "Creating a schema"
+    (testing "Creating a schema from file upload"
       (let [schema-path (format "/data/my-series-%s/releases/release-%s/schema" n n)
             schema-uri (str "https://example.org" schema-path)
-            response (POST schema-path
-                           {:content-type :json
-                            :body (json/write-str
-                                   {"@context" ["https://publishmydata.com/def/datahost/context"
-                                                {"@base" (format "https://example.org/data/my-series-%s/" n)}]
-                                    "dcterms:title" "Fun schema"
-                                    "dh:columns" [(csvw-type "foo_bar" ["Foo Bar"])
-                                                  (csvw-type "height" ["Height"])]})})
+            temp-schema-file (File/createTempFile "my-schema-1" ".json")
+
+            _ (with-open [file (io/writer temp-schema-file)]
+                (binding [*out* file]
+                  (println (json/write-str
+                            {"@context" ["https://publishmydata.com/def/datahost/context"
+                                         {"@base" (format "https://example.org/data/my-series-%s/" n)}]
+                             "dcterms:title" "Fun schema"
+                             "dh:columns" [(csvw-type "foo_bar" ["Foo Bar"])
+                                           (csvw-type "height" ["Height"])]}))))
+
+            json-file-multipart (build-json-multipart (.getAbsolutePath temp-schema-file))
+            response (ld-api-app {:request-method :post
+                         :uri schema-path
+                         :multipart-params {:schema-file json-file-multipart}
+                         :content-type "application/json"})
             resp-body (json/read-str (:body response))
             expected-doc (schema-doc n)
             [missing _extra _matching] (diff expected-doc resp-body)]
@@ -80,16 +99,26 @@
 (t/deftest one-column-schema-test
   (let [n (format "%03d" (rand-int 1000))
         _ (setup-release n)
-        {:keys [GET POST]} (get @th/*system* http-client)
+        {{:keys [GET]} :tpximpact.datahost.ldapi.test/http-client
+         ld-api-app :tpximpact.datahost.ldapi.router/handler} @th/*system*
         schema-path (format "/data/my-series-%s/releases/release-%s/schema" n n)
         schema {"dcterms:title" "Fun schema"
                 "dcterms:description" "Description"
                 "dh:columns" [{"csvw:datatype" "string"
                                "csvw:name" "test"
                                "csvw:titles" "Test"}]}
-        _create-response (POST schema-path
-                               {:content-type :json
-                                :body (json/write-str schema)})
+
+        temp-schema-file (File/createTempFile "my-schema-2" ".json")
+
+        _ (with-open [file (io/writer temp-schema-file)]
+            (binding [*out* file]
+              (println (json/write-str schema))))
+
+        json-file-multipart (build-json-multipart (.getAbsolutePath temp-schema-file))
+        _response (ld-api-app {:request-method :post
+                              :uri schema-path
+                              :multipart-params {:schema-file json-file-multipart}
+                              :content-type "application/json"})
 
         fetch-response (GET (format "/data/my-series-%s/releases/release-%s/schema" n n))
         fetched-doc (json/read-str (:body fetch-response))


### PR DESCRIPTION
This addresses #195 

As an implementation it works. However, I still need to figure out and retro-fit schema validation on the multipart file upload payload itself, which I don't think we can do at the top level because the file contents is a JSON string at that point. Still thinking about this.