### PR TITLE
Alternative RDF base URI in test base

### DIFF
--- a/datahost-ld-openapi/env/test/resources/test-system.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system.edn
@@ -1,6 +1,8 @@
 {:tpximpact.datahost.ldapi.jetty/http-port #int #or [#env "LD_API_HTTP_PORT" "3400"]
  :tpximpact.datahost.ldapi.native-datastore.repo/data-directory #or [#env "LD_API_TEST_DATA_DIR" "/tmp/ld-test-db"]
 
+ :tpximpact.datahost.system-uris/uris {:rdf-base-uri #uri "https://crunk.org/foop/"}
+
  :tpximpact.datahost.ldapi.test/http-client
  {:port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port}
 

--- a/datahost-ld-openapi/env/test/resources/test-system.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system.edn
@@ -7,11 +7,7 @@
  :tpximpact.datahost.ldapi.native-datastore/repo 
  {:data-directory #ig/ref :tpximpact.datahost.ldapi.native-datastore.repo/data-directory}
 
- :tpximpact.datahost.time/system-clock {}
-
  :tpximpact.datahost.ldapi.store.temp-file-store/store {}
 
  :tpximpact.datahost.ldapi.router/handler
- {:triplestore #ig/ref :tpximpact.datahost.ldapi.native-datastore/repo
-  :clock #ig/ref :tpximpact.datahost.time/system-clock
-  :change-store #ig/ref :tpximpact.datahost.ldapi.store.temp-file-store/store}}
+ {:change-store #ig/ref :tpximpact.datahost.ldapi.store.temp-file-store/store}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
@@ -41,7 +41,7 @@
   (change-uri [this series-slug release-slug revision-id change-id]))
 
 (defn make-system-uris
-  "Returns a ..."
+  "Returns an object that builds URIs based upon the configured RDF base URI"
   [base-uri]
 
   (reify AppUri

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -147,7 +147,8 @@
   (th/with-system-and-clean-up {{:keys [GET POST PUT]} :tpximpact.datahost.ldapi.test/http-client
                                 ld-api-app :tpximpact.datahost.ldapi.router/handler
                                 :as sys}
-    (let [csv-2019-path "test-inputs/revision/2019.csv"
+    (let [rdf-base-uri (th/sys->rdf-base-uri sys)
+          csv-2019-path "test-inputs/revision/2019.csv"
           csv-2020-path "test-inputs/revision/2020.csv"
           csv-2021-path "test-inputs/revision/2021.csv"
           csv-2021-deletes-path "test-inputs/revision/2021-deletes.csv"
@@ -213,7 +214,7 @@
                 normalised-revision-ld {"dcterms:title" revision-title
                                         "dcterms:description" revision-description
                                         "@type" "dh:Revision"
-                                        "dh:appliesToRelease" (str "https://example.org" release-url)}
+                                        "dh:appliesToRelease" (str rdf-base-uri series-slug "/releases/" release-slug)}
 
                 revision-resp (POST revision-post-url
                                     {:content-type :application/json
@@ -239,7 +240,7 @@
               (let [release-resp (GET release-url)
                     release-doc (json/read-str (:body release-resp))
                     release-revisions (get-release-revisions release-doc)]
-                (t/is (= #{(str "https://example.org" release-url "/revisions/1")} release-revisions))))
+                (t/is (= #{(str rdf-base-uri series-slug "/releases/" release-slug "/revisions/1")} release-revisions))))
 
             (testing "Changes append resource created with CSV appends file"
               ;; "/:series-slug/releases/:release-slug/revisions/:revision-id/changes"

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -112,7 +112,7 @@
       (t/is (= initial-doc updated-doc)))))
 
 (deftest round-tripping-series-test
-  (th/with-system-and-clean-up {{:keys [GET PUT]} :tpximpact.datahost.ldapi.test/http-client :as _sys}
+  (th/with-system-and-clean-up {{:keys [GET PUT]} :tpximpact.datahost.ldapi.test/http-client :as sys}
     (testing "A series that does not exist returns 'not found'"
       (try
         (GET "/data/does-not-exist")
@@ -122,14 +122,15 @@
             (is (= 404 status))
             (is (= "Not found" body))))))
 
-    (let [new-series-id (str "new-series-" (UUID/randomUUID))
+    (let [rdf-base-uri (th/sys->rdf-base-uri sys)
+          new-series-id (str "new-series-" (UUID/randomUUID))
           new-series-path (str "/data/" new-series-id)
           request-ednld {"dcterms:title" "A title"
                          "dcterms:description" "foobar"}
           normalised-ednld {"@type" "dh:DatasetSeries"
                             "dcterms:description" "foobar"
                             "@id" new-series-id
-                            "dh:baseEntity" (str "https://example.org" new-series-path)
+                            "dh:baseEntity" (str rdf-base-uri new-series-id)
                             "dcterms:title" "A title"}]
 
       (testing "A series can be created"

--- a/datahost-ld-openapi/test/tpximpact/test_helpers.clj
+++ b/datahost-ld-openapi/test/tpximpact/test_helpers.clj
@@ -1,6 +1,7 @@
 (ns tpximpact.test-helpers
   (:require [clojure.test :refer :all]
             [integrant.core :as ig]
+            [tpximpact.datahost.system-uris :as su]
             [tpximpact.db-cleaner :as dc]
             [tpximpact.datahost.sys :as sys]
             [tpximpact.datahost.ldapi.test-util.http-client :as http-client]))
@@ -65,3 +66,6 @@
                   :on-halt [ig/halt!]}
                  ~system-binding
                  ~@body))
+
+(defn sys->rdf-base-uri [sys]
+  (-> sys :tpximpact.datahost.system-uris/uris (su/rdf-base-uri)))


### PR DESCRIPTION
More work addressing  [Make base URI configurable#216](https://github.com/Swirrl/datahost-prototypes/issues/216)
and relates to previous PR https://github.com/Swirrl/datahost-prototypes/pull/221.