### PR TITLE
API: Reinstate Release LD schema input validation in handler

### DIFF
--- a/datahost-ld-openapi/README.md
+++ b/datahost-ld-openapi/README.md
@@ -10,7 +10,7 @@ If the tests pass images are built and tagged with the following tags:
 
 - The name of the branch (branch name tags will be mutated to track passing CI builds from the branch)
 - The full commit sha of the passing build
-- The names of any commit tags (or a unique abreviated commit sha if there isn't one)
+- The names of any commit tags (or a unique abbreviated commit sha if there isn't one)
 
 This means that the latest `main` version can be found at:
 

--- a/datahost-ld-openapi/doc/data-model-definitions.md
+++ b/datahost-ld-openapi/doc/data-model-definitions.md
@@ -30,7 +30,7 @@ While revisions specify only the data updates relative to _previous_ revision, t
 
 ### Change
 
-Each [revision](#revision) has a change attached (at the moment only one change per revision is supported). The change specifies a set of records to append, retract, or correct in the [dataset](##dataset) resulting from previous revisions. Change can have only one data file attached.
+Each [revision](#revision) has a change attached (at the moment only one change per revision is supported). The change specifies a set of records to append, retract, or correct in the [dataset](#dataset) resulting from previous revisions. Change can have only one data file attached.
 
 ### Dataset
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -20,7 +20,7 @@
          :body "not acceptable"}))))
 
 (defn resource-exist?
-  "Checks wether resource exists and short-cirtuits with 404 response if
+  "Checks whether resource exists and short-circuits with 404 response if
   not.
 
   Relies on [[resource-uri]] to create URI of the resource."
@@ -48,9 +48,9 @@
   and validates the parameters accordingly based on that.
 
   Explainers will be used to return the error message in the
-  respons (see [[malli.core/explainer]]).
+  response (see [[malli.core/explainer]]).
   
-  Motivation: on creation we usually require diffrent set of
+  Motivation: on creation we usually require different set of
   parameters to be in the request, while updates can supply only a
   subset (e.g. only the title).
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -62,6 +62,7 @@
   [clock triplestore]
   {:summary "Create schema for a release"
    :handler (partial handlers/post-release-schema clock triplestore)
+   ;; NOTE: file schema JSON content string is validated within the handler itself
    :parameters {:multipart [:map [:schema-file reitit.ring.malli/temp-file-part]]
                 :path {:series-slug :string
                        :release-slug :string}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -14,8 +14,9 @@
    ["dcterms:description" {:optional true} string?]
    ["@type" {:optional true} string?]
    ["@id" {:optional true} string?]
-   ;; ["@context" [:or :string [:tuple :string [:map ["@base" string?]]]]]
-   ])
+   ["@context" {:optional true}
+    [:or :string [:tuple :string [:map {:closed false}
+                                  ["@base" string?]]]]]])
 
 (def JsonLdSchema
   "Datahost specific JSON-LD documents"
@@ -34,7 +35,7 @@
    {:registry s.common/registry}))
 
 (def CreateSeriesInput
-  "Input schema for creaing a new series."
+  "Input schema for creating a new series."
   required-input-fragment)
 
 (def CreateReleaseInput
@@ -60,14 +61,12 @@
 
 (def LdSchemaInputColumn
   [:map 
-   ["csvw:datatype" [:or
-                     [:enum :integer :string :double]
-                     ;; [:map]
-                     ]]
+   ["csvw:datatype" [:or :string :keyword]]
    ["csvw:name" :string]
    ["csvw:titles" [:or
                    :string
-                   [:sequential :string]]]])
+                   [:sequential :string]]]
+   ["@type" {:optional true} string?]])
 
 (def LdSchemaInput
   "Schema for new schema documents"

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -18,14 +18,6 @@
     [:or :string [:tuple :string [:map {:closed false}
                                   ["@base" string?]]]]]])
 
-(def JsonLdSchema
-  "Datahost specific JSON-LD documents"
-  [:maybe
-   (mu/merge
-    JsonLdBase 
-    [:map
-     ["dh:baseEntity" {:optional true} string?]])])
-
 (def ^:private
   required-input-fragment
   (m/schema

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
@@ -7,7 +7,8 @@
    [clojure.tools.logging :as log]
    [tablecloth.api :as tc]
    [tech.v3.dataset :as ds]
-   [tpximpact.datahost.ldapi.resource :as resource])
+   [tpximpact.datahost.ldapi.resource :as resource]
+   [tpximpact.datahost.ldapi.routes.shared :as routes-shared])
   (:import (clojure.lang ExceptionInfo)
            (java.io ByteArrayInputStream File)
            [java.net URL]
@@ -23,6 +24,8 @@
 (def ^:private make-row-schema-options-valid? (m/validator MakeRowSchemaOptions))
 
 (def ^:private validate-dataset-options-valid? (m/validator ValidateOptions))
+
+(def ^:private validate-ld-release-schema-input-valid? (m/validator routes-shared/LdSchemaInput))
 
 (defn column-key
   [k]
@@ -209,3 +212,7 @@
   [v opts]
   {:pre [(as-dataset-opts-valid? opts)]}
   (-as-dataset v (merge {:file-type :csv :encoding "UTF-8"} opts)))
+
+(defn validate-ld-release-schema-input [ld-schema]
+  (when-not (validate-ld-release-schema-input-valid? ld-schema)
+    (throw (ex-info "Invalid Release schema input" {:ld-schema ld-schema}))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
@@ -181,7 +181,7 @@
   [v {:keys [file-type encoding]}]
   (-> v
       slurp
-      (.getBytes ^String encoding)
+      (.getBytes ^String (or encoding "UTF-8"))
       (ByteArrayInputStream.)
       (tc/dataset {:file-type file-type})))
 
@@ -192,7 +192,8 @@
   (tc/set-dataset-name (slurpable->dataset v opts) (.getPath ^URL v)))
 
 (defmethod -as-dataset java.nio.file.Path [^java.nio.file.Path v opts]
-  (tc/set-dataset-name (slurpable->dataset (.toFile v)) (.getFileName v)))
+  (tc/set-dataset-name (slurpable->dataset (.toFile v) opts)
+                       (.getFileName v)))
 
 (def AsDatasetOpts
   [:map

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/test_util/http_client.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/test_util/http_client.clj
@@ -1,5 +1,5 @@
 (ns tpximpact.datahost.ldapi.test-util.http-client
-  "Conveniencve http-client relying on `clj-http.client` library."
+  "Convenience http-client relying on `clj-http.client` library."
   (:require [clj-http.client :as http]))
 
 (defn- http-request


### PR DESCRIPTION
I removed the JSON input validation when we switched from submitting the Release schema JSON from request body to file upload.

Now that I've figured out how to get validation working on the JSON string content of the file upload itself, I've reinstated the validation call.

Bonus: Fixed some typos and minor issues.