### PR TITLE
API: revise base-path middleware to work properly with reitit; add test

### DIFF
--- a/datahost-ld-openapi/env/test/resources/test-system-base-path.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system-base-path.edn
@@ -1,0 +1,2 @@
+{:tpximpact.datahost.ldapi/base-path "/camino-base"
+ }

--- a/datahost-ld-openapi/resources/ldapi/base-system.edn
+++ b/datahost-ld-openapi/resources/ldapi/base-system.edn
@@ -4,9 +4,9 @@
 
  :tpximpact.datahost.system-uris/uris {:rdf-base-uri #uri "https://example.org/data/"}
 
- ;; Associate a context and path-info with the ring request.
- ;; The request URI must be a subpath of the supplied context.
- ;; NOT to be confused with the RDF Base URI (although it may match)
+ ;; Associate a context and path-info with the ring request. The request URI must
+ ;; be a subpath of the supplied context. NOT to be confused with the RDF Base URI
+ ;; (although it may need to work closely with that for dereffing)
  :tpximpact.datahost.ldapi/base-path ""
 
  :tpximpact.datahost.ldapi.jetty/runnable-service

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/router_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/router_test.clj
@@ -1,5 +1,6 @@
 (ns tpximpact.datahost.ldapi.router-test
   (:require
+   [clojure.data.json :as json]
    [clojure.java.io :as io]
    [clojure.test :as t]
    [grafter-2.rdf4j.repository :as repo]
@@ -7,17 +8,19 @@
    [tpximpact.datahost.ldapi.store.file :as fstore]
    [tpximpact.datahost.system-uris :as su]
    [tpximpact.datahost.time :as time]
-   [tpximpact.datahost.ldapi.router :as sut])
+   [tpximpact.datahost.ldapi.router :as sut]
+   [tpximpact.test-helpers :as th])
   (:import (java.net URI)))
 
 (defn- get-test-router
-  ([] (get-test-router time/system-clock))
-  ([clock]
+  ([] (get-test-router {}))
+  ([override-opts]
    (let [triplestore (repo/sail-repo)
          rdf-base-uri (URI. "https://example.org/data/")
          system-uris (su/make-system-uris rdf-base-uri)
          change-store (fstore/->FileChangeStore (io/file "/Users/lee/data/filestore-tmp"))]
-     (sut/router {:clock clock :triplestore triplestore :change-store change-store :system-uris system-uris}))))
+     (sut/router (merge {:clock time/system-clock :triplestore triplestore :change-store change-store :system-uris system-uris}
+                        override-opts)))))
 
 (t/deftest cors-preflight-request-test
   (let [router (get-test-router)
@@ -55,3 +58,18 @@
         {:keys [status body]} (handler request)]
     (t/is (= 200 status))
     (t/is (= "{+url}-metadata.json\nmetadata.json" body))))
+
+(t/deftest base-path-request-test
+  (th/with-system {{:keys [GET PUT]} :tpximpact.datahost.ldapi.test/http-client :as sys}
+                  (th/start-system ["ldapi/base-system.edn"
+                                    "test-system.edn"
+                                    "test-system-base-path.edn"
+                                    "ldapi/env.edn"])
+
+                  (tpximpact.db-cleaner/clean-db sys)
+    (let [{:keys [status headers] :as _response} (PUT "/camino-base/data/new-series-again"
+                                                      {:content-type :json
+                                                       :body (json/write-str {"@context" {"dcterms" "http://foop.com"}
+                                                                              "dcterms:title" "Test base path"
+                                                                              "dcterms:description" "Test base path series"})})]
+      (t/is (= 201 status)))))

--- a/datahost-ld-openapi/test/tpximpact/native_datastore_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/native_datastore_test.clj
@@ -6,7 +6,7 @@
 
 (deftest native-datastore-test
   (testing "Base data is loaded on startup"
-    (th/with-system sys
+    (th/with-system sys nil
       (let [repo (:tpximpact.datahost.ldapi.native-datastore/repo sys)
             qry {:prefixes {:dcat "<http://www.w3.org/ns/dcat#>"
                             :rdfs "<http://www.w3.org/2000/01/rdf-schema#>"}

--- a/datahost-ld-openapi/test/tpximpact/test_helpers.clj
+++ b/datahost-ld-openapi/test/tpximpact/test_helpers.clj
@@ -46,8 +46,8 @@
   (test-fn)
   (stop-system))
 
-(defmacro with-system* [{:keys [on-halt on-init] :as _opts} system-binding & body]
-  `(let [sys# (start-system)
+(defmacro with-system* [{:keys [on-halt on-init] :as _opts} system-binding system-loader & body]
+  `(let [sys# (or ~system-loader (start-system))
          ~system-binding sys#]
      (try
        (doseq [f!# ~on-init]
@@ -67,6 +67,7 @@
   `(with-system* {:on-init [dc/clean-db]
                   :on-halt [ig/halt!]}
                  ~system-binding
+                 nil
                  ~@body))
 
 (defn sys->rdf-base-uri [sys]


### PR DESCRIPTION
Follow on work from PR https://github.com/Swirrl/datahost-prototypes/pull/221.

I have returned from holiday and this is the PR to add tests to ensure that the alternative request base path configurations worked - well they didn’t! I have fixed this issue now in a draft PR that I’m still working on

It turns out that setting the Ring context in middleware to work as a context for a base path in routing doesn’t work with Reitit in Datahost the same as it works in muttnik. I had assumed that Reitit would do the “right thing” with this information from the Ring request.

Regardless, even if Reitit did look at the request `:context`, the other reason the middleware wasn’t working correctly is because Reitit is optimised for speed as a “routing first” router, so the middleware is not hit before a 404 is returned from the route matchers.