### PR TITLE
ldapi: naming changes, ChangeStore protocol changes

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
@@ -1,17 +1,55 @@
 (ns tpximpact.datahost.ldapi.store)
 
+
 (defprotocol ChangeStore
   "Represents a repository for document changes"
-  (insert-append [this file]
+  (-insert-data [this data]
     "Inserts a ring file upload into this store. Returns a key value which
-     can be used to retrieve the append data from this store using get-append.
+     can be used to retrieve the append data from this store using `-get-data`.
 
      The file parameter should be a map with at least the following keys:
      :tempfile - An IOFactory instance containing the append data
      :filename - The name of the uploaded file on the request")
 
-  (get-append [this append-key]
-    "Retrieves append data using the key returned by insert-append. If the
-    key is found in this store, an input stream positioned at the start of the
-    append data is returned."))
+  (-insert-data-with-request [this request]
+    "Because call to `-data-key` may be relatively expensive and
+    involve IO we want to cache it. We do it by creating a 'request'
+    which will contain the key but won't expose it to the user.")
 
+  (-get-data [this data-key]
+    "Retrieves append data using the key returned by `insert-data` If the
+    key is found in this store, an input stream positioned at the start of the
+    append data is returned.")
+
+  (-data-key [this data]
+    "Returns a unique key for the given data. The key can be used to
+    look up if the store already contains the data. The returned value
+    should be treated as an opaque object."))
+
+(defn insert-data
+  [store data]
+  (-insert-data store data))
+
+(deftype InsertRequest [data key]
+  clojure.lang.ILookup
+  (valAt [this k]
+    (case k
+      :key key
+      :data data
+      nil)))
+
+(defn request-data-insert
+  [store ^InsertRequest request]
+  (-insert-data-with-request store request))
+
+(defn get-data
+  [store data-key]
+  (-get-data store data-key))
+
+(defn data-key
+  [store data]
+  (-data-key store data))
+
+(defn make-insert-request!
+  [store data]
+  (->InsertRequest data (data-key store data)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
@@ -27,8 +27,8 @@
    {:description "Description of a change to a revision."}
    [:datahost.change.data/ref {:description "Reference/key to the data (e.g. CSV file)."}
     [:fn (comp dataset-input-type-valid? type)]]
-   [:datahost.change.data/format {:description "Format of the input data, e.g. :csv"
-                                  :json-schema/example "csv"}
+   [:datahost.change.data/format {:description "Format of the input data, e.g. 'text/csv'"
+                                  :json-schema/example "text/csv"}
     ;; 'native' means we're passing native Clojure data structures.
     [:string {:description "Mime type of the referenced data. Values as in 'dcterms:format'"}]]
    [:datahost.change/kind [:enum

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
@@ -195,6 +195,9 @@
   (tc/set-dataset-name (slurpable->dataset (.toFile v) opts)
                        (.getFileName v)))
 
+(defmethod -as-dataset java.io.BufferedInputStream [^java.io.BufferedInputStream v opts]
+  (slurpable->dataset v opts))
+
 (def AsDatasetOpts
   [:map
    [:file-type {:optional true} [:enum :csv]]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/file_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/file_test.clj
@@ -35,7 +35,7 @@
 (defn- add-to-store [store files m contents]
   (let [f (new-temp-file files "filestore-test")]
     (spit f contents)
-    (let [key (store/insert-append store {:tempfile f :filename (.getName f)})]
+    (let [key (store/insert-data store {:tempfile f :filename (.getName f)})]
       (assoc m key contents))))
 
 (def file-contents-gen gen/string)
@@ -49,7 +49,7 @@
                                 (add-to-store store fs acc contents))
                               {}
                               file-contents)
-                fetched (into {} (map (fn [k] [k (slurp (store/get-append store k))]) (keys added)))]
+                fetched (into {} (map (fn [k] [k (slurp (store/get-data store k))]) (keys added)))]
             (= added fetched)))))))
 
 (defspec added-data-can-be-fetched-by-key

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/temp_file_store.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/temp_file_store.clj
@@ -8,10 +8,14 @@
 
 (defrecord TempFileStore [file-store]
   store/ChangeStore
-  (insert-append [_this file]
-    (store/insert-append file-store file))
-  (get-append [_this append-key]
-    (store/get-append file-store append-key))
+  (-insert-data [_this file]
+    (store/insert-data file-store file))
+  (-insert-data-with-request [_this request]
+    (store/-insert-data-with-request file-store request))
+  (-get-data [_this data-key]
+    (store/get-data file-store data-key))
+  (-data-key [_this data]
+    (store/data-key file-store data))
 
   AutoCloseable
   (close [_]


### PR DESCRIPTION
Relatively minor refactoring in preparation for https://github.com/Swirrl/datahost-prototypes/issues/182

Summary of changes
- renaming a lot of occurrences of 'append' to 'update'
- extending the `ChangeStore` interface to avoid doing repeated file reads (one for calculating the checksum, one for parsing the CSV)
