### PR TITLE
Manage basic auth as google secret

### DIFF
--- a/datahost-ld-openapi/deps.edn
+++ b/datahost-ld-openapi/deps.edn
@@ -20,7 +20,9 @@
 				metosin/jsonista {:mvn/version "0.3.7"}
 				org.glassfish/jakarta.json {:mvn/version "2.0.1"}
 				com.apicatalog/titanium-json-ld {:mvn/version "1.3.2"}
-				scicloj/tablecloth {:mvn/version "7.000-beta-50"}}
+				scicloj/tablecloth {:mvn/version "7.000-beta-50"}
+
+        com.google.cloud/google-cloud-secretmanager {:mvn/version  "2.23.0"}}
 
  :aliases
  {:run {:main-opts ["-m" "tpximpact.datahost.ldapi"]}

--- a/datahost-ld-openapi/env/auth/resources/ldapi/env.edn
+++ b/datahost-ld-openapi/env/auth/resources/ldapi/env.edn
@@ -1,4 +1,9 @@
 ;; production environment overrides for basic auth
 {:tpximpact.datahost.ldapi.router/handler
  {:auth {:realm "IDP"
-         :users {"idp" #ig/ref :tpximpact.datahost.ldapi.secrets/basic-auth-hash}}}}
+         :users {"idp" #ig/ref :tpximpact.datahost.ldapi.secrets/basic-auth-hash}}}
+
+ :tpximpact.datahost.ldapi.secrets/basic-auth-hash
+ {:gcloud-project "swirrl-ons-datahost"
+  :secret-name "basic-auth-hash"
+  :version "latest"}}

--- a/datahost-ld-openapi/env/auth/resources/ldapi/env.edn
+++ b/datahost-ld-openapi/env/auth/resources/ldapi/env.edn
@@ -1,4 +1,4 @@
 ;; production environment overrides for basic auth
 {:tpximpact.datahost.ldapi.router/handler
  {:auth {:realm "IDP"
-         :users {"idp" "bcrypt+sha512$4e83e24a51f46d267325bde793938fb2$12$cdc62a29f94fdd49016c7b779e0f881ad32026ddb11f355c"}}}}
+         :users {"idp" #ig/ref :tpximpact.datahost.ldapi.secrets/basic-auth-hash}}}}

--- a/datahost-ld-openapi/resources/ldapi/base-system.edn
+++ b/datahost-ld-openapi/resources/ldapi/base-system.edn
@@ -19,9 +19,4 @@
 
  :tpximpact.datahost.time/system-clock {}
 
- :tpximpact.datahost.ldapi.secrets/basic-auth-hash
- {:gcloud-project "swirrl-ons-datahost"
-  :secret-name "basic-auth-hash"
-  :version "latest"}
-
  }

--- a/datahost-ld-openapi/resources/ldapi/base-system.edn
+++ b/datahost-ld-openapi/resources/ldapi/base-system.edn
@@ -18,4 +18,10 @@
   :change-store #ig/ref :tpximpact.datahost.ldapi.store.file/store}
 
  :tpximpact.datahost.time/system-clock {}
+
+ :tpximpact.datahost.ldapi.secrets/basic-auth-hash
+ {:gcloud-project "swirrl-ons-datahost"
+  :secret-name "basic-auth-hash"
+  :version "latest"}
+
  }

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/secrets.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/secrets.clj
@@ -1,7 +1,15 @@
 (ns tpximpact.datahost.ldapi.secrets
+  (:require [clojure.spec.alpha :as s]
+            [integrant.core :as ig])
   (:import [com.google.cloud.secretmanager.v1
-            ProjectName SecretName SecretVersionName SecretManagerServiceClient])
-  (:require [integrant.core :as ig]))
+            ProjectName SecretName SecretVersionName SecretManagerServiceClient]))
+
+(s/def ::gcloud-project string?)
+(s/def ::secret-name string?)
+(s/def ::version string?)
+
+(defmethod ig/pre-init-spec ::basic-auth-hash [_]
+  (s/keys :req-un [::gcloud-project ::secret-name ::version]))
 
 (defmethod ig/init-key ::basic-auth-hash
   [_ {:keys [gcloud-project secret-name version]}]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/secrets.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/secrets.clj
@@ -1,0 +1,11 @@
+(ns tpximpact.datahost.ldapi.secrets
+  (:import [com.google.cloud.secretmanager.v1
+            ProjectName SecretName SecretVersionName SecretManagerServiceClient])
+  (:require [integrant.core :as ig]))
+
+(defmethod ig/init-key ::basic-auth-hash
+  [_ {:keys [gcloud-project secret-name version]}]
+  (with-open [client (SecretManagerServiceClient/create)]
+    (let [secret-version (SecretVersionName/of gcloud-project secret-name version)
+          latest (.accessSecretVersion client secret-version)]
+      (-> latest .getPayload .getData .toByteArray (String. "UTF-8")))))

--- a/deploy/terraform/ldapi/modules/server/main.tf
+++ b/deploy/terraform/ldapi/modules/server/main.tf
@@ -50,10 +50,14 @@ resource "google_service_account" "ldapi_service_account" {
   display_name = "Service account to run the ldapi server"
 }
 
-# service account needs to be able to read images from the swirrl-devops-infrastructure project
 resource "google_project_iam_member" "ldapi_service_account_permissions" {
   project = "swirrl-devops-infrastructure-1"
-  role = "roles/artifactregistry.reader"
+  for_each = toset([
+    # service account needs to be able to read images from the swirrl-devops-infrastructure project
+    "roles/artifactregistry.reader",
+    "roles/secretmanager.secretAccessor",
+  ])
+  role = each.key
   member = "serviceAccount:${google_service_account.ldapi_service_account.email}"
 }
 

--- a/deploy/terraform/ldapi/modules/server/main.tf
+++ b/deploy/terraform/ldapi/modules/server/main.tf
@@ -50,14 +50,16 @@ resource "google_service_account" "ldapi_service_account" {
   display_name = "Service account to run the ldapi server"
 }
 
-resource "google_project_iam_member" "ldapi_service_account_permissions" {
+# service account needs to be able to read images from the swirrl-devops-infrastructure project
+resource "google_project_iam_member" "ldapi_service_account_permissions_acr" {
   project = "swirrl-devops-infrastructure-1"
-  for_each = toset([
-    # service account needs to be able to read images from the swirrl-devops-infrastructure project
-    "roles/artifactregistry.reader",
-    "roles/secretmanager.secretAccessor",
-  ])
-  role = each.key
+  role = "roles/artifactregistry.reader"
+  member = "serviceAccount:${google_service_account.ldapi_service_account.email}"
+}
+
+resource "google_project_iam_member" "ldapi_service_account_permissions_secrets" {
+  project = "swirrl-ons-datahost"
+  role = "roles/secretmanager.secretAccessor"
   member = "serviceAccount:${google_service_account.ldapi_service_account.email}"
 }
 


### PR DESCRIPTION
Use google secrets as a method to manage the basic auth secret.

NOTE: Before merge/deploy, we need to test the running instance & container's access to secret manage.

# Method

Use the google secrets API directly in application code, using the `gcloud` java library.

## Benefits

Can run same code locally as in prod. Doesn't leave env vars or config with secrets lying around. Recommended by Google.

## Downsides

App has a startup dependency on google secrets API. Though any other method that does not supply the secret to the compiled artifact, loading the secret at runtime, has the same dependency.

Adds complexity to the dev environment to run this code (it doesn't run in dev/test usually). The user's environment must have gcloud credentials setup, and the user must have access to the secretmanager.

# Running

The system running this code needs access to the `secretmanager.secretAccessor` role, including a developer's environment if they want to test it.

Access is granted to the LDAPI instance's service account via the terraform change, output below:

Terraform changes
```diff
Terraform will perform the following actions:

  # module.dev.module.server.google_project_iam_member.ldapi_service_account_permissions will be destroyed
  # (because resource uses count or for_each)
  - resource "google_project_iam_member" "ldapi_service_account_permissions" {
      - etag    = "BwYDbrnz8Io=" -> null
      - id      = "swirrl-devops-infrastructure-1/roles/artifactregistry.reader/serviceAccount:dev-ldapi-account@swirrl-ons-datahost.iam.gserviceaccount.com" -> null
      - member  = "serviceAccount:dev-ldapi-account@swirrl-ons-datahost.iam.gserviceaccount.com" -> null
      - project = "swirrl-devops-infrastructure-1" -> null
      - role    = "roles/artifactregistry.reader" -> null
    }

  # module.dev.module.server.google_project_iam_member.ldapi_service_account_permissions["roles/artifactregistry.reader"] will be created
  + resource "google_project_iam_member" "ldapi_service_account_permissions" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + member  = "serviceAccount:dev-ldapi-account@swirrl-ons-datahost.iam.gserviceaccount.com"
      + project = "swirrl-devops-infrastructure-1"
      + role    = "roles/artifactregistry.reader"
    }

  # module.dev.module.server.google_project_iam_member.ldapi_service_account_permissions["roles/secretmanager.secretAccessor"] will be created
  + resource "google_project_iam_member" "ldapi_service_account_permissions" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + member  = "serviceAccount:dev-ldapi-account@swirrl-ons-datahost.iam.gserviceaccount.com"
      + project = "swirrl-devops-infrastructure-1"
      + role    = "roles/secretmanager.secretAccessor"
    }

Plan: 2 to add, 0 to change, 1 to destroy.
```