### PR TITLE
Add csvm handlers for release & revisions

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -158,7 +158,8 @@
                       :components {:securitySchemes {"basic" {:type "http" :scheme "basic"}}}}
             :handler (openapi/create-openapi-handler)}}]
     ["/.well-known"
-     ["/csvm" {:get {:handler (constantly
+     ["/csvm" {:no-doc true
+               :get {:handler (constantly
                                {:status 200
                                 :headers {"content-type" "text/plain"}
                                 :body "{+url}-metadata.json\nmetadata.json"})}}]]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -157,6 +157,11 @@
                              :version "0.1.0"}
                       :components {:securitySchemes {"basic" {:type "http" :scheme "basic"}}}}
             :handler (openapi/create-openapi-handler)}}]
+    ["/.well-known"
+     ["/csvm" {:get {:handler (constantly
+                               {:status 200
+                                :headers {"content-type" "text/plain"}
+                                :body "{+url}-metadata.json\nmetadata.json"})}}]]
 
     ["/data" {:muuntaja leave-keys-alone-muuntaja-coercer
               :tags ["linked data api"]}

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -209,3 +209,46 @@
                 (is (= (select-keys body ["dcterms:issued" "dcterms:modified"])
                        (select-keys body' ["dcterms:issued" "dcterms:modified"]))
                     "The document shouldn't be modified")))))))))
+
+(deftest csvm-release-test
+  (th/with-system-and-clean-up {{:keys [GET PUT]} :tpximpact.datahost.ldapi.test/http-client
+                                :as sys}
+
+    (let [new-series-slug (str "new-series-" (UUID/randomUUID))
+          new-series-path (str "/data/" new-series-slug)
+          release-1-id (str "release-" (UUID/randomUUID))
+          release-1-path (str new-series-path "/releases/" release-1-id)
+          release-1-csvm-path (str release-1-path "-metadata.json")]
+
+      (testing "Fetching csvw metadata for a release that does not exist returns 'not found'"
+        (let [{:keys [status body]} (GET release-1-csvm-path)]
+          (is (= 404 status))
+          (is (= "Not found" body))))
+
+      (PUT new-series-path
+           {:content-type :json
+            :body (json/write-str {"dcterms:title" "A title"
+                                   "dcterms:description" "Description"})})
+
+      (PUT release-1-path
+           {:content-type :json
+            :body (json/write-str {"dcterms:title" "Example Release"
+                                   "dcterms:description" "Description"})})
+
+      (testing "Fetching a release csv that does exist works"
+        (let [response (GET release-1-path {:headers {"accept" "text/csv"}})]
+          (is (= 200 (:status response)))
+          ;; (is (not (empty? (:body response))))
+          ;; TODO: what is the csv release meant to be? `""` empty string
+          ;; seems off when the json returns something not-nil
+          (is (= (str "<http://localhost:3400" release-1-csvm-path ">; "
+                      "rel=\"describedBy\"; "
+                      "type=\"application/csvm+json\""),
+                 (get-in response [:headers "link"])))))
+
+      (testing "Fetching csvm for release that does exist works"
+        (let [response (GET release-1-csvm-path)
+              body (json/read-str (:body response))]
+          (is (= 200 (:status response)))
+          (is (= {"@context" ["http://www.w3.org/ns/csvw" {"@language" "en"}]}
+                 body)))))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/router_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/router_test.clj
@@ -47,3 +47,11 @@
         {:keys [status headers] :as _response} (handler request)]
     (t/is (= 201 status))
     (t/is (= origin (get headers "Access-Control-Allow-Origin")))))
+
+(t/deftest csvm-well-known-request-test
+  (let [router (get-test-router)
+        handler (ring/ring-handler router)
+        request {:request-method :get :uri "/.well-known/csvm"}
+        {:keys [status body]} (handler request)]
+    (t/is (= 200 status))
+    (t/is (= "{+url}-metadata.json\nmetadata.json" body))))


### PR DESCRIPTION
Closes: #219 

This PR implements (empty) csv metadata as per the spec[1], by:

 - Adding a Link header to csvs for releases and revisions, to point to the json metadata file for the csv. (at `{csv-url}-metadata.json`)
 - Adding a placeholder json metadata file at the url `{csv-url}-metadata.json`, where a resource at `{csv-url}` exists.
 - Adding a metadata URI pattern spec at `/.well-known/csvm`. (though according to spec this is redundant)

[1] https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#locating-metadata