### PR TITLE
ldapi: more complete release schema validation

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -464,7 +464,6 @@
         schema-doc (update schema-doc "dh:columns" (fn [cols]
                                                      (map-indexed (fn mapper [index col]
                                                                     (assoc col "@id" (str schema-uri "/columns/" (inc index))
-                                                                           "@type" "dh:DimensionColumn"
                                                                            "csvw:number" (inc index)))
                                                                   cols)))
         schema-resource (resource/from-json-ld-doc schema-doc)]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -166,13 +166,14 @@
 
               schema-req-body {"dcterms:title" "Test schema"
                                "dh:columns"
-                               (let [csvw-type (fn [col-name titles datatype]
-                                                 {"csvw:datatype" datatype
+                               (let [csvw-type (fn [typ col-name titles datatype]
+                                                 {"@type" typ
+                                                  "csvw:datatype" datatype
                                                   "csvw:name" col-name
                                                   "csvw:titles" titles})]
                                  ;; we put schema only on 2 columns
-                                 [(csvw-type "measure_type" ["Measure type"] :string)
-                                  (csvw-type "year" "Year" :integer)])}
+                                 [(csvw-type "dh:MeasureColumn" "measure_type" ["Measure type"] :string)
+                                  (csvw-type "dh:DimensionColumn" "year" "Year" :integer)])}
 
               _validated (when-not (m/validate LdSchemaInput schema-req-body)
                            (throw (ex-info (str (me/humanize (m/explain LdSchemaInput schema-req-body)))


### PR DESCRIPTION
We want to validates Release schemas on upload. 

The relevant endpoint already validates the incoming schemas, but more thorough validation is needed. This PR updates the schema and marks some field as 'required', and verifies we have at least 1 measure, 1+ dimension and 0+ attributes.

Closes #217 