### PR TITLE
Fix use of multipart requests and message body in HTTP POST (changes)

### DIFF
--- a/datahost-ld-openapi/doc/data-model-example.ttl
+++ b/datahost-ld-openapi/doc/data-model-example.ttl
@@ -85,7 +85,7 @@ example:datasets
 #
 # DELETE's will look the same as POSTS just with the HTTP verb replaced
 
-# GET /data/life-expectancy/releases/2023 Accept: application/json+ld
+# GET /data/life-expectancy/releases/2023 Accept: application/ld+json
 #
 # {"@id": "/data/life-expectancy/releases/1",
 #  "@type": "datahost:Release"

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -552,7 +552,7 @@
               {:before before :after after})))]
     (if (and (= 0N before) (= 1N after))
       {:resource-id 1
-       :jsonld-doc (resource/->json-ld change (output-context ["dh" "dcterms" "rdf"] ld-root))}
+       :inserted-jsonld-doc (resource/->json-ld change (output-context ["dh" "dcterms" "rdf"] ld-root))}
       {:message "Change already exists."})))
 
 (defn- previous-change-coords

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -288,16 +288,16 @@
          change-ds :dataset} (some-> release-schema (validate-incoming-change-data appends))
         ;; insert relevant triples
         insert-req (store/make-insert-request! change-store (:tempfile appends))
-        {:keys [jsonld-doc resource-id message]} (when-not validation-err
-                                                   (db/insert-change! triplestore
-                                                                      system-uris
-                                                                      {:api-params (get-api-params request)
-                                                                       :ld-root (su/rdf-base-uri system-uris)
-                                                                       :jsonld-doc jsonld-doc
-                                                                       :store-key (:key insert-req)
-                                                                       :change-uri change-uri
-                                                                       :datahost.change/kind change-kind
-                                                                       :datahost.request/uris request-uris}))]
+        {:keys [inserted-jsonld-doc resource-id message]} (when-not validation-err
+                                                            (db/insert-change! triplestore
+                                                                               system-uris
+                                                                               {:api-params (get-api-params request)
+                                                                                :ld-root (su/rdf-base-uri system-uris)
+                                                                                :jsonld-doc jsonld-doc
+                                                                                :store-key (:key insert-req)
+                                                                                :change-uri change-uri
+                                                                                :datahost.change/kind change-kind
+                                                                                :datahost.request/uris request-uris}))]
     (assert (= resource-id change-id))
     (log/info (format "post-change: '%s' validation: found-schema? = %s, change-valid? = %s, insert-ok? = %s"
                       (.getPath change-uri) (some? release-schema) (nil? validation-err) (nil? message)))
@@ -328,7 +328,7 @@
 
         (as-json-ld {:status 201
                      :headers {"Location" (.getPath change-uri)}
-                     :body jsonld-doc})))))
+                     :body inserted-jsonld-doc})))))
 
 (defn change->csv-stream [change-store change]
   (let [appends (get change (cmp/expand :dh/updates))]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -27,7 +27,7 @@
    :body "Not found"})
 
 (defn- as-json-ld [response]
-  (assoc-in response [:headers "content-type"] "application/json+ld"))
+  (assoc-in response [:headers "content-type"] "application/ld+json"))
 
 (defn get-api-params [{:keys [path-params query-params]}]
   (-> query-params (update-keys keyword) (merge path-params)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -106,20 +106,20 @@
   (when-let [accept-header (get-in request [:headers "accept"])]
     (and (str/includes? accept-header "text/html")
          (not (str/includes? accept-header "application/json"))
-         (not (str/includes? accept-header "application/json+ld")))))
+         (not (str/includes? accept-header "application/ld+json")))))
 
 
 (def browser-render-convenience-middleware
   "This is an affordance that attempts to detect an in-browser GET request. If
-  detected, the application/json+ld content-type from API response will be overridden
+  detected, the application/ld+json content-type from API response will be overridden
   so that the browser renders the response as plain JSON and does not attempt to download
-  the unrecognized application/json+ld as a file."
+  the unrecognized application/ld+json as a file."
   (fn [handler]
     (fn [request]
       (if (and (read-request? request)
                (browser-html-request? request))
         (let [response (handler request)]
-          (if (= (get-in response [:headers "content-type"]) "application/json+ld")
+          (if (= (get-in response [:headers "content-type"]) "application/ld+json")
             ;; replace content-type for raw browser request
             (assoc-in response [:headers "content-type"] "application/json")
             response))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -26,7 +26,9 @@
    [tpximpact.datahost.ldapi.routes.middleware :as middleware]
    [tpximpact.datahost.ldapi.routes.release :as routes.rel]
    [tpximpact.datahost.ldapi.routes.revision :as routes.rev]
-   [tpximpact.datahost.ldapi.routes.series :as routes.s])
+   [tpximpact.datahost.ldapi.routes.series :as routes.s]
+   [clojure.data.json :as json]
+   [clojure.java.io :as io])
   (:import
    (java.io InputStream InputStreamReader OutputStream)))
 
@@ -215,6 +217,7 @@
                        :default-values true
                        ;; malli options
                        :options nil})
+           :multipart-opts {:formats {"application/json" (comp json/read io/reader)}}
            :muuntaja muuntaja-custom-instance
            :middleware [;; exception handling
                         ldapi-errors/exception-middleware

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -3,7 +3,7 @@
    [clojure.data.json :as json]
    [malli.core :as m]
    [malli.error :as me]
-   [reitit.coercion]
+   [reitit.coercion :as coercion]
    [reitit.ring.middleware.multipart :as multipart]
    [ring.middleware.multipart-params :as multipart-params]
    [tpximpact.datahost.ldapi.db :as db]
@@ -131,56 +131,52 @@
              :body {:query-params query-errors}}
             (handler request)))))))
 
-(defn- parse-multipart-params [request]
-  (let [params (->> (:multipart-params request)
-                    (map (fn [[k {:keys [content-type tempfile] :as p}]]
-                           [(keyword k)
-                            (if (= content-type "application/json")
-                                (some-> tempfile slurp json/read-str)
-                                p)]))
-                    (into {}))]
-    (assoc request :multipart-params params)))
+(defn- match-content-type [content-type formats]
+  (or (get formats content-type)
+      (let [[_ ns type] (re-find #"([^/]+)/(?:[^\+]+\+)?([^\+].*)" content-type)]
+        (get formats (str ns \/ type)))))
+
+(defn- parse-multipart-params [request {:keys [formats] :as options}]
+  (letfn [(parse-part [[k {:keys [content-type tempfile] :as p}]]
+            [(keyword k)
+             (if-let  [parse-fn (match-content-type content-type formats)]
+               (parse-fn tempfile)
+               p)])]
+    (update request :multipart-params #(->> % (map parse-part) (into {})))))
+
+(defn- coerced-request [request coercers]
+  (if-let [coerced (if coercers (coercion/coerce-request coercers request))]
+    (update request :parameters merge coerced)
+    request))
 
 (defn- compile-multipart-middleware [options]
-  (fn [{:keys [parameters coercion]} opts]
+  (fn [{:keys [parameters coercion multipart-opts]} opts]
     (if-let [multipart (:multipart parameters)]
-      (let [parameter-coercion {:multipart (reitit.coercion/->ParameterCoercion
+      (let [parameter-coercion {:multipart (coercion/->ParameterCoercion
                                             :multipart-params :string false true)}
-            opts (assoc opts :reitit.coercion/parameter-coercion parameter-coercion)
-            coercers (if multipart (reitit.coercion/request-coercers coercion parameters opts))]
+            opts (assoc opts ::coercion/parameter-coercion parameter-coercion)
+            coercers (if multipart (coercion/request-coercers coercion parameters opts))]
         {:data {:swagger {:consumes ^:replace #{"multipart/form-data"}}}
          :wrap (fn [handler]
                  (fn
                    ([request]
                     (-> request
                         (multipart-params/multipart-params-request options)
-                        (parse-multipart-params)
-                        (#'multipart/coerced-request coercers)
+                        (parse-multipart-params multipart-opts)
+                        (coerced-request coercers)
                         (handler)))
                    ([request respond raise]
                     (-> request
                         (multipart-params/multipart-params-request options)
-                        (parse-multipart-params)
-                        (#'multipart/coerced-request coercers)
+                        (parse-multipart-params multipart-opts)
+                        (coerced-request coercers)
                         (handler respond raise)))))}))))
 
-(defn create-multipart-middleware
-  "Creates a Middleware to handle the multipart params, based on
-  ring.middleware.multipart-params, taking same options. Mounts only
-  if endpoint has `[:parameters :multipart]` defined. Publishes coerced
-  parameters into `[:parameters :multipart]` under request."
-  ([]
-   (create-multipart-middleware nil))
-  ([options]
-   {:name ::multipart
-    :compile (compile-multipart-middleware options)}))
-
 (def multipart-middleware
-  "Middleware to handle the multipart params, based on
-  ring.middleware.multipart-params, taking same options. Mounts only
-  if endpoint has `[:parameters :multipart]` defined. Publishes coerced
-  parameters into `[:parameters :multipart]` under request."
-  (create-multipart-middleware))
+  "Modified reitit.ring.middleware.multipart/multipart-middleware that parses
+  multipart \"parts\" according to their content-type/configuration."
+  {:name ::multipart
+   :compile (compile-multipart-middleware nil)})
 
 (defn csvm-request-response
   [triplestore system-uris handler _id]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -25,7 +25,7 @@
               (= "application/ld+json" content-type))
         (handler request)
         {:status 406
-         :body "not acceptable"}))))
+         :body "Not acceptable. Only Content-Type: application/json is accepted"}))))
 
 (defn entity-uris-from-path
   [system-uris entities handler _id]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -65,7 +65,7 @@
   {:summary "Create schema for a release"
    :handler (partial handlers/post-release-schema clock triplestore system-uris)
    ;; NOTE: file schema JSON content string is validated within the handler itself
-   :parameters {:multipart [:map [:schema-file reitit.ring.malli/temp-file-part]]
+   :parameters {:multipart [:map [:schema-file routes-shared/LdSchemaInput]]
                 :path {:series-slug :string
                        :release-slug :string}}
    :openapi {:security [{"basic" []}]}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -19,7 +19,7 @@
                        :release-slug string?}}
    :responses {200 {:content
                     {"text/csv" any?
-                     "application/json+ld" {:body string?}}}
+                     "application/ld+json" {:body string?}}}
                404 {:body [:re "Not found"]}}})
 
 (defn put-release-route-config [clock triplestore system-uris]
@@ -39,10 +39,10 @@
                 :query schema/ApiQueryParams}
    :openapi {:security [{"basic" []}]}
    :responses {200 {:description "Release already existed and was successfully updated"
-                    :content {"application/json+ld"
+                    :content {"application/ld+json"
                               {:body string?}}}
                201 {:description "Release did not exist previously and was successfully created"
-                    :content {"application/json+ld"
+                    :content {"application/ld+json"
                               {:body string?}}}
                500 {:description internal-server-error-desc
                     :body [:map
@@ -56,7 +56,7 @@
    :parameters {:path {:series-slug :string
                        :release-slug :string}}
    :responses {200 {:description "Release schema successfully retrieved"
-                    :content {"application/json+ld"
+                    :content {"application/ld+json"
                               {:body string?}}}
                404 {:body [:re "Not found"]}}})
 
@@ -70,10 +70,10 @@
                        :release-slug :string}}
    :openapi {:security [{"basic" []}]}
    :responses {200 {:description "Schema already exists."
-                    :content {"application/json+ld"
+                    :content {"application/ld+json"
                               {:body string?}}}
                201 {:description "Schema successfully created"
-                    :content {"application/json+ld"
+                    :content {"application/ld+json"
                               {:body string?}}}
                500 {:description internal-server-error-desc
                     :body [:map

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -1,10 +1,11 @@
 (ns tpximpact.datahost.ldapi.routes.revision
   (:require
-    [reitit.ring.malli]
-    [reitit.coercion.malli :as rcm]
-    [tpximpact.datahost.ldapi.handlers :as handlers]
-    [tpximpact.datahost.ldapi.routes.middleware :as middleware]
-    [tpximpact.datahost.ldapi.routes.shared :as routes-shared]))
+   [reitit.ring.malli]
+   [reitit.coercion.malli :as rcm]
+   [tpximpact.datahost.ldapi.handlers :as handlers]
+   [tpximpact.datahost.ldapi.routes.middleware :as middleware]
+   [tpximpact.datahost.ldapi.routes.shared :as routes-shared]
+   [clojure.data.json :as json]))
 
 (defn get-revision-route-config [triplestore change-store system-uris]
   {:summary "Retrieve metadata or CSV contents for an existing revision"
@@ -81,8 +82,9 @@
                           triplestore system-uris
                           {:resource :dh/Change :missing-params {:change-id 1}} )
                  :resource-already-created?]]
-   :parameters {:multipart [:map [:appends reitit.ring.malli/temp-file-part]]
-                :body routes-shared/CreateChangeInput
+   :parameters {:multipart [:map
+                            [:jsonld-doc routes-shared/CreateChangeInput]
+                            [:appends reitit.ring.malli/temp-file-part]]
                 :path {:series-slug string?
                        :release-slug string?
                        :revision-id int?}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -20,14 +20,14 @@
                        :revision-id int?}}
    :responses {200 {:content
                     {"text/csv" any?
-                     "application/json+ld" {:body string?}}}
+                     "application/ld+json" {:body string?}}}
                404 {:body [:re "Not found"]}}})
 
 (defn get-release-list-route-config [triplestore system-uris]
   {:summary "All releases metadata in the given series"
    :handler (partial handlers/get-release-list triplestore system-uris)
    :parameters {:path {:series-slug string?}}
-   :responses {200 {:content {"application/json+ld"
+   :responses {200 {:content {"application/ld+json"
                               {:body string?}}}
                404 {:body [:re "Not found"]}}})
 
@@ -36,7 +36,7 @@
    :handler (partial handlers/get-revision-list triplestore system-uris)
    :parameters {:path {:series-slug string?
                        :release-slug string?}}
-   :responses {200 {:content {"application/json+ld"
+   :responses {200 {:content {"application/ld+json"
                               {:body string?}}}
                404 {:body [:re "Not found"]}}})
 
@@ -64,7 +64,7 @@
                                        :optional true} string?]]}
    :openapi {:security [{"basic" []}]}
    :responses {201 {:description "Revision was successfully created"
-                    :content {"application/json+ld"
+                    :content {"application/ld+json"
                               {:body string?}}
                     ;; headers is not currently supported
                     :headers {"Location" string?}}
@@ -90,7 +90,7 @@
                        :revision-id int?}}
    :openapi {:security [{"basic" []}]}
    :responses {201 {:description "Changes were added to a Revision"
-                    :content {"application/json+ld"
+                    :content {"application/ld+json"
                               {:body string?}}
                     ;; headers is not currently supported
                     :headers {"Location" string?}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -75,8 +75,7 @@
 
 (defn changes-route-base [triplestore change-store system-uris change-kind]
   {:handler (partial handlers/post-change triplestore change-store system-uris change-kind)
-   :middleware [[middleware/json-only :json-only]
-                [(partial middleware/entity-uris-from-path system-uris #{:dh/Release :dh/Revision}) :entity-uris]
+   :middleware [[(partial middleware/entity-uris-from-path system-uris #{:dh/Release :dh/Revision}) :entity-uris]
                 [(partial middleware/resource-exist? triplestore system-uris :dh/Revision) :resource-exists?]
                 [(partial middleware/resource-already-created?
                           triplestore system-uris

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
@@ -8,7 +8,7 @@
 (defn get-series-list-route-config [triplestore system-uris]
   {:summary "All series metadata in the database"
    :handler (partial handlers/get-series-list triplestore system-uris)
-   :responses {200 {:content {"application/json+ld"
+   :responses {200 {:content {"application/ld+json"
                               {:body string?}}}
                404 {:body [:re "Not found"]}}})
 
@@ -17,7 +17,7 @@
    :description "A dataset series is a named dataset regardless of schema, methodology or compatibility changes"
    :handler (partial handlers/get-dataset-series triplestore system-uris)
    :parameters {:path {:series-slug string?}}
-   :responses {200 {:content {"application/json+ld"
+   :responses {200 {:content {"application/ld+json"
                               {:body string?}}}
                404 {:body [:re "Not found"]}}})
 
@@ -38,10 +38,10 @@
                 :query schema/ApiQueryParams}
    :openapi {:security [{"basic" []}]}
    :responses {200 {:description "Series already existed and was successfully updated"
-                    :content {"application/json+ld"
+                    :content {"application/ld+json"
                               {:body routes-shared/ResourceSchema}}}
                201 {:description "Series did not exist previously and was successfully created"
-                    :content {"application/json+ld"
+                    :content {"application/ld+json"
                               {:body routes-shared/ResourceSchema}}}
                500 {:description "Internal server error"
                     :body [:map

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -138,7 +138,8 @@
 
 (defn- build-csv-multipart [csv-path]
   (let [appends-file (io/file (io/resource csv-path))]
-    {:tempfile appends-file
+    {:name "appends"
+     :content appends-file
      :size (.length appends-file)
      :filename (.getName appends-file)
      :content-type "text/csv;"}))
@@ -273,9 +274,10 @@
                                   "dcterms:format" "text/csv"}
                     multipart-temp-file-part (build-csv-multipart csv-2020-path)
                     change-api-response (POST (str new-revision-location "/changes")
-                                              {:multipart {:appends multipart-temp-file-part}
-                                               :content-type "application/json"
-                                               :body (json/write-str change-ednld)})
+                                              {:multipart [multipart-temp-file-part]
+                                               ;; :content-type "application/json"
+                                               ;; :body (json/write-str change-ednld)
+                                               })
                     new-change-resource-location (-> change-api-response :headers (get "Location"))]
                 (is (= 422 (:status change-api-response)))
                 (is (nil? new-change-resource-location))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -272,11 +272,10 @@
               (let [change-ednld {"dcterms:description" "A new second change"
                                   "dcterms:format" "text/csv"}
                     multipart-temp-file-part (build-csv-multipart csv-2020-path)
-                    change-api-response (ld-api-app {:request-method :post
-                                                     :uri (str new-revision-location "/changes")
-                                                     :multipart-params {:appends multipart-temp-file-part}
-                                                     :content-type "application/json"
-                                                     :body (json/write-str change-ednld)})
+                    change-api-response (POST (str new-revision-location "/changes")
+                                              {:multipart {:appends multipart-temp-file-part}
+                                               :content-type "application/json"
+                                               :body (json/write-str change-ednld)})
                     new-change-resource-location (-> change-api-response :headers (get "Location"))]
                 (is (= 422 (:status change-api-response)))
                 (is (nil? new-change-resource-location))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -136,17 +136,8 @@
           (t/is (= nil missing1))
           (t/is (= nil missing2)))))))
 
-(defn- build-csv-multipart [csv-path]
-  (let [appends-file (io/file (io/resource csv-path))]
-    {:name "appends"
-     :content appends-file
-     :size (.length appends-file)
-     :filename (.getName appends-file)
-     :content-type "text/csv;"}))
-
 (deftest round-tripping-revision-test
   (th/with-system-and-clean-up {{:keys [GET POST PUT]} :tpximpact.datahost.ldapi.test/http-client
-                                ld-api-app :tpximpact.datahost.ldapi.router/handler
                                 :as sys}
     (let [rdf-base-uri (th/sys->rdf-base-uri sys)
           csv-2019-path "test-inputs/revision/2019.csv"
@@ -187,22 +178,8 @@
                            (throw (ex-info (str (me/humanize (m/explain LdSchemaInput schema-req-body)))
                                            {:schema schema-req-body})))
 
-              temp-schema-file (File/createTempFile "revision-test-schema-1" ".json")
-
-              _ (with-open [file (io/writer temp-schema-file)]
-                  (binding [*out* file]
-                    (println (json/write-str schema-req-body))))
-
-              json-file-multipart (let [json-file (io/file (.getAbsolutePath temp-schema-file))]
-                                    {:tempfile json-file
-                                     :size (.length json-file)
-                                     :filename (.getName json-file)
-                                     :content-type "application/json"})
-
-              _resp (ld-api-app {:request-method :post
-                                 :uri (str release-url "/schema")
-                                 :multipart-params {:schema-file json-file-multipart}
-                                 :content-type "application/json"})]
+              _resp (POST (str release-url "/schema")
+                          {:multipart [(th/jsonld-multipart "schema-file" schema-req-body)]})]
           (is (= 201 (:status release-resp)))
 
           ;; REVISION
@@ -247,12 +224,10 @@
               ;; "/:series-slug/releases/:release-slug/revisions/:revision-id/changes"
               (let [change-ednld {"dcterms:description" "A new change"
                                   "dcterms:format" "text/csv"}
-                    multipart-temp-file-part (build-csv-multipart csv-2019-path)
-                    change-api-response (ld-api-app {:request-method :post
-                                                     :uri (str new-revision-location "/changes")
-                                                     :multipart-params {:appends multipart-temp-file-part}
-                                                     :content-type "application/json"
-                                                     :body (json/write-str change-ednld)})
+                    multipart-temp-file-part (th/build-csv-multipart csv-2019-path)
+                    change-api-response (POST (str new-revision-location "/changes")
+                                              {:multipart [(th/jsonld-multipart "jsonld-doc" change-ednld)
+                                                           multipart-temp-file-part]})
                     new-change-resource-location (-> change-api-response :headers (get "Location"))]
 
                 (is (= 201 (:status change-api-response)))
@@ -272,12 +247,10 @@
               ; /data/:series-slug/releases/:release-slug/revisions/:revision-id/changes
               (let [change-ednld {"dcterms:description" "A new second change"
                                   "dcterms:format" "text/csv"}
-                    multipart-temp-file-part (build-csv-multipart csv-2020-path)
+                    multipart-temp-file-part (th/build-csv-multipart csv-2020-path)
                     change-api-response (POST (str new-revision-location "/changes")
-                                              {:multipart [multipart-temp-file-part]
-                                               ;; :content-type "application/json"
-                                               ;; :body (json/write-str change-ednld)
-                                               })
+                                              {:multipart [(th/jsonld-multipart "jsonld-doc" change-ednld)
+                                                           multipart-temp-file-part]})
                     new-change-resource-location (-> change-api-response :headers (get "Location"))]
                 (is (= 422 (:status change-api-response)))
                 (is (nil? new-change-resource-location))))
@@ -311,12 +284,10 @@
               (testing "Third Changes append resource created against 2nd Revision"
                 (let [change-3-ednld {"dcterms:description" "A new third change"
                                       "dcterms:format" "text/csv"}
-                      multipart-temp-file-part (build-csv-multipart csv-2021-path)
-                      change-api-response (ld-api-app {:request-method :post
-                                                       :uri (str new-revision-location-2 "/changes")
-                                                       :multipart-params {:appends multipart-temp-file-part}
-                                                       :content-type "application/json"
-                                                       :body (json/write-str change-3-ednld)})]
+                      multipart-temp-file-part (th/build-csv-multipart csv-2021-path)
+                      change-api-response (POST (str new-revision-location-2 "/changes")
+                                                {:multipart [(th/jsonld-multipart "jsonld-doc" change-3-ednld)
+                                                             multipart-temp-file-part]})]
                   (is (= 201 (:status change-api-response)))
                   (is (str/ends-with? (get (json/read-str (:body change-api-response)) "@id")
                                       "/changes/1"))))
@@ -357,12 +328,10 @@
                       new-revision-location-3 (-> revision-resp-3 :headers (get "Location"))
                       change-4-ednld {"dcterms:description" "A new fourth deletes change"
                                       "dcterms:format" "text/csv"}
-                      multipart-temp-file-part (build-csv-multipart csv-2021-deletes-path)
-                      change-api-response (ld-api-app {:request-method :post
-                                                       :uri (str new-revision-location-3 "/deletes")
-                                                       :multipart-params {:appends multipart-temp-file-part}
-                                                       :content-type "application/json"
-                                                       :body (json/write-str change-4-ednld)})
+                      multipart-temp-file-part (th/build-csv-multipart csv-2021-deletes-path)
+                      change-api-response (POST (str new-revision-location-3 "/deletes")
+                                                {:multipart [(th/jsonld-multipart "jsonld-doc" change-4-ednld)
+                                                             multipart-temp-file-part]})
                       response-body-doc (json/read-str (:body change-api-response))]
                   (is (= 201 (:status change-api-response)))
                   (is (= ":dh/ChangeKindRetract" (get response-body-doc "dh:changeKind")))

--- a/datahost-ld-openapi/test/tpximpact/test_helpers.clj
+++ b/datahost-ld-openapi/test/tpximpact/test_helpers.clj
@@ -90,4 +90,4 @@
     (multipart "appends" appends-file "text/csv")))
 
 (defn jsonld-multipart [name jsonld]
-  (multipart name (.getBytes (json/write-str jsonld) "UTF-8") "application/json"))
+  (multipart name (.getBytes (json/write-str jsonld) "UTF-8") "application/ld+json"))


### PR DESCRIPTION
Fix: #233 

This PR fixes a fundamental issue with the way that certain POST requests were being handled and tested.

An HTTP request has (in short) headers & message body. If the request is a multipart request, the multiple parts sit in the message body. Ring (and reitit) parse the request, and can have keys `:body` and `:multipart-params`, however a valid HTTP request can never produce a Ring request that has _both_ a `:body` and `:multipart-params`.

The tests were passing both keys, and the handlers were handling both keys, but were not forming a valid HTTP request, rather passing an invalid request directly into the root handler.

When a user, via swagger or otherwise, tries to form such a request it cannot work.

# Fix

The tests have been fixed to make an actual HTTP request with clj-http, ensuring that the HTTP interface is adhered to, and incoming requests are valid.

The tests now send 2 parts in a multipart request, the jsonld metadata and the existing csv data.

The handlers have been adjusted to accept only multipart parameters, one with a jsonld message, and the existing csv.

# Potential Controversy
 - I've changed the mime-type for jsonld throughout to be "correct" [1] - `application/ld+json` E.G., [2]
 - I've reimplemented a bit of reitit's multipart middleware because it doesn't (seem to) allow parsing of the parts
 - I've added a new key on the router `:data` config map `:multipart-opts` to define parsers for content-types. This can be configured at router level, or at individual routes.

[1] https://www.iana.org/assignments/media-types/application/ld+json
[2] https://github.com/Swirrl/datahost-prototypes/pull/230/files#diff-241a927aca4dcf3734f5e5d389782b56d5cc6b8b9c54f68579ab54f738293333R88