### PR TITLE
API: Add application base path (or mount point) to router and requests

### DIFF
--- a/datahost-ld-openapi/resources/ldapi/base-system.edn
+++ b/datahost-ld-openapi/resources/ldapi/base-system.edn
@@ -4,6 +4,11 @@
 
  :tpximpact.datahost.system-uris/uris {:rdf-base-uri #uri "https://example.org/data/"}
 
+ ;; Associate a context and path-info with the ring request.
+ ;; The request URI must be a subpath of the supplied context.
+ ;; NOT to be confused with the RDF Base URI (although it may match)
+ :tpximpact.datahost.ldapi/base-path ""
+
  :tpximpact.datahost.ldapi.jetty/runnable-service
  {:host "localhost"
   :port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port
@@ -18,8 +23,8 @@
  {:triplestore #ig/ref :tpximpact.datahost.ldapi.native-datastore/repo
   :clock #ig/ref :tpximpact.datahost.time/system-clock
   :change-store #ig/ref :tpximpact.datahost.ldapi.store.file/store
-  :system-uris #ig/ref :tpximpact.datahost.system-uris/uris}
+  :system-uris #ig/ref :tpximpact.datahost.system-uris/uris
+  :base-path #ig/ref :tpximpact.datahost.ldapi/base-path}
 
  :tpximpact.datahost.time/system-clock {}
-
  }

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi.clj
@@ -21,6 +21,9 @@
 
 (derive ::drafter-base-uri ::const)
 
+;; The application base path or mount point
+(derive ::base-path ::const)
+
 (defmethod ig/pre-init-spec ::default-catalog-id [_]
   string?)
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -4,6 +4,7 @@
    [buddy.auth.middleware :as buddy]
    [buddy.auth :refer [authenticated?]]
    [buddy.hashers :as hashers]
+   [clojure.spec.alpha :as s]
    [clojure.string :as str]
    [integrant.core :as ig]
    [reitit.dev.pretty :as pretty]
@@ -252,9 +253,9 @@
     (ring/create-default-handler))
    {:executor sieppari/executor}))
 
-;(defmethod ig/pre-init-spec :tpximpact.datahost.ldapi.router/handler [_]
-;  (s/keys :req-un [::clock ::triplestore ::change-store ::system-uris ::rdf-base-uri]
-;          :opt-un [::auth]))
+(defmethod ig/pre-init-spec :tpximpact.datahost.ldapi.router/handler [_]
+  (s/keys :req-un [::clock ::triplestore ::change-store ::system-uris ::base-path]
+          :opt-un [::auth]))
 
 (defmethod ig/init-key :tpximpact.datahost.ldapi.router/handler [_ opts]
   (handler opts))


### PR DESCRIPTION
More work addressing https://github.com/Swirrl/datahost-prototypes/issues/216
and relates to previous PRs https://github.com/Swirrl/datahost-prototypes/pull/221 & #224.

I do not plan to enable set the `:tpximpact.datahost.ldapi/base-path` key to a non empty string value at present, because some of the tests use hard-coded paths that would break. I will do some follow-up work to alter those tests.