### PR TITLE
ldapi: fixes revision creation with query params only

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -91,15 +91,17 @@
                                     ["description" :description-string]]
                                    {:registry s.common/registry}))}
    :post-revision {:body (m/explainer [:maybe CreateRevisionInput])
-                   :query (m/schema [:map
-                                     ["title" :title-string]
-                                     ["description" {:optional true} :description-string]]
-                                    {:registry s.common/registry})}
+                   :query (m/explainer
+                           (m/schema [:map
+                                      ["title" :title-string]
+                                      ["description" {:optional true} :description-string]]
+                                     {:registry s.common/registry}))}
    :post-revision-change {:body (m/explainer [:maybe CreateChangeInput])
-                          :query (m/schema [:map
-                                            ["title" {:optional true} :title-string]
-                                            ["description" :description-string]]
-                                           {:registry s.common/registry})}})
+                          :query (m/explainer
+                                  (m/schema [:map
+                                             ["title" {:optional true} :title-string]
+                                             ["description" :description-string]]
+                                            {:registry s.common/registry}))}})
 
 (defn base-url [request]
   (request/request-url (select-keys request [:scheme :headers :uri])))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -350,7 +350,13 @@
               ;; This Release already has 3 Revisions, so we expect another 10 in the series
               (is (= new-revision-ids (for [i (range 4 14)]
                                         (format "%s/releases/%s/revisions/%d" series-slug release-slug i)))
-                  "Expected Revision IDs integers increase in an orderly sequence"))))))))
+                  "Expected Revision IDs integers increase in an orderly sequence")))
+
+          (testing "Create revision with query params only"
+            (let [{status :status body :body} (POST (str release-url "/revisions")
+                                                    {:content-type :json
+                                                     :query-params {:title "final revision"}})]
+              (is (= 201 status)))))))))
 
 (deftest csvm-revision-test
   (th/with-system-and-clean-up


### PR DESCRIPTION
Summary: Some predefined explainers used by the `validate-creation-body+query-params` middleware weren't really explainers (missing `malli.core/explainer` call).

Closes #232