### PR TITLE
Don't try catch http requests in tests

### DIFF
--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -113,34 +113,23 @@
           release-1-id (str "release-" (UUID/randomUUID))
           release-1-path (str new-series-path "/releases/" release-1-id)]
       (testing "Fetching a release for a series that does not exist returns 'not found'"
-        (try
-
-          (GET release-1-path)
-
-          (catch Throwable ex
-            (let [{:keys [status body]} (ex-data ex)]
-              (is (= 404 status))
-              (is (= "Not found" body))))))
+        (let [{:keys [status body]} (GET release-1-path)]
+          (is (= 404 status))
+          (is (= "Not found" body))))
 
       (testing "Fetching a release that does not exist returns 'not found'"
-        (try
-          (GET release-1-path)
-
-          (catch Throwable ex
-            (let [{:keys [status body]} (ex-data ex)]
-              (is (= 404 status))
-              (is (= "Not found" body))))))
+        (let [{:keys [status body]} (GET release-1-path)]
+          (is (= 404 status))
+          (is (= "Not found" body))))
 
       (testing "Creating a release for a series that is not found fails gracefully"
-        (try
-          (PUT (str "/data/this-series-does-not-exist/releases/release-xyz")
-               {:content-type :json
-                :body (json/write-str {"dcterms:title" "Example Release"
-                                       "dcterms:description" "Description"})})
-            (catch Throwable ex
-              (let [{:keys [status body]} (ex-data ex)]
-                (is (= 422 status))
-                (is (= "Series for this release does not exist" body))))))
+        (let [{:keys [status body]}
+              (PUT (str "/data/this-series-does-not-exist/releases/release-xyz")
+                   {:content-type :json
+                    :body (json/write-str {"dcterms:title" "Example Release"
+                                           "dcterms:description" "Description"})})]
+          (is (= 422 status))
+          (is (= "Series for this release does not exist" body))))
 
       (PUT new-series-path
            {:content-type :json

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -114,13 +114,9 @@
 (deftest round-tripping-series-test
   (th/with-system-and-clean-up {{:keys [GET PUT]} :tpximpact.datahost.ldapi.test/http-client :as sys}
     (testing "A series that does not exist returns 'not found'"
-      (try
-        (GET "/data/does-not-exist")
-
-        (catch Throwable ex
-          (let [{:keys [status body]} (ex-data ex)]
-            (is (= 404 status))
-            (is (= "Not found" body))))))
+      (let [{:keys [status body]} (GET "/data/does-not-exist")]
+        (is (= 404 status))
+        (is (= "Not found" body))))
 
     (let [rdf-base-uri (th/sys->rdf-base-uri sys)
           new-series-id (str "new-series-" (UUID/randomUUID))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/test_util/http_client.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/test_util/http_client.clj
@@ -3,9 +3,11 @@
   (:require [clj-http.client :as http]))
 
 (defn- http-request
-  [method-fn base-url path & args]
+  [method-fn base-url path & [request & args]]
   (assert (not (.endsWith base-url "/")))
-  (apply method-fn (str base-url path) args))
+  (apply method-fn
+         (str base-url path)
+         (assoc request :throw-exceptions false) args))
 
 (defn make-client
   "Returns a map `{:keys [GET PUT POST DELETE HEAD]}` where each value


### PR DESCRIPTION
Because if the code under test doesn't throw (E.G., a 200) then the assertions are never run and so don't fail.