### PR TITLE
Compile all appends and deletes into a complete download

### DIFF
--- a/datahost-ld-openapi/doc/data-model-definitions.md
+++ b/datahost-ld-openapi/doc/data-model-definitions.md
@@ -30,7 +30,7 @@ While revisions specify only the data updates relative to _previous_ revision, t
 
 ### Change
 
-Each [revision](#revision) has a change attached (at the moment only one change per revision is supported). The change specifies a set of records to append, retract, or correct in the [dataset](##dataset) resulting from previous revisions. Change can has only one data file attached.
+Each [revision](#revision) has a change attached (at the moment only one change per revision is supported). The change specifies a set of records to append, retract, or correct in the [dataset](##dataset) resulting from previous revisions. Change can have only one data file attached.
 
 ### Dataset
 

--- a/datahost-ld-openapi/doc/data-model-definitions.md
+++ b/datahost-ld-openapi/doc/data-model-definitions.md
@@ -28,6 +28,10 @@ Revisions are like ‘versions’ of the dataset (from a users point of view): s
 
 While revisions specify only the data updates relative to _previous_ revision, the user should be able to fetch the full dataset snapshot (at this particular revision). This snapshot is a dataset accumulated by replaying all revisions in order.
 
+### Change
+
+Each [revision](#revision) has a change attached (at the moment only one change per revision is supported). The change specifies a set of records to append, retract, or correct in the [dataset](##dataset) resulting from previous revisions. Change can has only one data file attached.
+
 ### Dataset
 
 Dataset is the accumulation of all changes added with successive [revisions](#revision), up to a particular revision. To avoid ambiguities, we can specify: dataset of series "S", release "A" at revision "N".

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -319,7 +319,7 @@
                      :body jsonld-doc})))))
 
 (defn change->csv-stream [change-store change]
-  (let [appends (get change (cmp/expand :dh/appends))]
+  (let [appends (get change (cmp/expand :dh/updates))]
     (when-let [dataset (csv-file-locations->dataset change-store [appends])]
       (write-dataset-to-outputstream dataset))))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/models/shared.clj
@@ -10,6 +10,23 @@
 
 ;;; ---- KEY CTORS
 
+(defn dataset-series-key [series-slug]
+  (str (.getPath ld-root) series-slug))
+
+(defn release-key [series-slug release-slug]
+  (str (dataset-series-key series-slug) "/releases/" release-slug))
+
+(defn release-schema-key
+  ([{:keys [series-slug release-slug]}]
+   (release-schema-key series-slug release-slug))
+  ([series-slug release-slug]
+   (str (release-key series-slug release-slug) "/schema" )))
+
+(defn revision-key [series-slug release-slug revision-id]
+  (str (release-key series-slug release-slug) "/revisions/" revision-id))
+
+;;; --- URI CTORS
+
 (defn dataset-series-uri [series-slug]
   (.resolve ld-root series-slug))
 
@@ -22,23 +39,11 @@
 (defn dataset-release-uri* [{:keys [series-slug release-slug]}]
   (URI. (format "%s/releases/%s" (dataset-series-uri series-slug) release-slug)))
 
-(defn dataset-series-key [series-slug]
-  (str (.getPath ld-root) series-slug))
-
 (defn new-dataset-file-uri [filename]
   (.resolve ld-root (str "files/" (UUID/randomUUID) "/" filename)))
 
-(defn release-key [series-slug release-slug]
-  (str (dataset-series-key series-slug) "/releases/" release-slug))
-
 (defn release-uri-from-slugs [series-slug release-slug]
   (.resolve ld-root (release-key series-slug release-slug)))
-
-(defn release-schema-key
-  ([{:keys [series-slug release-slug]}]
-   (release-schema-key series-slug release-slug))
-  ([series-slug release-slug]
-   (str (release-key series-slug release-slug) "/schema" )))
 
 (defn release-schema-uri [series-slug release-slug]
   (.resolve ld-root (release-schema-key series-slug release-slug)))
@@ -49,9 +54,6 @@
 (defn dataset-revision-uri* [{:keys [series-slug release-slug revision-id]}]
   (URI. (format "%s/releases/%s/revisions/%s" (dataset-series-uri series-slug) release-slug revision-id)))
 
-(defn revision-key [series-slug release-slug revision-id]
-  (str (release-key series-slug release-slug) "/revisions/" revision-id))
-
 (defn change-key [series-slug release-slug revision-id change-id]
   (str (revision-key series-slug release-slug revision-id) "/changes/" change-id))
 
@@ -59,6 +61,7 @@
   (.resolve ld-root (revision-key series-slug release-slug revision-id)))
 
 (defn change-uri [series-slug release-slug revision-id change-id]
+  (assert change-id)
   (.resolve ld-root (change-key series-slug release-slug revision-id change-id)))
 
 (defmulti -resource-uri

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -71,16 +71,9 @@
 (defn changes-route-base [triplestore change-store change-kind]
   {:handler (partial handlers/post-change triplestore change-store change-kind)
    :middleware [[middleware/json-only :json-only]
-                [(partial middleware/resource-exist? triplestore :dh/Revision) :resource-exists?]
-                [(partial middleware/flag-resource-exists triplestore
-                          :dh/Change ::change) :flag-resource-exists]
-                [(partial middleware/validate-creation-body+query-params
-                          {:resource-id ::change
-                           :body-explainer (get-in routes-shared/explainers [:post-revision-change :body])
-                           :query-explainer (get-in routes-shared/explainers [:put-revision-change :query])})
-                 :validate-body+query]]
+                [(partial middleware/resource-exist? triplestore :dh/Revision) :resource-exists?]]
    :parameters {:multipart [:map [:appends reitit.ring.malli/temp-file-part]]
-                :body [:any]
+                :body routes-shared/CreateChangeInput
                 :path {:series-slug string?
                        :release-slug string?
                        :revision-id int?}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -54,7 +54,8 @@
   (m/schema
    [:map
     ["dcterms:title" {:optional true} :title-string]
-    ["dcterms:description" {:optional false} :description-string]]
+    ["dcterms:description" {:optional false} :description-string]
+    ["dcterms:format" {:optional false :json-schema/example "text/csv"} :string]]
    {:registry s.common/registry}))
 
 (def LdSchemaInputColumn

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
@@ -1,0 +1,69 @@
+(ns tpximpact.datahost.ldapi.util.data-compilation
+  "Functionality related to compiling a dataset for a Revision/Release.
+
+  At the moment the only supported input/output type is CSV files."
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]
+   [tablecloth.api :as tc]
+   [tpximpact.datahost.ldapi.util.data-validation
+    :refer [-as-dataset as-dataset]]))
+
+(def registry
+  (merge
+   (m/class-schemas)
+   (m/comparator-schemas)
+   (m/base-schemas)
+   (m/type-schemas)
+   {:datahost.types/uri #(instance? java.net.URI %)
+    :datahost.types/file #(instance? java.io.File %)
+    :datahost.types/path #(instance? java.nio.file.Path %)
+    :datahost.types/seq-of-maps #(= :datahost.types/seq-of-maps (type %))}))
+
+(def dataset-input-type-valid? (m/validator [:qualified-keyword]))
+
+(def ChangeInfo
+  [:map
+   {:description "Description of a change to a revision."}
+   [:datahost.change.data/ref {:description "Reference/key to the data (e.g. CSV file)."}
+    [:fn (comp dataset-input-type-valid? type)]]
+   [:datahost.change.data/format {:description "Format of the input data, e.g. :csv"
+                                  :json-schema/example "csv"}
+    ;; 'native' means we're passing native Clojure data structures.
+    [:string {:description "Mime type of the referenced data. Values as in 'dcterms:format'"}]]
+   [:datahost.change/kind [:enum
+                           :datahost.change.kind/append
+                           :datahost.change.kind/retract]]])
+
+(def CompileDatasetOptions
+  (m/schema
+   [:map
+    [:changes [:sequential ChangeInfo]]]))
+
+(def ^:private compile-dataset-opts-valid? (m/validator CompileDatasetOptions))
+
+(defn- compile-reducer
+  [ds change]
+  (let [{:datahost.change/keys [kind input-format]} change]
+    (case (:datahost.change/kind change)
+      :datahost.change.kind/append (tc/union ds (as-dataset (:datahost.change.data/ref change) {}))
+      :datahost.change.kind/retract (tc/difference ds (as-dataset (:datahost.change.data/ref change) {})))))
+
+(defn compile-dataset
+  "Returns a dataset.
+
+  'opts' should conform to `CompileDatasetOptions` schema."
+  [opts]
+  (when-not (compile-dataset-opts-valid? opts)
+    (throw (ex-info "Illegal options" {:opts opts
+                                       :malli/explanation (-> (m/explain CompileDatasetOptions opts)
+                                                              (me/humanize))})))
+  (let [{:keys [changes]} opts
+        change (when-let [change (first changes)]
+                 (when (not= :datahost.change.kind/append (:datahost.change/kind change))
+                   (throw (ex-info "First change kind should be an 'append'"
+                                   {:kind (:datahost.change/kind (first change))})))
+                 change)]
+    (reduce compile-reducer
+            (as-dataset (:datahost.change.data/ref change) {})
+            (next changes))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
@@ -188,6 +188,9 @@
 (defmethod -as-dataset URL [v opts]
   (tc/set-dataset-name (slurpable->dataset v opts) (.getPath ^URL v)))
 
+(defmethod -as-dataset java.nio.file.Path [^java.nio.file.Path v opts]
+  (tc/set-dataset-name (slurpable->dataset (.toFile v)) (.getFileName v)))
+
 (def AsDatasetOpts
   [:map
    [:file-type {:optional true} [:enum :csv]]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -239,10 +239,11 @@
                 (t/is (= #{(str "https://example.org" release-url "/revisions/1")} release-revisions))))
 
             (testing "Changes append resource created with CSV appends file"
-              ;"/:series-slug/releases/:release-slug/revisions/:revision-id/changes"
-              (let [change-ednld {"dcterms:description" "A new change"}
+              ;; "/:series-slug/releases/:release-slug/revisions/:revision-id/changes"
+              (let [change-ednld {"dcterms:description" "A new change"
+                                  "dcterms:format" "text/csv"}
                     multipart-temp-file-part (build-csv-multipart csv-2019-path)
-                    change-api-response (ld-api-app {:request-method :post
+                    change-api-response (ld-api-app {:request-method :post 
                                                      :uri (str new-revision-location "/changes")
                                                      :multipart-params {:appends multipart-temp-file-part}
                                                      :content-type "application/json"
@@ -265,7 +266,8 @@
 
             (testing "Ensure we can't add more than 1 change to a revision."
               ; /data/:series-slug/releases/:release-slug/revisions/:revision-id/changes
-              (let [change-ednld {"dcterms:description" "A new second change"}
+              (let [change-ednld {"dcterms:description" "A new second change"
+                                  "dcterms:format" "text/csv"}
                     multipart-temp-file-part (build-csv-multipart csv-2020-path)
                     change-api-response (ld-api-app {:request-method :post
                                                      :uri (str new-revision-location "/changes")
@@ -303,7 +305,8 @@
                   "Created with the resource URI provided in the Location header")
 
               (testing "Third Changes append resource created against 2nd Revision"
-                (let [change-3-ednld {"dcterms:description" "A new third change"}
+                (let [change-3-ednld {"dcterms:description" "A new third change"
+                                      "dcterms:format" "text/csv"}
                       multipart-temp-file-part (build-csv-multipart csv-2021-path)
                       change-api-response (ld-api-app {:request-method :post
                                                        :uri (str new-revision-location-2 "/changes")
@@ -347,7 +350,8 @@
                                              :body (json/write-str {"dcterms:title" (str "A third revision for release "
                                                                                          release-slug)})})
                       new-revision-location-3 (-> revision-resp-3 :headers (get "Location"))
-                      change-4-ednld {"dcterms:description" "A new fourth deletes change"}
+                      change-4-ednld {"dcterms:description" "A new fourth deletes change"
+                                      "dcterms:format" "text/csv"}
                       multipart-temp-file-part (build-csv-multipart csv-2021-deletes-path)
                       change-api-response (ld-api-app {:request-method :post
                                                        :uri (str new-revision-location-3 "/deletes")

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_compilation_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_compilation_test.clj
@@ -1,0 +1,40 @@
+(ns tpximpact.datahost.ldapi.util.data-compilation-test
+  (:require
+   [clojure.test :as t :refer [deftest testing is]]
+   [tablecloth.api :as tc]
+   [tpximpact.datahost.ldapi.util.data-compilation :as dc]
+   [tpximpact.datahost.ldapi.util.data-validation
+    :refer [-as-dataset]]))
+
+(defmethod -as-dataset :datahost.types/seq-of-maps [v _opts]
+    (tc/dataset v))
+
+(def data
+  (let [item (fn [n] {:x n :y n})
+        ds-input (fn [r kind]
+                   {:datahost.change.data/ref (with-meta (mapv item r) {:type :datahost.types/seq-of-maps})
+                    :datahost.change.data/format "native"
+                    :datahost.change/kind kind})]
+    {1 (ds-input (range 4) :datahost.change.kind/append)
+     2 (ds-input (range 4 10) :datahost.change.kind/append)
+     3 (ds-input (range 8 10) :datahost.change.kind/retract)}))
+
+(defn data-record-count [k]
+  (count (:datahost.change.data/ref (get data k))))
+
+(deftest compilation-smoke-test
+  (testing "We can create result from appends"
+    (let [result (dc/compile-dataset {:changes [(get data 1)
+                                                (get data 2)]})]
+      (is (= (+ (data-record-count 1)
+                (data-record-count 2))
+             (tc/row-count result)))))
+
+  (testing "We can handle appends and retractions"
+    (let [result (dc/compile-dataset {:changes [(get data 1)
+                                                (get data 2)
+                                                (get data 3)]})]
+      (is (= (+ (data-record-count 1)
+                (data-record-count 2)
+                (- (data-record-count 3)))
+             (tc/row-count result))))))


### PR DESCRIPTION
We allow uploads of appends/retractions in CSV format. Those changes should be compiled into a single dataset for each revision. This PR introduces new namespace that provides such functionality. It does _not_ plug it into the relevant handlers yet.

- new functionality in the `tpximpact.datahost.ldapi.util.data-compilation` ns. Relying on tablecloth's functionality.
- renamed :dh/appends to :dh/updates
- added :dcterms/format to triple to changes

Also:
- [remove flag-resource-exists middleware from changes](https://github.com/Swirrl/datahost-prototypes/pull/213/commits/b3e85c606ec04e41f6b46721c415f125b081e728)


Closes #190