### PR TITLE
ldapi: create snapshot CSV on ingest

### DIFF
--- a/datahost-ld-openapi/env/test/resources/test-system.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system.edn
@@ -1,7 +1,7 @@
 {:tpximpact.datahost.ldapi.jetty/http-port #int #or [#env "LD_API_HTTP_PORT" "3400"]
  :tpximpact.datahost.ldapi.native-datastore.repo/data-directory #or [#env "LD_API_TEST_DATA_DIR" "/tmp/ld-test-db"]
 
- :tpximpact.datahost.system-uris/uris {:rdf-base-uri #uri "https://crunk.org/foop/"}
+ :tpximpact.datahost.system-uris/uris {:rdf-base-uri #uri "https://crunk.org/data/"}
 
  :tpximpact.datahost.ldapi.test/http-client
  {:port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -100,21 +100,21 @@
       schema)))
 
 (defn get-revision
-  ([triplestore revision-uri]
-   (let [q (let [bgps [[revision-uri 'a :dh/Revision]
-                       [revision-uri :dcterms/title '?title]
-                       [revision-uri :dh/appliesToRelease '?release]]]
-             {:prefixes default-prefixes
-              :construct (conj bgps
-                               [revision-uri :dh/hasChange '?change]
-                               [revision-uri :dcterms/description '?description]
-                               [revision-uri :dh/revisionSnapshotCSV '?snapshot])
-              :where (conj bgps
-                           [:optional [[revision-uri :dh/hasChange '?change]]]
-                           [:optional [[revision-uri :dcterms/description '?description]]]
-                           [:optional [['?change :dh/revisionSnapshotCSV '?snapshot]]])})]
-     (datastore/eager-query triplestore
-                            (f/format-query q :pretty? true)))))
+  [triplestore revision-uri]
+  (let [q (let [bgps [[revision-uri 'a :dh/Revision]
+                      [revision-uri :dcterms/title '?title]
+                      [revision-uri :dh/appliesToRelease '?release]]]
+            {:prefixes default-prefixes
+             :construct (conj bgps
+                              [revision-uri :dh/hasChange '?change]
+                              [revision-uri :dcterms/description '?description]
+                              [revision-uri :dh/revisionSnapshotCSV '?snapshot])
+             :where (conj bgps
+                          [:optional [[revision-uri :dh/hasChange '?change]]]
+                          [:optional [[revision-uri :dcterms/description '?description]]]
+                          [:optional [['?change :dh/revisionSnapshotCSV '?snapshot]]])})]
+    (datastore/eager-query triplestore
+                           (f/format-query q :pretty? true))))
 
 (defn get-all-series
   "Returns all Series in triple from"
@@ -171,18 +171,18 @@
 
 (defn get-change
   "Returns a single Revision Change in triple form"
-  ([triplestore change-uri]
-   (->> (f/format-query (let [bgps [[change-uri 'a :dh/Change]
-                                    [change-uri :dcterms/description '?description]
-                                    [change-uri :dcterms/format '?format]
-                                    [change-uri :dh/updates '?updates]
-                                    [change-uri :dh/appliesToRevision '?revision]]
-                              snapshot-csv-tri [change-uri :dh/revisionSnapshotCSV '?snapshot]]
-                          {:prefixes default-prefixes
-                           :construct (conj bgps snapshot-csv-tri)
-                           :where (conj bgps [:optional [snapshot-csv-tri]])})
-                        :pretty? true)
-        (datastore/eager-query triplestore))))
+  [triplestore change-uri]
+  (->> (f/format-query (let [bgps [[change-uri 'a :dh/Change]
+                                   [change-uri :dcterms/description '?description]
+                                   [change-uri :dcterms/format '?format]
+                                   [change-uri :dh/updates '?updates]
+                                   [change-uri :dh/appliesToRevision '?revision]]
+                             snapshot-csv-tri [change-uri :dh/revisionSnapshotCSV '?snapshot]]
+                         {:prefixes default-prefixes
+                          :construct (conj bgps snapshot-csv-tri)
+                          :where (conj bgps [:optional [snapshot-csv-tri]])})
+                       :pretty? true)
+       (datastore/eager-query triplestore)))
 
 (defn- get-changes-info-query
   [release-uri max-rev]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -198,7 +198,7 @@
    :order-by ['(asc ?rev_number)]})
 
 (defn get-changes-info
-  "Returns records for all changess, optionally up to `?max-rev` (int)
+  "Returns records for all changes, optionally up to `?max-rev` (int)
   revision (inclusive).
 
   The returned seq will contain maps of shape
@@ -556,7 +556,7 @@
       {:message "Change already exists."})))
 
 (defn- previous-change-coords
-  "Given revision and change id, tries to find the preceeding change's
+  "Given revision and change id, tries to find the preceding change's
   revision and change ids. If not possible, indicates an extra DB
   lookup is needed.
 
@@ -572,7 +572,7 @@
     :else [(dec revision-id) :find]))
 
 (defn get-previous-change
-  "Returns the previouis change (as Quads), nil when no previous change existsts."
+  "Returns the previous change (as Quads), nil when no previous change exists."
   [triplestore system-uris  {:keys [revision-id change-id] :as params}]
   (let [revision-uri ^URI (su/dataset-revision-uri* system-uris params)
         [prev-rev-id c] (previous-change-coords revision-id change-id)]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -198,11 +198,11 @@
    :order-by ['(asc ?rev_number)]})
 
 (defn get-changes-info
-  "Returns records for all appends, optionally up to `?max-rev` (int)
+  "Returns records for all changess, optionally up to `?max-rev` (int)
   revision (inclusive).
 
   The returned seq will contain maps of shape
-       {:rev_num Number :rev URI :appends FILE-KEY :kind change-kind}"
+       {:rev_num Number :rev URI :updates FILE-KEY :kind change-kind}"
   ([triplestore release-uri] (get-changes-info triplestore release-uri nil))
   ([triplestore release-uri ?max-rev]
    {:pre [(some? release-uri) (or (nil? ?max-rev) (pos? ?max-rev))]}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.data.json :as json]
    [clojure.tools.logging :as log]
-   [grafter.vocabularies.rdf :as vocab.rdf]
    [grafter.matcha.alpha :as matcha]
    [ring.util.io :as ring-io]
    [tablecloth.api :as tc]
@@ -11,10 +10,13 @@
    [tpximpact.datahost.ldapi.db :as db]
    [tpximpact.datahost.ldapi.store :as store]
    [tpximpact.datahost.ldapi.json-ld :as json-ld]
+   [tpximpact.datahost.ldapi.handlers.internal :as internal]
    [tpximpact.datahost.ldapi.resource :as resource]
    [tpximpact.datahost.ldapi.routes.shared :as shared]
    [tpximpact.datahost.ldapi.schemas.api :as s.api]
-   [tpximpact.datahost.ldapi.util.data-validation :as data-validation])
+   [tpximpact.datahost.ldapi.util.data-validation :as data-validation]
+   [tpximpact.datahost.ldapi.util.triples
+    :refer [triples->ld-resource triples->ld-resource-collection]])
   (:import (java.net URI)))
 
 (defn- box [x]
@@ -35,57 +37,23 @@
     (fn [out-stream]
       (tc/write! tc-dataset out-stream {:file-type :csv}))))
 
-(defn triples->ld-resource
-  "Given triples returned from a DB query, transform them into a single resource
-   map (e.g. Release or Revision) that's ready for JSON serialization"
-  ([matcha-db]
-   (-> (matcha/build-1 [(keyword "@id") ?s]
-                       {?p ?o
-                        (keyword "@type") ?t}
-                       [[?s ?p ?o]
-                        (matcha/optional [[?s vocab.rdf/rdf:a ?t]])]
-                       matcha-db)
-       (dissoc vocab.rdf/rdf:a)))
-  ([matcha-db subject]
-   (-> (matcha/build-1 [(keyword "@id") ?s]
-                       {?p ?o
-                        (keyword "@type") ?t}
-                       [[?s ?p ?o]
-                        (matcha/optional [[?s vocab.rdf/rdf:a ?t]])
-                        (matcha/values ?s [subject])]
-                       matcha-db)
-       (dissoc vocab.rdf/rdf:a))))
-
-(defn triples->ld-resource-collection
-  "Given triples returned from a DB query, transform them into a collection of
-  resource maps (e.g. seq of Revisions) that are ready for JSON serialization"
-  ([matcha-db]
-   (->> (matcha/build [(keyword "@id") ?s]
-                      {?p ?o
-                       (keyword "@type") ?t}
-                      [[?s ?p ?o]
-                       (matcha/optional [[?s vocab.rdf/rdf:a ?t]])]
-                      matcha-db)
-        (map #(dissoc % vocab.rdf/rdf:a))))
-  ([matcha-db subject]
-   (->> (matcha/build [(keyword "@id") ?s]
-                      {?p ?o
-                       (keyword "@type") ?t}
-                      [(matcha/values ?s [subject])
-                       [?s ?p ?o]
-                       (matcha/optional [[?s vocab.rdf/rdf:a ?t]])]
-                      matcha-db)
-        (map #(dissoc % vocab.rdf/rdf:a)))))
+(defn- change-store-to-ring-io-writer
+  "Use as argument to `ring-io/piped-input-stream`."
+  [change-store data-key ^java.io.OutputStream out-stream]
+  (with-open [in ^java.io.InputStream (store/get-data change-store data-key)]
+    (.transferTo in out-stream)))
 
 (defn csv-file-locations->dataset [change-store append-keys]
-  (if (sequential? append-keys)
-    (some->> (remove nil? append-keys)
-             (map #(data-validation/as-dataset (store/get-data change-store %)
-                                               {:file-type :csv}))
-             (seq)
-             (apply tc/concat))
-    (some->> (store/get-data change-store append-keys)
-             (data-validation/as-dataset {:file-type :csv}))))
+  (let [as-dataset (fn [k]
+                     (with-open [is (store/get-data change-store k)]
+                       (data-validation/as-dataset is {:file-type :csv})))]
+   (if (sequential? append-keys)
+     (some->> (remove nil? append-keys)
+              (map as-dataset)
+              (seq)
+              (apply tc/concat))
+     (some->> (store/get-data change-store append-keys)
+              (as-dataset)))))
 
 (defn release->csv-stream [triplestore change-store release]
   (let [appends-file-keys (->> (db/get-changes-info triplestore (resource/id release) nil)
@@ -131,13 +99,17 @@
       (if (= accept "text/csv")
         (-> {:status 200
              :headers {"content-type" "text/csv"
-                       "content-disposition" "attachment; filename=release.csv"}
-             :body (or (release->csv-stream triplestore change-store release) "")}
+                       "content-disposition" "attachment ; filename=release.csv"}
+             :body (let [{:keys [data-key]} (db/get-release-snapshot-info triplestore system-uris path-params)]
+                     (when-not data-key (throw (ex-info "No CSV snapshot for release found."
+                                                        {:path-params path-params})))
+                     (ring-io/piped-input-stream (partial change-store-to-ring-io-writer change-store data-key)))}
             (shared/set-csvm-header request))
         (as-json-ld {:status 200
                      :body (-> (json-ld/compact release (json-ld/simple-context system-uris))
                                (.toString))}))
       not-found-response)))
+
 
 (defn put-release [clock triplestore system-uris {path-params :path-params
                                                   body-params :body-params :as request}]
@@ -203,28 +175,26 @@
       (write-dataset-to-outputstream merged-datasets))))
 
 (defn get-revision
-  [triplestore change-store system-uris
-   {{:keys [series-slug release-slug revision-id]} :path-params
-    {:strs [accept]} :headers :as request}]
+  [_triplestore change-store system-uris {{revision :dh/Revision} :datahost.request/entities
+                                          {:strs [accept]} :headers :as request}]
   (if (shared/csvm-request? request)
     (shared/csvm-request {:triplestore triplestore
                           :system-uris system-uris
                           :request request})
-    (if-let [revision-ld (->> (su/revision-uri system-uris series-slug release-slug revision-id)
-                              (db/get-revision triplestore)
-                              matcha/index-triples
-                              triples->ld-resource)]
+    (let [revision-ld (->> revision matcha/index-triples triples->ld-resource)]
       (if (= accept "text/csv")
         (-> {:status 200
              :headers {"content-type" "text/csv"
                        "content-disposition" "attachment ; filename=revision.csv"}
-             :body (or (revision->csv-stream triplestore change-store revision-ld) "")}
+             :body (let [key (get revision-ld (cmp/expand :dh/revisionSnapshotCSV))]
+                     (when (nil? key)
+                       (throw (ex-info "No snapshot reference for revision" {:revision revision})))
+                     (ring-io/piped-input-stream (partial change-store-to-ring-io-writer change-store key)))}
             (shared/set-csvm-header request))
 
         (as-json-ld {:status 200
                      :body (-> (json-ld/compact revision-ld (json-ld/simple-context system-uris))
-                               (.toString))}))
-      not-found-response)))
+                               (.toString))})))))
 
 (defn- wrap-ld-collection-contents [coll]
   {"https://publishmydata.com/def/datahost/collection-contents" coll})
@@ -279,69 +249,80 @@
                                                                   body-params (su/rdf-base-uri system-uris)
                                                                   release-uri revision-uri next-revision-id)]
         (as-json-ld {:status 201
-                     :headers {"Location" (format "/data/%s/releases/%s/revisions/%s"
-                                                  series-slug release-slug resource-id)}
+                     :headers {"Location" (.getPath revision-uri)}
                      :body jsonld-doc}))
 
       {:status 422
        :body "Release for this revision does not exist"})))
 
-(defn- dataset-validation-error!
-  "Returns nil on success, error response on validation failure."
+(defn- validate-incoming-change-data
+  "Returns a map {:dataset DATASET (optional-key :error-response) ...},
+  containing :error-response entry when validation failed."
   [release-schema appends]
-  (try
-    (let [dataset (data-validation/as-dataset (:tempfile appends) {})
-          schema (data-validation/make-row-schema release-schema)
-          {:keys [explanation]} (data-validation/validate-dataset dataset schema
-                                                                  {:fail-fast? true})]
-      (when (some? explanation)
-        {:status 400
-         :body explanation}))))
+  (let [dataset (data-validation/as-dataset (:tempfile appends) {})
+        schema (data-validation/make-row-schema release-schema)
+        {:keys [explanation]} (data-validation/validate-dataset dataset schema
+                                                                {:fail-fast? true})]
+    (cond-> {:dataset dataset}
+      (some? explanation) (assoc :error-response {:status 400 :body explanation}))))
 
-(defn post-change [triplestore
-                   change-store
-                   system-uris
-                   change-kind
-                   {{:keys [series-slug release-slug revision-id]} :path-params
-                    {{:keys [appends]} :multipart} :parameters ;TODO: change 'appends' to ??
-                    jsonld-doc :body-params :as request}]
-  (let [change-uri ^URI (su/change-uri system-uris series-slug release-slug revision-id 1)]
-    (if (db/resource-exists? triplestore change-uri)
-      {:status 422
-       :body "A change is already associated with the revision."}
+(defn post-change
+  [triplestore
+   change-store
+   system-uris
+   change-kind
+   {path-params :path-params
+    {{:keys [appends]} :multipart} :parameters ;TODO: change 'appends' to ??
+    input-jsonld-doc :body-params
+    {release-uri :dh/Release :as request-uris} :datahost.request/uris
+    :as request}]
+  (let [change-id 1
+        change-uri ^URI (su/change-uri* system-uris (assoc path-params :change-id change-id))
+        ;; validate incoming data
+        release-schema (db/get-release-schema triplestore release-uri)
+        {validation-err :error-response
+         change-ds :dataset} (some-> release-schema (validate-incoming-change-data appends))
+        ;; insert relevant triples
+        insert-req (store/make-insert-request! change-store (:tempfile appends))
+        {:keys [jsonld-doc resource-id message]} (when-not validation-err
+                                                   (db/insert-change! triplestore
+                                                                      system-uris
+                                                                      {:api-params (get-api-params request)
+                                                                       :ld-root (su/rdf-base-uri system-uris)
+                                                                       :jsonld-doc input-jsonld-doc
+                                                                       :store-key (:key insert-req)
+                                                                       :change-uri change-uri
+                                                                       :datahost.change/kind change-kind
+                                                                       :datahost.request/uris request-uris}))]
+    (assert (= resource-id change-id))
+    (log/info (format "post-change: '%s' validation: found-schema? = %s, change-valid? = %s, insert-ok? = %s"
+                      (.getPath change-uri) (some? release-schema) (nil? validation-err) (nil? message)))
+    (cond
+      (some? validation-err) validation-err
 
-      (let [api-params (get-api-params request)
-            insert-req (store/make-insert-request! change-store (:tempfile appends))
-            release-schema (db/get-release-schema triplestore (su/dataset-release-uri* system-uris api-params))
-            validation-err (when (some? release-schema)
-                             (dataset-validation-error! release-schema appends))
-            ; one change append per revision
-            change-number 1
-            {:keys [jsonld-doc resource-id message]} (when-not validation-err
-                                                       (db/insert-change! triplestore
-                                                                          {:api-params api-params
-                                                                           :jsonld-doc jsonld-doc
-                                                                           :insert-request insert-req
-                                                                           :datahost.change/kind change-kind
-                                                                           :ld-root (su/rdf-base-uri system-uris)
-                                                                           :revision-uri (su/dataset-revision-uri* system-uris api-params)
-                                                                           :change-uri (su/change-uri system-uris series-slug release-slug revision-id change-number)}))]
-        (log/info (format "post-change: '%s' validation: found-schema? = %s change-valid? = %s"
-                          (.getPath change-uri) (some? release-schema) (nil? validation-err)))
-        (cond
-          (some? validation-err) validation-err
+      (some? message) {:status 422 :body message}
 
-          (some? message) {:status 422 :body message}
+      :else
+      (do
+        (store/request-data-insert change-store insert-req)
+        (log/debug (format "post-change: '%s' stored-change: '%s'" (.getPath change-uri) (:key insert-req)))
 
-          :else-success
-          (do
-            (store/request-data-insert change-store insert-req)
-            (log/debug (format "post-change: %s stored-change '%s'" (.getPath change-uri) (:key insert-req)))
+        (let [{:keys [new-snapshot-key]} (internal/post-change--generate-csv-snapshot
+                                          {:triplestore triplestore
+                                           :change-store change-store
+                                           :system-uris system-uris}
+                                          {:path-params path-params
+                                           :change-kind change-kind
+                                           :change-id change-id
+                                           :dataset change-ds
+                                           "dcterms:format" (get input-jsonld-doc "dcterms:format")})]
+          (log/debug (format "post-change: '%s' stored snapshot" (.getPath change-uri))
+                     {:new-snapshot-key new-snapshot-key})
+          (db/tag-with-snapshot triplestore change-uri {:dh/revisionSnapshotCSV new-snapshot-key}))
 
-            (as-json-ld {:status 201
-                         :headers {"Location" (format "/data/%s/releases/%s/revisions/%s/changes/%s"
-                                                      series-slug release-slug revision-id resource-id)}
-                         :body jsonld-doc})))))))
+        (as-json-ld {:status 201
+                     :headers {"Location" (.getPath change-uri)}
+                     :body jsonld-doc})))))
 
 (defn change->csv-stream [change-store change]
   (let [appends (get change (cmp/expand :dh/updates))]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -45,8 +45,8 @@
 
 (defn csv-file-locations->dataset [change-store append-keys]
   (let [as-dataset (fn [k]
-                     (with-open [is (store/get-data change-store k)]
-                       (data-validation/as-dataset is {:file-type :csv})))]
+                     (with-open [in (store/get-data change-store k)]
+                       (data-validation/as-dataset in {:file-type :csv})))]
    (if (sequential? append-keys)
      (some->> (remove nil? append-keys)
               (map as-dataset)
@@ -304,9 +304,11 @@
 
       :else
       (do
+        ;; store the change
         (store/request-data-insert change-store insert-req)
         (log/debug (format "post-change: '%s' stored-change: '%s'" (.getPath change-uri) (:key insert-req)))
 
+        ;; generate and store the dataset snapshot
         (let [{:keys [new-snapshot-key]} (internal/post-change--generate-csv-snapshot
                                           {:triplestore triplestore
                                            :change-store change-store

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers/internal.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers/internal.clj
@@ -68,7 +68,7 @@
         insert-request (store/make-insert-request! change-store is)]
 
     (store/request-data-insert change-store insert-request)
-    (log/debug "post-change--generate-csv-shapshot:" path-params
+    (log/debug "post-change--generate-csv-snapshot:" path-params
                {:snapshot-rows (tc/row-count ds)
                 :bytes-written (.size os)
                 :snapshot-key (:key insert-request)})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers/internal.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers/internal.clj
@@ -1,0 +1,77 @@
+(ns tpximpact.datahost.ldapi.handlers.internal
+  "Functions in this namespace shouldn't be used outside
+  `tpximpact.datahost.ldapi.handlers` namespace."
+  (:require
+   [clojure.tools.logging :as log]
+   [grafter.matcha.alpha :as matcha]
+   [malli.core :as m]
+   [tablecloth.api :as tc]
+   [tpximpact.datahost.ldapi.db :as db]
+   [tpximpact.datahost.ldapi.compact :as cmp]
+   [tpximpact.datahost.ldapi.schemas.common :as s.common]
+   [tpximpact.datahost.ldapi.store :as store]
+   [tpximpact.datahost.ldapi.util.data-compilation :as data-compilation]
+   [tpximpact.datahost.ldapi.util.triples
+    :refer [triples->ld-resource]])
+  (:import
+   [java.io ByteArrayInputStream ByteArrayOutputStream]))
+
+
+(defn- previous-dataset-snapshot-key
+  "Returns a  [[store/ChangeStore]] key for the previous revision+change, or nil.
+  
+  Throws when previous change exists but does not
+  contain :dh/revisionSnapshotCSV."
+  [{:keys [triplestore system-uris]} params]
+  (let [prev-change (db/get-previous-change triplestore system-uris
+                                            (update params :revision-id #(Long/parseLong %)))
+        prev-change (some-> prev-change matcha/index-triples triples->ld-resource)
+        prev-ds-snapshot-key (get prev-change (cmp/expand :dh/revisionSnapshotCSV))]
+    ;; we have previous change but no snapshot? how did we get into that state?
+    (when (and prev-change (not prev-ds-snapshot-key))
+      (throw (ex-info "Previous change has no snapshot file."
+                      {:path-params params :previous-change prev-change})))
+    prev-ds-snapshot-key))
+
+(defn- ->change-info
+  [data-ref kind fmt]
+  (assert data-ref)
+  {:datahost.change.data/ref data-ref
+   :datahost.change/kind kind
+   :datahost.change.data/format fmt})
+
+(defn post-change--generate-csv-snapshot
+  "Returns a map  {:new-snapshot-key ... (optional-key :previous-snapshot-key) ...}.
+
+  Throws when we found previous change, but there's no CSV snapshot
+  associated with it.
+
+  Generates new dataset snapshot and stores it in change-store.
+  
+  Assumptions:
+  - the incoming change's (CSV) dataset fits in memory
+  - the existing dataset snapshot fits in memory
+  - the new snapshot (existing snapshot + changes) fits in memory."
+  [{:keys [triplestore change-store system-uris] :as sys}
+   {:keys [change-id change-kind path-params] change-ds :dataset :as change-info}]
+  {:pre [(m/validate s.common/ChangeKind change-kind) (contains? change-info "dcterms:format")]}
+  (let [prev-ds-snapshot-key (previous-dataset-snapshot-key sys (assoc path-params :change-id change-id))
+        change-ds-fmt (get change-info "dcterms:format")
+        changes (if prev-ds-snapshot-key
+                  [(->change-info prev-ds-snapshot-key :dh/ChangeKindAppend "text/csv")
+                   (->change-info change-ds change-kind change-ds-fmt)]
+                  [(->change-info change-ds change-kind change-ds-fmt)])
+        os ^ByteArrayOutputStream (ByteArrayOutputStream.)
+        ds (data-compilation/compile-dataset {:changes changes :store change-store})
+        _ (tc/write! ds os {:file-type :csv})
+        is ^ByteArrayInputStream (ByteArrayInputStream. (.toByteArray os))
+        insert-request (store/make-insert-request! change-store is)]
+
+    (store/request-data-insert change-store insert-request)
+    (log/debug "post-change--generate-csv-shapshot:" path-params
+               {:snapshot-rows (tc/row-count ds)
+                :bytes-written (.size os)
+                :snapshot-key (:key insert-request)})
+
+    (cond-> {:new-snapshot-key (:key insert-request)}
+      prev-ds-snapshot-key (assoc :previous-snapshot-key prev-ds-snapshot-key))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -4,6 +4,7 @@
    [malli.error :as me]
    [tpximpact.datahost.ldapi.db :as db]
    [tpximpact.datahost.system-uris :refer [resource-uri] :as su]
+   [tpximpact.datahost.ldapi.routes.shared :as shared]
    [tpximpact.datahost.ldapi.schemas.common :as s.common]))
 
 (def not-found-response
@@ -126,3 +127,12 @@
              :body {:query-params query-errors}}
             (handler request)))))))
 
+
+(defn csvm-request-response
+  [triplestore system-uris handler _id]
+  (fn [request]
+    (if (shared/csvm-request? request)
+      (shared/csvm-request {:triplestore triplestore
+                            :system-uris system-uris
+                            :request request})
+      (handler request))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -63,7 +63,7 @@
       (handler request))))
 
 (defn resource-already-created?
-  "Checks wether resource already exists and short-circuits with 422
+  "Checks whether resource already exists and short-circuits with 422
   response if it does.
 
   Options:

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -3,7 +3,12 @@
    [malli.core :as m]
    [malli.error :as me]
    [tpximpact.datahost.ldapi.db :as db]
-   [tpximpact.datahost.system-uris :refer [resource-uri]]))
+   [tpximpact.datahost.system-uris :refer [resource-uri] :as su]
+   [tpximpact.datahost.ldapi.schemas.common :as s.common]))
+
+(def not-found-response
+  {:status 404
+   :body "Not found"})
 
 (defn json-only
   "Middleware that requires the request to pass 'Content-Type: application/json'.
@@ -17,6 +22,33 @@
         {:status 406
          :body "not acceptable"}))))
 
+(defn entity-uris-from-path
+  [system-uris entities handler _id]
+  {:pre [(m/validate [:set s.common/EntityType] entities)]}
+  (fn entity-uris [request]
+    (let [uris (reduce (fn [r entity]
+                         (assoc! r entity (su/resource-uri entity system-uris (:path-params request))))
+                       (transient {})
+                       entities)]
+     (handler (assoc request :datahost.request/uris (persistent! uris))))))
+
+(defn entity-or-not-found
+  "If found, puts the entity under [:datahost.request/entities entity-kw],
+  short-circuits with 404 response otherwise."
+  [triplestore system-uris entity-kw handler _id]
+  {:pre [(m/validate s.common/EntityType entity-kw)]}
+  (fn inner [{:keys [path-params]:as request}]
+    (let [{:keys [series-slug release-slug revision-id change-id]} path-params
+          uri (resource-uri entity-kw system-uris path-params)
+          entity (case entity-kw
+                   :dh/DatasetSeries (db/get-dataset-series triplestore uri)
+                   :dh/Release (db/get-release-by-uri triplestore uri)
+                   :dh/Revision (db/get-revision triplestore uri)
+                   :dh/Change (db/get-change triplestore uri))]
+      (if entity
+        (handler (assoc-in request [:datahost.request/entities entity-kw] entity))
+        not-found-response))))
+
 (defn resource-exist?
   "Checks whether resource exists and short-circuits with 404 response if
   not.
@@ -29,13 +61,29 @@
       {:status 404 :body "not found"}
       (handler request))))
 
+(defn resource-already-created?
+  "Checks wether resource already exists and short-circuits with 422
+  response if it does.
+
+  Options:
+
+  - :resource - :dh/DataSeries etc
+  - :missing-params - map of params possibly missing from path
+  params (e.g. when the request generates an ID)"
+  [triplestore system-uris {:keys [resource missing-params]} handler _id]
+  {:pre [(m/validate s.common/EntityType resource)]}
+  (fn created? [{:keys [path-params] :as request}]
+    (if (db/resource-exists? triplestore (resource-uri resource system-uris (merge path-params missing-params)))
+      {:status 422 :body "Resource already exists"}
+      (handler request))))
+
 (defn flag-resource-exists
   "Adds a boolean flag to the request under resource-id, when
   the given resource exists.
 
   - resource: [:enum :dh/DatasetSeries :dh/Release :dh/Revision :dh/Change]"
   [triplestore system-uris resource resource-id handler _id]
-  {:pre [(m/validate [:enum :dh/DatasetSeries :dh/Release :dh/Revision :dh/Change] resource)]}
+  {:pre [(m/validate s.common/EntityType resource)]}
   (fn [{:keys [path-params] :as request}]
     (handler (cond-> request
                (db/resource-exists? triplestore (resource-uri resource system-uris path-params))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -12,6 +12,8 @@
 (defn get-release-route-config [triplestore change-store system-uris]
   {:summary "Retrieve metadata for an existing release"
    :handler (partial handlers/get-release triplestore change-store system-uris)
+   :middleware [[(partial middleware/csvm-request-response triplestore system-uris) :csvm-response]
+                [(partial middleware/entity-uris-from-path system-uris #{:dh/Release}) :entity-uris]]
    :coercion (rcm/create {:transformers {}, :validate false})
    :parameters {:path {:series-slug string?
                        :release-slug string?}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -10,8 +10,10 @@
   {:summary "Retrieve metadata or CSV contents for an existing revision"
    :coercion (rcm/create {:transformers {}, :validate false})
    :handler (partial handlers/get-revision triplestore change-store system-uris)
-   :middleware [[(partial middleware/entity-or-not-found triplestore system-uris :dh/Revision)
-                 :entity-or-not-found]]
+   :middleware [[(partial middleware/csvm-request-response triplestore system-uris) :csvm-response]
+                [(partial middleware/entity-or-not-found triplestore system-uris :dh/Revision)
+                 :entity-or-not-found]
+                [(partial middleware/entity-uris-from-path system-uris #{:dh/Release}) :entity-uris]]
    :parameters {:path {:series-slug string?
                        :release-slug string?
                        :revision-id int?}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -10,6 +10,8 @@
   {:summary "Retrieve metadata or CSV contents for an existing revision"
    :coercion (rcm/create {:transformers {}, :validate false})
    :handler (partial handlers/get-revision triplestore change-store system-uris)
+   :middleware [[(partial middleware/entity-or-not-found triplestore system-uris :dh/Revision)
+                 :entity-or-not-found]]
    :parameters {:path {:series-slug string?
                        :release-slug string?
                        :revision-id int?}}
@@ -71,7 +73,12 @@
 (defn changes-route-base [triplestore change-store system-uris change-kind]
   {:handler (partial handlers/post-change triplestore change-store system-uris change-kind)
    :middleware [[middleware/json-only :json-only]
-                [(partial middleware/resource-exist? triplestore system-uris :dh/Revision) :resource-exists?]]
+                [(partial middleware/entity-uris-from-path system-uris #{:dh/Release :dh/Revision}) :entity-uris]
+                [(partial middleware/resource-exist? triplestore system-uris :dh/Revision) :resource-exists?]
+                [(partial middleware/resource-already-created?
+                          triplestore system-uris
+                          {:resource :dh/Change :missing-params {:change-id 1}} )
+                 :resource-already-created?]]
    :parameters {:multipart [:map [:appends reitit.ring.malli/temp-file-part]]
                 :body routes-shared/CreateChangeInput
                 :path {:series-slug string?

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
@@ -42,3 +42,7 @@
    (m/base-schemas)
    (m/type-schemas)
    custom-registry-keys))
+
+(def EntityType [:enum :dh/DatasetSeries :dh/Release :dh/Revision :dh/Change])
+
+(def ChangeKind [:enum :dh/ChangeKindAppend :dh/ChangeKindRetract])

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
@@ -51,5 +51,7 @@
   (-data-key store data))
 
 (defn make-insert-request!
+  "Creates an insert request. This can be a potentially be an expensive
+  operation. Data can be a File, InputStream, etc."
   [store data]
   (->InsertRequest data (data-key store data)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/file.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/file.clj
@@ -74,7 +74,7 @@
   (-get-data [_this data-key]
     (let [location (file-location root-dir (.toString data-key))]
       (if (.exists location)
-        (io/input-stream location)      ;TODO: verify the strem is closed in all call sites
+        (io/input-stream location)
         (throw (ex-info "Data not found for key" {:key data-key})))))
 
   (-data-key [_this data]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/file.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/file.clj
@@ -1,6 +1,7 @@
 (ns tpximpact.datahost.ldapi.store.file
   "Namespace for implementing a store for change data which uses the file system"
   (:require
+    [clojure.tools.logging :as log]
     [clojure.java.io :as io]
     [integrant.core :as ig]
     [tpximpact.datahost.ldapi.store :as store])
@@ -12,19 +13,33 @@
 (defn- consume-input-stream
   "Reads an input stream to the end"
   [^InputStream is]
-  (let [buf (byte-array 4096)]
+  (let [buf (byte-array 2048)]
     (loop []
       (let [bytes-read (.read is buf)]
         (when-not (= -1 bytes-read)
           (recur))))))
 
+(defn- maybe-reset-stream
+  [input]
+  (when (instance? java.io.InputStream input)
+    (let [is ^java.io.InputStream input]
+      (.reset is))))
+
 (defn- file->digest
-  "Computes a file digest as a string for a file with the named digest
-   algorithm"
-  [file digest-alg]
+  "Computes a file digest as a string for input with the named digest
+   algorithm.
+
+  'input' can be whatever [[io/input-stream]] can handle."
+  [input digest-alg]
   (let [digest (MessageDigest/getInstance digest-alg)]
-    (with-open [is (DigestInputStream. (io/input-stream file) digest)]
+    (with-open [is (DigestInputStream. (io/input-stream input) digest)]
       (consume-input-stream is)
+      ;; we expect the caller `store/make-insert-request!` to supply a
+      ;; stream that should be used repeatedly. At least 2 times:
+      ;; 1. to calculate the digest 2. write it to file.
+      ;; So we reset it here. If the InputStream implementation
+      ;; throws on .reset(), it's probably a mistake to use it here
+      (maybe-reset-stream input)
       (let [^bytes bytes (.digest digest)]
         (.formatHex (HexFormat/of) bytes)))))
 
@@ -39,26 +54,28 @@
 
 (defrecord FileChangeStore [root-dir]
   store/ChangeStore
-  (-insert-data-with-request [this request]
-    (let [file-digest (:key request)
-          location (file-location root-dir file-digest)]
+  (-insert-data-with-request [_ request]
+    (let [{data :data digest :key} request
+          _ (assert digest)
+          location (file-location root-dir digest)]
       (when-not (.exists location)
         (.mkdirs (.getParentFile location))
         ;; copy input file into temp location within store then rename to
         ;; final destination
         (let [store-temp (File/createTempFile "filestore" nil root-dir)]
           (io/copy (:data request) store-temp)
-          (.renameTo store-temp location)))
-      file-digest))
+          (.renameTo store-temp location)
+          (log/debug  "-insert-data-with-request" {:type (type data) :key digest})))
+      digest))
   
   (-insert-data [this {:keys [tempfile]}]
     (store/-insert-data-with-request this (store/make-insert-request! this tempfile)))
 
-  (-get-data [_this append-key]
-    (let [location (file-location root-dir (.toString append-key))]
+  (-get-data [_this data-key]
+    (let [location (file-location root-dir (.toString data-key))]
       (if (.exists location)
-        (io/input-stream location)
-        (throw (ex-info "Append not found for key" {:key append-key})))))
+        (io/input-stream location)      ;TODO: verify the strem is closed in all call sites
+        (throw (ex-info "Data not found for key" {:key data-key})))))
 
   (-data-key [_this data]
     (file->digest data "SHA-256")))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
@@ -23,7 +23,9 @@
    (as-dataset is opts)))
 
 (def dataset-input-type-valid? (m/validator [:or
+                                             ;; specify :type in metadata
                                              [:qualified-keyword]
+                                             ;; or we can accept an object of some class
                                              [:fn #(instance? java.lang.Class %)]]))
 
 (def ChangeInfo

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
@@ -198,10 +198,14 @@
 (defmethod -as-dataset java.io.BufferedInputStream [^java.io.BufferedInputStream v opts]
   (slurpable->dataset v opts))
 
+(defmethod -as-dataset :datahost.types/seq-of-maps [v _opts]
+  (tc/dataset v))
+
 (def AsDatasetOpts
   [:map
    [:file-type {:optional true} [:enum :csv]]
-   [:encoding {:optional true} [:enum "UTF-8"]]])
+   [:encoding {:optional true} [:enum "UTF-8"]]
+   [:store {:optional true} [:fn some?]]])
 
 (def ^:private as-dataset-opts-valid? (m/validator AsDatasetOpts))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/triples.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/triples.clj
@@ -1,0 +1,46 @@
+(ns tpximpact.datahost.ldapi.util.triples
+  (:require
+   [grafter.matcha.alpha :as matcha]
+   [grafter.vocabularies.rdf :as vocab.rdf]))
+
+(defn triples->ld-resource
+  "Given triples returned from a DB query, transform them into a single resource
+   map (e.g. Release or Revision) that's ready for JSON serialization"
+  ([matcha-db]
+   (-> (matcha/build-1 [(keyword "@id") ?s]
+                       {?p ?o
+                        (keyword "@type") ?t}
+                       [[?s ?p ?o]
+                        (matcha/optional [[?s vocab.rdf/rdf:a ?t]])]
+                       matcha-db)
+       (dissoc vocab.rdf/rdf:a)))
+  ([matcha-db subject]
+   (-> (matcha/build-1 [(keyword "@id") ?s]
+                       {?p ?o
+                        (keyword "@type") ?t}
+                       [[?s ?p ?o]
+                        (matcha/optional [[?s vocab.rdf/rdf:a ?t]])
+                        (matcha/values ?s [subject])]
+                       matcha-db)
+       (dissoc vocab.rdf/rdf:a))))
+
+(defn triples->ld-resource-collection
+  "Given triples returned from a DB query, transform them into a collection of
+  resource maps (e.g. seq of Revisions) that are ready for JSON serialization"
+  ([matcha-db]
+   (->> (matcha/build [(keyword "@id") ?s]
+                      {?p ?o
+                       (keyword "@type") ?t}
+                      [[?s ?p ?o]
+                       (matcha/optional [[?s vocab.rdf/rdf:a ?t]])]
+                      matcha-db)
+        (map #(dissoc % vocab.rdf/rdf:a))))
+  ([matcha-db subject]
+   (->> (matcha/build [(keyword "@id") ?s]
+                      {?p ?o
+                       (keyword "@type") ?t}
+                      [(matcha/values ?s [subject])
+                       [?s ?p ?o]
+                       (matcha/optional [[?s vocab.rdf/rdf:a ?t]])]
+                      matcha-db)
+        (map #(dissoc % vocab.rdf/rdf:a)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
@@ -84,7 +84,7 @@
       (assert change-id)
       (.resolve base-uri (change-key base-uri series-slug release-slug revision-id change-id)))
 
-    (change-uri* [this {:keys [series-slug release-slug revision-id change-id]}]
+    (change-uri* [_this {:keys [series-slug release-slug revision-id change-id]}]
       (assert change-id)
       (.resolve base-uri (change-key base-uri series-slug release-slug revision-id change-id)))))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
@@ -1,4 +1,14 @@
 (ns tpximpact.datahost.system-uris
+  "Contains few families of functions for creating resource
+  keys (strings) or URIs. Also a generic `resource-uri` fn
+  (and associated multimethod `-resource-uri` that accepts can
+  construct an URI from a map of path params.
+  
+  
+  - 'dataset-[series|release|revision]-uri' - ctors taking individual
+  ids as arguments
+  - 'dataset-[series|release|revision]-uri*'- ctors taking a map
+  as argument"
   (:require [integrant.core :as ig])
   (:import (java.net URI)))
 
@@ -38,7 +48,9 @@
 
   (dataset-revision-uri* [this api-params])
 
-  (change-uri [this series-slug release-slug revision-id change-id]))
+  (change-uri [this series-slug release-slug revision-id change-id])
+
+  (change-uri* [this api-params]))
 
 (defn make-system-uris
   "Returns an object that builds URIs based upon the configured RDF base URI"
@@ -69,6 +81,10 @@
       (URI. (format "%s/releases/%s/revisions/%s" (dataset-series-uri this series-slug) release-slug revision-id)))
 
     (change-uri [_ series-slug release-slug revision-id change-id]
+      (assert change-id)
+      (.resolve base-uri (change-key base-uri series-slug release-slug revision-id change-id)))
+
+    (change-uri* [this {:keys [series-slug release-slug revision-id change-id]}]
       (assert change-id)
       (.resolve base-uri (change-key base-uri series-slug release-slug revision-id change-id)))))
 

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -236,15 +236,14 @@
                                    "dcterms:description" "Description"})})
 
       (testing "Fetching a release csv that does exist works"
-        (let [response (GET release-1-path {:headers {"accept" "text/csv"}})]
+        (let [response (GET release-1-path {:headers {"accept" "text/csv"}})
+              [_ _ path :as v] (re-find #"<http:\/\/(.+):\d+(\S+)>; rel=\"describedBy\"; type=\"application\/csvm\+json\""
+                                        (get-in response [:headers "link"]))]
           (is (= 200 (:status response)))
           ;; (is (not (empty? (:body response))))
           ;; TODO: what is the csv release meant to be? `""` empty string
           ;; seems off when the json returns something not-nil
-          (is (= (str "<http://localhost:3400" release-1-csvm-path ">; "
-                      "rel=\"describedBy\"; "
-                      "type=\"application/csvm+json\""),
-                 (get-in response [:headers "link"])))))
+          (is (= release-1-csvm-path path))))
 
       (testing "Fetching csvm for release that does exist works"
         (let [response (GET release-1-csvm-path)

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -421,7 +421,6 @@
         (let [response (GET revision-1-path {:headers {"accept" "text/csv"}})
               [_ _ path :as v] (re-find #"<http:\/\/(.+):\d+(\S+)>; rel=\"describedBy\"; type=\"application\/csvm\+json\""
                                         (get-in response [:headers "link"]))]
-          (tap> {:v v})
           (is (= 200 (:status response)))
           ;; (is (not (empty? (:body response))))
           ;; TODO: what is the csv release meant to be? `""` empty string
@@ -430,7 +429,6 @@
 
       (testing "Fetching csvm for revision that does exist works"
         (let [response (GET revision-1-csvm-path)
-              _ (tap> (:body response)) 
               body (json/read-str (:body response))]
           (is (= 200 (:status response)))
           (is (= {"@context" ["http://www.w3.org/ns/csvw" {"@language" "en"}]}

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -417,20 +417,23 @@
           (is (= 404 status))
           (is (= "Not found" body))))
 
-      (testing "Fetching a release csv that does exist works"
-        (let [response (GET revision-1-path {:headers {"accept" "text/csv"}})]
+      (testing "Fetching a revision csv that does exist works"
+        (let [response (GET revision-1-path {:headers {"accept" "text/csv"}})
+              [_ _ path :as v] (re-find #"<http:\/\/(.+):\d+(\S+)>; rel=\"describedBy\"; type=\"application\/csvm\+json\""
+                                        (get-in response [:headers "link"]))]
+          (tap> {:v v})
           (is (= 200 (:status response)))
           ;; (is (not (empty? (:body response))))
           ;; TODO: what is the csv release meant to be? `""` empty string
           ;; seems off when the json returns something not-nil
-          (is (= (str "<http://localhost:3400" revision-1-csvm-path ">; "
-                      "rel=\"describedBy\"; "
-                      "type=\"application/csvm+json\""),
-                 (get-in response [:headers "link"])))))
+          (is (= revision-1-csvm-path path))))
 
-      (testing "Fetching csvm for release that does exist works"
+      (testing "Fetching csvm for revision that does exist works"
         (let [response (GET revision-1-csvm-path)
+              _ (tap> (:body response)) 
               body (json/read-str (:body response))]
           (is (= 200 (:status response)))
           (is (= {"@context" ["http://www.w3.org/ns/csvw" {"@language" "en"}]}
                  body)))))))
+
+

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -254,7 +254,6 @@
                                                      :body (json/write-str change-ednld)})
                     new-change-resource-location (-> change-api-response :headers (get "Location"))]
 
-
                 (is (= 201 (:status change-api-response)))
                 (is (= (str new-revision-location "/changes/1")
                        new-change-resource-location)
@@ -282,7 +281,7 @@
                 (is (= 422 (:status change-api-response)))
                 (is (nil? new-change-resource-location))))
 
-            (testing "Fetching Revision as CSV with multiple CSV append changes"
+            (testing "Fetching Revision as CSV after 'appending' a single CSV"
               (let [response (GET new-revision-location {:headers {"accept" "text/csv"}})
                     resp-body-seq (line-seq (BufferedReader. (StringReader. (:body response))))]
                 (is (= 200 (:status response)))
@@ -291,7 +290,6 @@
                        (count resp-body-seq))
                     "responds with concatenated changes from both CSVs")
                 (is (= (first resp-body-seq) (first csv-2020-seq)))
-                ;;(is (= (second resp-body-seq) (second csv-2020-seq)))
                 (is (str/includes? (last resp-body-seq) ",2019,")))))
 
           (testing "Creation of a second revision for a release"
@@ -305,6 +303,7 @@
                   new-revision-location-2 (-> revision-resp-2 :headers (get "Location"))]
 
               (is (= 201 (:status revision-resp-2)))
+              (is (re-find #".*\/revisions\/2" inserted-revision-id-2))
               (is (str/ends-with? new-revision-location-2 inserted-revision-id-2)
                   "Created with the resource URI provided in the Location header")
 
@@ -322,6 +321,7 @@
                                       "/changes/1"))))
 
               (testing "Fetching Release as CSV with multiple Revision and CSV append changes"
+                
                 (let [response (GET release-url {:headers {"accept" "text/csv"}})
                       resp-body-seq (line-seq (BufferedReader. (StringReader. (:body response))))
                       valid-row-sample "Aged 16 to 64 years level 3 or above qualifications,Merseyside,2021,59.6,per cent,62.7,56.5,"]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -168,7 +168,6 @@
                             {:content-type :json
                                   :body (json/write-str request-ednld)})
               resp-body (json/read-str (:body response))]
-          (println response)
           (is (= 200 (:status response)))
           (is (not= (Instant/parse (get resp-body "dcterms:issued"))
                     (Instant/parse (get resp-body "dcterms:modified")))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/temp_file_store.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/temp_file_store.clj
@@ -1,10 +1,9 @@
 (ns tpximpact.datahost.ldapi.store.temp-file-store
-  (:require [clojure.test :as t]
-            [integrant.core :as ig]
+  (:require [integrant.core :as ig]
             [tpximpact.datahost.ldapi.files :as files]
             [tpximpact.datahost.ldapi.store :as store]
             [tpximpact.datahost.ldapi.store.file :as fstore])
-  (:import [java.lang AutoCloseable]))
+  (:import (java.lang AutoCloseable)))
 
 (defrecord TempFileStore [file-store]
   store/ChangeStore

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_compilation_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_compilation_test.clj
@@ -15,9 +15,9 @@
                    {:datahost.change.data/ref (with-meta (mapv item r) {:type :datahost.types/seq-of-maps})
                     :datahost.change.data/format "native"
                     :datahost.change/kind kind})]
-    {1 (ds-input (range 4) :datahost.change.kind/append)
-     2 (ds-input (range 4 10) :datahost.change.kind/append)
-     3 (ds-input (range 8 10) :datahost.change.kind/retract)}))
+    {1 (ds-input (range 4) :dh/ChangeKindAppend)
+     2 (ds-input (range 4 10) :dh/ChangeKindAppend)
+     3 (ds-input (range 8 10) :dh/ChangeKindRetract)}))
 
 (defn data-record-count [k]
   (count (:datahost.change.data/ref (get data k))))


### PR DESCRIPTION
To enable instantenaous CSV downloads, we want to generate the dataset snapshot when a 'change' is added to the a revision. There's no job queue/worker threads/etc, so the work will happen in the request handler. 

###  Summary of changes:

- uploading a change (append|retraction) causes an append/retraction to previous revision's CSV snapshot.
  - the dataset needs to fit into memory - we just rely on tablecloth's datasets and manipulate them in memory.
  - when such the revision is not tagged with a snapshot (key to the ChangeStore) - we throw
- snapshot CSVs are stored in the ChangeStore - I don't see any reasons why the snapshots should be stored separately from changes
- more utility middleware: e.g. creating often used URIs from path params
- replaced occurrences of `datahost.change.kind/*` with `:dh/ChangeKind*`
- related code re-shuffling (e.g. an *.handlers.internal ns for a few helper fns) 

We already have integration tests for that cover the changes and I don't think we would get much ROI by testing the internal details (though, if you think some piece of code really needs a test, let me know). 

Closes #182 