### PR TITLE
ldapi: uploading and applying corrections

### DIFF
--- a/datahost-ld-openapi/bin/hurl-data/change2.csv
+++ b/datahost-ld-openapi/bin/hurl-data/change2.csv
@@ -1,2 +1,3 @@
 name,age
+fabio,25
 bob,25

--- a/datahost-ld-openapi/bin/hurl-data/change2.meta.json
+++ b/datahost-ld-openapi/bin/hurl-data/change2.meta.json
@@ -1,0 +1,5 @@
+{	
+	"dcterms:title": "second change",
+	"dcterms:description": "The second change!",
+	"dcterms:format": "text/csv"
+}

--- a/datahost-ld-openapi/bin/hurl-data/change3.csv
+++ b/datahost-ld-openapi/bin/hurl-data/change3.csv
@@ -1,0 +1,2 @@
+name,age
+max,44

--- a/datahost-ld-openapi/bin/hurl-data/change3.meta.json
+++ b/datahost-ld-openapi/bin/hurl-data/change3.meta.json
@@ -1,0 +1,5 @@
+{	
+	"dcterms:title": "third change",
+	"dcterms:description": "The third change!",
+	"dcterms:format": "text/csv"
+}

--- a/datahost-ld-openapi/bin/hurl-data/test-schema.json
+++ b/datahost-ld-openapi/bin/hurl-data/test-schema.json
@@ -5,13 +5,13 @@
 	"dcterms:title": "Fun schema",
 	"dh:columns": [
 		{
-			"@type": "dh:MeasureColumn",
+			"@type": "dh:DimensionColumn",
 			"csvw:datatype": "string",
 			"csvw:name": "name",
             "csvw:titles": "name"
         },
         {
-			"@type": "dh:DimensionColumn",
+			"@type": "dh:MeasureColumn",
 			"csvw:datatype": "int",
 			"csvw:name": "age",
             "csvw:titles": "age"

--- a/datahost-ld-openapi/bin/hurl-data/test.hurl.template
+++ b/datahost-ld-openapi/bin/hurl-data/test.hurl.template
@@ -36,9 +36,9 @@ Content-Type: application/json
 
 HTTP 201
 [Captures]
-revision_url: header "Location"
+revision1_url: header "Location"
 
-POST http://localhost:3000{{revision_url}}/appends
+POST http://localhost:3000{{revision1_url}}/appends
 [MultipartFormData]
 appends: file,bin/hurl-data/change1.csv; text/csv
 jsonld-doc: file,bin/hurl-data/change1.meta.json; application/json
@@ -47,7 +47,57 @@ HTTP 201
 
 GET http://localhost:3000/data/test-011/releases/release-1
 Accept: text/csv
-[Options]
-very-verbose: true
 
 HTTP 200
+
+POST http://localhost:3000/data/test-011/releases/release-1/revisions
+Accept: application/json
+Content-Type: application/json
+{
+	"dcterms:title": "Rev 2",
+	"dcterms:description": "A test revision 2 (with retraction)"
+}
+
+HTTP 201
+[Captures]
+revision2_url: header "Location"
+
+POST http://localhost:3000{{revision2_url}}/retractions
+[MultipartFormData]
+appends: file,bin/hurl-data/change2.csv; text/csv
+jsonld-doc: file,bin/hurl-data/change2.meta.json; application/json
+
+HTTP 201
+
+GET http://localhost:3000/data/test-011/releases/release-1
+Accept: text/csv
+
+HTTP 200
+
+POST http://localhost:3000/data/test-011/releases/release-1/revisions
+Accept: application/json
+Content-Type: application/json
+{
+	"dcterms:title": "Rev 3",
+	"dcterms:description": "A test revision 3 (with corrections)"
+}
+
+HTTP 201
+[Captures]
+revision3_url: header "Location"
+
+POST http://localhost:3000{{revision3_url}}/corrections
+#[Options]
+#very-verbose: true
+[MultipartFormData]
+appends: file,bin/hurl-data/change3.csv; text/csv
+jsonld-doc: file,bin/hurl-data/change3.meta.json; application/json
+
+HTTP 201
+
+GET http://localhost:3000/data/test-011/releases/release-1
+Accept: text/csv
+
+HTTP 200
+[Asserts]
+body matches /max,44/

--- a/datahost-ld-openapi/env/test/resources/test-inputs/revision/2021-corrections.csv
+++ b/datahost-ld-openapi/env/test/resources/test-inputs/revision/2021-corrections.csv
@@ -1,0 +1,11 @@
+Measure type,Statistical Geography,Year,Aged 16 to 64 years level 3 or above qualifications,Unit of Measure,Upper Confidence Interval,Lower Confidence Interval,Observation Status
+Aged 16 to 64 years level 3 or above qualifications,Staffordshire,2021,99.0,per cent,65,55.4,
+Aged 16 to 64 years level 3 or above qualifications,Vale of Glamorgan,2021,99.0,per cent,72.3,57.9,
+Aged 16 to 64 years level 3 or above qualifications,Surrey,2021,99.0,per cent,72.9,65.1,
+Aged 16 to 64 years level 3 or above qualifications,Gloucester,2021,99.0,per cent,71.7,48.9,
+Aged 16 to 64 years level 3 or above qualifications,Rushmoor,2021,99.0,per cent,74.7,42.7,
+Aged 16 to 64 years level 3 or above qualifications,Buckinghamshire,2021,99.0,per cent,72.8,63.2,
+Aged 16 to 64 years level 3 or above qualifications,Essex,2021,99.0,per cent,57.4,49.8,
+Aged 16 to 64 years level 3 or above qualifications,North Yorkshire,2021,99.0,per cent,69.7,59.3,
+Aged 16 to 64 years level 3 or above qualifications,Worcestershire,2021,99.0,per cent,66.9,56.5,
+Aged 16 to 64 years level 3 or above qualifications,Ceredigion,2021,99.0,per cent,77.9,64.5,

--- a/datahost-ld-openapi/env/test/resources/test-inputs/schemas/simple.json
+++ b/datahost-ld-openapi/env/test/resources/test-inputs/schemas/simple.json
@@ -1,12 +1,15 @@
 {
  "dh:columns": [
-     {"csvw:name": "year",
+     {"@type": "dh:DimensionColumn",
+      "csvw:name": "year",
       "csvw:datatype": "integer",
       "csvw:titles": "Year"},
-     {"csvw:name": "measure",
-      "csvw:datatype": "string",
-      "csvw:titles": ["Unit of Measure"]},
-     {"csvw:name": "upper_confidence_interval",
+     {"@type": "dh:MeasureColumn",
+      "csvw:name": "measure",
+      "csvw:datatype": "double",
+      "csvw:titles": ["Aged 16 to 64 years level 3 or above qualifications"]},
+     {"@type": "dh:DimensionColumn",
+      "csvw:name": "upper_confidence_interval",
       "csvw:datatype": "double",
       "csvw:required": true,
       "csvw:titles": "Upper Confidence Interval"}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers/internal.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers/internal.clj
@@ -62,7 +62,8 @@
                    (->change-info change-ds change-kind change-ds-fmt)]
                   [(->change-info change-ds change-kind change-ds-fmt)])
         os ^ByteArrayOutputStream (ByteArrayOutputStream.)
-        ds (data-compilation/compile-dataset {:changes changes :store change-store})
+        ds (data-compilation/compile-dataset {:changes changes :store change-store
+                                              :row-schema (:row-schema change-info)})
         _ (tc/write! ds os {:file-type :csv})
         is ^ByteArrayInputStream (ByteArrayInputStream. (.toByteArray os))
         insert-request (store/make-insert-request! change-store is)]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -228,7 +228,10 @@
         ["" {:post (routes.rev/post-revision-appends-changes-route-config triplestore change-store system-uris)}]]
 
        ["/:revision-id/retractions"
-        {:post (routes.rev/post-revision-deletes-changes-route-config triplestore change-store system-uris)}]]]]]
+        {:post (routes.rev/post-revision-deletes-changes-route-config triplestore change-store system-uris)}]
+       ["/:revision-id/corrections"
+        {:post (routes.rev/post-revision-corrections-changes-route-config triplestore change-store system-uris)}]
+       ]]]]
 
    {;;:reitit.middleware/transform dev/print-request-diffs ;; pretty diffs
     ;;:validate spec/validate ;; enable spec validation for route data

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -103,6 +103,10 @@
   (merge (changes-route-base triplestore change-store system-uris :dh/ChangeKindRetract)
          {:summary "Add deletes changes to a Revision via a CSV file."}))
 
+(defn post-revision-corrections-changes-route-config [triplestore change-store system-uris]
+  (merge (changes-route-base triplestore change-store system-uris :dh/ChangeKindCorrect)
+         {:summary "Add corrections to a Revision via a CSV file."}))
+
 (defn get-revision-changes-route-config [triplestore change-store system-uris]
   {:summary "Retrieve CSV contents for an existing change"
    :coercion (rcm/create {:transformers {}, :validate false})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
@@ -33,7 +33,10 @@
                      [:re {:error/message (format "Should match regex: %s" (str regex))} regex])
      ;; description allows newlines
      :description-string (let [regex #"^\w[\w\s\S\D]+$"]
-                           [:re {:error/message (format "Should match regex: %s" (str regex))} regex])}))
+                           [:re {:error/message (format "Should match regex: %s" (str regex))} regex])
+     :datahost/uri (m/-simple-schema
+                    {:type :uri
+                     :pred #(instance? URI %)})}))
 
 (def registry
   (merge
@@ -45,4 +48,4 @@
 
 (def EntityType [:enum :dh/DatasetSeries :dh/Release :dh/Revision :dh/Change])
 
-(def ChangeKind [:enum :dh/ChangeKindAppend :dh/ChangeKindRetract])
+(def ChangeKind [:enum :dh/ChangeKindAppend :dh/ChangeKindRetract :dh/ChangeKindCorrect])

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
@@ -7,9 +7,18 @@
    [malli.core :as m]
    [malli.error :as me]
    [tablecloth.api :as tc]
+   [tpximpact.datahost.uris :as uris]
+   [tpximpact.datahost.ldapi.schemas.common :as s.common]
    [tpximpact.datahost.ldapi.store :as store]
    [tpximpact.datahost.ldapi.util.data-validation
-    :refer [-as-dataset as-dataset]]))
+    :refer [-as-dataset as-dataset]
+    :as data-validation])
+  (:import
+   (org.apache.commons.codec.digest MurmurHash3)))
+
+(def hash-column-name
+  "Name of the column holding the hash of the row (excluding the measurement itself.)"
+  "datahost.row/hash")
 
 (defmethod -as-dataset tech.v3.dataset.impl.dataset.Dataset [v _opts]
   v)
@@ -21,6 +30,86 @@
   (assert store)
   (with-open [is (store/get-data store v)]
    (as-dataset is opts)))
+
+(defn make-hasher [column-names]
+  (fn hasher* [record]
+    (let [^StringBuilder sb (StringBuilder.)]
+      (.append sb "|")
+      (loop [columns column-names]
+        (if-not (seq columns)
+          (MurmurHash3/hash32 (.toString sb))
+          (do
+            (.append sb (get record (first columns)))
+            (.append sb "|")
+            (recur (next columns))))))))
+
+(defn make-columnwise-hasher []
+  (fn hasher* [& columns]
+    (let [^StringBuilder sb (StringBuilder.)]
+      (.append sb "|")
+      (loop [columns columns]
+        (if-not (seq columns)
+          (MurmurHash3/hash32 (.toString sb))
+          (do
+            (.append sb (first columns))
+            (.append sb "|")
+            (recur (next columns))))))))
+
+(def ^:private measure-type-uri (:measure uris/column-types))
+
+(defn- make-column-info-xform
+  [filter-fn]
+  (comp (map m/properties)
+        (filter filter-fn)
+        (map #(get % :dataset.column/name))))
+
+(def ^:private tuple-schema-component-names-xform
+  "Transducer transforming elements of [[m/children]] output into strings."
+  (make-column-info-xform #(not= measure-type-uri (get % :dataset.column/type))))
+
+(def ^:private tuple-schema-measure-names-xform
+  "Transducer transforming elements of [[mu/children]] output into strings."
+  (make-column-info-xform #(= measure-type-uri (get % :dataset.column/type))))
+
+(defn check-dataset-has-columns
+  [dataset column-names]
+  (when-not (every? #(tc/has-column? dataset %) column-names)
+    (throw (ex-info "Not every required column is in the dataset"
+                    {:dataset-columns (tc/column-names dataset)
+                     :schema-columns column-names}))))
+
+(defn- compile--extract-component-column-names
+  "Returns a seq of column names. Throws when any of the component
+  columns extracted from release-schema are not present in the
+  dataset."
+  [row-schema]
+  (sort (sequence tuple-schema-component-names-xform
+                  ;;(mu/subschemas row-schema)
+                  (m/children row-schema))))
+
+(defn compile--extract-measure-column-name
+  [row-schema]
+  {:post [some?]}
+  (first (sort (sequence tuple-schema-measure-names-xform
+                         ;;(mu/subschemas row-schema)
+                         (m/children row-schema)))))
+
+(defn- add-id-column
+  "Adds a column column containing unique id of the measurment
+  (based on component names from row-schema)."
+  [dataset row-schema]
+  (assert row-schema)
+  (let [col-names (compile--extract-component-column-names row-schema)
+        hasher (make-columnwise-hasher)]
+    (check-dataset-has-columns dataset col-names)
+    (-> dataset
+        (tc/map-columns hash-column-name
+                        :int
+                        col-names
+                        hasher)
+        (vary-meta assoc ::hash-column hash-column-name))))
+
+;;; main functionality
 
 (def dataset-input-type-valid? (m/validator [:or
                                              ;; specify :type in metadata
@@ -37,28 +126,88 @@
                                   :json-schema/example "text/csv"}
     ;; 'native' means we're passing native Clojure data structures.
     [:string {:description "Mime type of the referenced data. Values as in 'dcterms:format'"}]]
-   [:datahost.change/kind [:enum
-                           :dh/ChangeKindAppend
-                           :dh/ChangeKindRetract]]])
+   [:datahost.change/kind s.common/ChangeKind]])
 
 (def CompileDatasetOptions
   (m/schema
    [:map
     [:changes [:sequential ChangeInfo]]
-    [:store {:optional true} [:fn some?]]]))
+    [:store {:optional true} [:fn some?]]
+    [:row-schema data-validation/DatasetRow]]))
+
+(defn- has-hashed-column? [ds]
+  (tc/has-column? ds hash-column-name))
+
+(defmulti -apply-change
+  "Returns a dataset.
+
+  Assumptions:
+  
+  - the base dataset already has column with hashed (named in `hash-column-name`)
+  - the input and result datasets fit in memory."
+  (fn dispatch [ctx base-ds change-ds] (:datahost.change/kind ctx)))
+
+(defmethod -apply-change :dh/ChangeKindAppend [ctx base-ds change-ds]
+  (assert (has-hashed-column? base-ds))
+  (let [{:keys [row-schema]} ctx]
+    (-> base-ds
+        (tc/concat (add-id-column change-ds row-schema))
+        ;; it's an 'append', so we remove already existing entries
+        (tc/unique-by [hash-column-name] {:strategy :first}))))
+
+(defmethod -apply-change :dh/ChangeKindRetract [{:keys [row-schema] :as _ctx} base-ds change-ds]
+  (assert (has-hashed-column? base-ds))
+  (let [change-ds+id (add-id-column change-ds row-schema)]
+    (tc/difference base-ds change-ds+id)))
+
+(defmethod -apply-change :dh/ChangeKindCorrect [ctx base-ds change-ds]
+  (assert (has-hashed-column? base-ds))
+  (let [{:keys [measure-column row-schema]} ctx
+        change-ds-name (tc/dataset-name change-ds)
+        right-col-name (if (= "_unnamed" change-ds-name)
+                         (str "right." measure-column)
+                         (str change-ds-name "." measure-column))
+        change-ds+id (add-id-column change-ds row-schema)
+        corrections-ds (-> (tc/inner-join change-ds+id base-ds [hash-column-name])
+                           (tc/select-columns (-> (tc/column-names base-ds)
+                                                  set
+                                                  (disj right-col-name))))]
+    (-> base-ds
+        (tc/concat corrections-ds)
+        (tc/unique-by [hash-column-name] {:strategy :last}))))
+
+(defn make-change-context
+  [change-kind row-schema]
+  {:row-schema row-schema
+   :datahost.change/kind change-kind
+   :hashable-columns (compile--extract-component-column-names row-schema)
+   :measure-column (compile--extract-measure-column-name row-schema)})
+
+(defn apply-change
+  [context base-ds change-ds]
+  {:pre [(has-hashed-column? base-ds)]}
+  (-apply-change context base-ds change-ds))
+
+(defn- ensure-components-hash-column
+  [dataset row-schema]
+  (if (tc/has-column? dataset hash-column-name)
+    dataset
+    (add-id-column dataset row-schema)))
 
 (def ^:private compile-dataset-opts-valid? (m/validator CompileDatasetOptions))
 
 (defn- compile-reducer
-  [opts ds change]
-  (let [{:datahost.change/keys [kind input-format]} change
+  "Reducer function for creating a dataset out of a seq of [[ChangeInfo]]s"
+  [{row-schema :row-schema :as opts} ds change]
+  (let [{:datahost.change/keys [kind]} change
+        ctx (make-change-context kind row-schema)
         dataset (as-dataset (:datahost.change.data/ref change) opts)]
-    (log/trace "reducer:"
-               {:new {:dataset (tc/dataset-name dataset) :row-count (tc/row-count dataset) :kind kind}
-                :old {:dataset (tc/dataset-name ds) :row-count (tc/row-count ds)}})
-    (case (:datahost.change/kind change)
-      :dh/ChangeKindAppend (tc/concat ds dataset)
-      :dh/ChangeKindRetract (tc/difference ds dataset))))
+    (log/trace "compile-reducer:"
+               {:new {:dataset (tc/dataset-name dataset)
+                      :row-count (tc/row-count dataset) :kind kind}
+                :old {:dataset (tc/dataset-name ds)
+                      :row-count (tc/row-count ds)}})
+    (apply-change ctx (ensure-components-hash-column ds row-schema) dataset)))
 
 (defn compile-dataset
   "Returns a dataset.
@@ -75,7 +224,20 @@
                    (throw (ex-info "First change kind should be an 'append'"
                                    {:kinds (map :datahost.change/kind changes)})))
                  change)
-        ds-opts opts]
-    (reduce (partial compile-reducer ds-opts)
-            (as-dataset (:datahost.change.data/ref change) ds-opts)
-            (next changes))))
+        ds-opts opts
+        base-ds (-> change :datahost.change.data/ref (as-dataset ds-opts))
+        _ (when (tc/has-column? base-ds hash-column-name)
+            (throw (ex-info (format "Base dataset already contains '%s' column"
+                                    hash-column-name)
+                            {:columns (vec (tc/column-names base-ds))})))
+        base-ds (ensure-components-hash-column base-ds (:row-schema opts))]
+    ;; let's ensure data issues in dev are immediately revealed
+    (assert (= (tc/row-count (tc/unique-by base-ds hash-column-name))
+               (tc/row-count base-ds))
+            "Possible data issue: are combinations of all non-measure values unique?")
+    (-> (reduce (partial compile-reducer ds-opts)
+                base-ds
+                (next changes))
+        ;; only return columns that teh caller passed in
+        (tc/select-columns (disj (set (tc/column-names base-ds))
+                                 hash-column-name)))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
@@ -31,18 +31,6 @@
   (with-open [is (store/get-data store v)]
    (as-dataset is opts)))
 
-(defn make-hasher [column-names]
-  (fn hasher* [record]
-    (let [^StringBuilder sb (StringBuilder.)]
-      (.append sb "|")
-      (loop [columns column-names]
-        (if-not (seq columns)
-          (MurmurHash3/hash32 (.toString sb))
-          (do
-            (.append sb (get record (first columns)))
-            (.append sb "|")
-            (recur (next columns))))))))
-
 (defn make-columnwise-hasher []
   (fn hasher* [& columns]
     (let [^StringBuilder sb (StringBuilder.)]
@@ -87,7 +75,7 @@
                   ;;(mu/subschemas row-schema)
                   (m/children row-schema))))
 
-(defn compile--extract-measure-column-name
+(defn- compile--extract-measure-column-name
   [row-schema]
   {:post [some?]}
   (first (sort (sequence tuple-schema-measure-names-xform

--- a/datahost-ld-openapi/src/tpximpact/datahost/uris.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/uris.clj
@@ -1,0 +1,10 @@
+(ns tpximpact.datahost.uris
+  (:import (java.net URI)))
+
+(defrecord ColumnTypes [measure dimension attribute])
+
+(def ^:private col-types-base "https://publishmydata.com/def/datahost")
+
+(def column-types (->ColumnTypes (URI. (str col-types-base "/MeasureColumn"))
+                                 (URI. (str col-types-base "/DimensionColumn"))
+                                 (URI. (str col-types-base "/AttributeColumn"))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -74,7 +74,7 @@
   - change-kind: one of :dh/ChangeKindAppend etc
   - file-path - path to the CSV
   - title - string
-  - url-suffix: strin of the form \"/revisions/3/changes/1"
+  - url-suffix: string of the form \"/revisions/3/changes/1"
   [http-client release-url change-kind revision-title file-path url-suffix]
   (let [{:keys [POST]} http-client
         revision-resp (POST (str release-url "/revisions")

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_compilation_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_compilation_test.clj
@@ -1,40 +1,94 @@
 (ns tpximpact.datahost.ldapi.util.data-compilation-test
   (:require
    [clojure.test :as t :refer [deftest testing is]]
+   [malli.core :as m]
    [tablecloth.api :as tc]
+   [tpximpact.datahost.uris :as uris]
+   [tpximpact.datahost.ldapi.db :as db]
+   [tpximpact.datahost.system-uris :as system-uris]
+   [tpximpact.datahost.ldapi.routes.shared :refer [LdSchemaInput]]
    [tpximpact.datahost.ldapi.util.data-compilation :as dc]
    [tpximpact.datahost.ldapi.util.data-validation
-    :refer [-as-dataset]]))
+    :refer [-as-dataset]
+    :as data-validation])
+  (:import [java.net URI]))
 
 (defmethod -as-dataset :datahost.types/seq-of-maps [v _opts]
     (tc/dataset v))
 
 (def data
-  (let [item (fn [n] {:x n :y n})
+  (let [item (fn [n] {"dim" n "n" n})
         ds-input (fn [r kind]
                    {:datahost.change.data/ref (with-meta (mapv item r) {:type :datahost.types/seq-of-maps})
                     :datahost.change.data/format "native"
                     :datahost.change/kind kind})]
     {1 (ds-input (range 4) :dh/ChangeKindAppend)
      2 (ds-input (range 4 10) :dh/ChangeKindAppend)
-     3 (ds-input (range 8 10) :dh/ChangeKindRetract)}))
+     3 (ds-input (range 8 10) :dh/ChangeKindRetract)
+     4 (update (ds-input (range 5 8) :dh/ChangeKindCorrect)
+               :datahost.change.data/ref
+               (fn [records]
+                 (with-meta (mapv #(update % "n" * 100) records)
+                   (meta records))))
+     5 (ds-input (range 100 120) :dh/ChangeKindRetract)}))
 
 (defn data-record-count [k]
   (count (:datahost.change.data/ref (get data k))))
 
 (deftest compilation-smoke-test
-  (testing "We can create result from appends"
-    (let [result (dc/compile-dataset {:changes [(get data 1)
-                                                (get data 2)]})]
-      (is (= (+ (data-record-count 1)
-                (data-record-count 2))
-             (tc/row-count result)))))
+  (let [system-uris (system-uris/make-system-uris (URI. "https://example.org/data/"))
+        row-schema (m/schema [:tuple
+                              [:maybe {:dataset.column/name "n"
+                                       :dataset.column/type (:measure uris/column-types)} :int]
+                              [:int {:dataset.column/name "dim"
+                                     :dataset.column/type (:dimension uris/column-types)}]])]
+    (assert (data-validation/row-schema-valid? row-schema))
 
-  (testing "We can handle appends and retractions"
-    (let [result (dc/compile-dataset {:changes [(get data 1)
-                                                (get data 2)
-                                                (get data 3)]})]
-      (is (= (+ (data-record-count 1)
-                (data-record-count 2)
-                (- (data-record-count 3)))
-             (tc/row-count result))))))
+    (testing "We can create result from appends"
+      (let [result (dc/compile-dataset {:changes [(get data 1)
+                                                  (get data 2)]
+                                        :row-schema row-schema})]
+        (is (= (+ (data-record-count 1)
+                  (data-record-count 2))
+               (tc/row-count result)))))
+
+    (testing "We can handle appends and retractions"
+      (let [result (dc/compile-dataset {:changes [(get data 1)
+                                                  (get data 2)
+                                                  (get data 3)]
+                                        :row-schema row-schema})]
+        (is (= (+ (data-record-count 1)
+                  (data-record-count 2)
+                  (- (data-record-count 3)))
+               (tc/row-count result)))))
+
+    (testing "We can handle appends and corrections"
+      (let [result (dc/compile-dataset {:changes [(get data 1)
+                                                  (get data 2)
+                                                  (get data 4)]
+                                        :row-schema row-schema})]
+        (is (= (+ (data-record-count 1)
+                  (data-record-count 2))
+               (tc/row-count result)))
+        (is (= [500 600 700] (-> (tc/order-by result "dim")
+                                 (tc/select-columns ["n"])
+                                 (tc/select-rows (range 5 8))
+                                 (tc/->array "n")
+                                 (vec))))))
+    (testing "No changes when correcting items not present in base dataset "
+      (let [result (dc/compile-dataset {:changes [(get data 1)
+                                                  (get data 2)
+                                                  (get data 5)]
+                                        :row-schema row-schema})]
+        (is (= (+ (data-record-count 1)
+                  (data-record-count 2))
+               (tc/row-count result)))))))
+
+(deftest row-schema-validator-test
+  (let [schema-data [:tuple
+                     [:maybe {:dataset.column/name "Foo"
+                              :dataset.column/type (:dimension uris/column-types)} :int]
+                     [:int {:dataset.column/name "Boo"
+                            :dataset.column/type (:measure uris/column-types)}]]]
+   (is (data-validation/row-schema-valid? (m/schema schema-data)))
+   (is (not (data-validation/row-schema-valid? schema-data)))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_validation_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_validation_test.clj
@@ -44,8 +44,10 @@
     
     (let [schema (db/get-release-schema repo (su/dataset-release-uri* system-uris {:series-slug "s1" :release-slug "r1"}))]
       (testing "Creating malli row schemas from JSON-LD schema"
-        (is (= ["Year" "Unit of Measure"]
-               (-> (util.data-validation/make-row-schema schema ["Year" "Unit of Measure"])
+        (is (= ["Year" "Aged 16 to 64 years level 3 or above qualifications"]
+               (-> (util.data-validation/make-row-schema schema
+                                                         ["Year"
+                                                          "Aged 16 to 64 years level 3 or above qualifications"])
                    (util.data-validation/row-schema->column-names)))))
 
       (testing "Validating data"


### PR DESCRIPTION
There are now three change related endpoints:
- '.../appends',
- '.../retractions'
- '.../corrections'

This change deals with the last one. Each of those endpoints accepts a plain CSV. _Plain_ in this context means that it does not include any extra metadata columns. We identify rows by hashing values according to the release schema (all schema columns except the measure column).

The generated snapshot CSVs also don't contain any extra columns.

Additionally: the 'appends' operation now ensures we don't have duplicate rows hashes (we choose the first occurring value, if user wants the later occurring one, they probably want a 'correction').

I've used Murmur hash as the hashing algorithm, as we already have `org.apache.commons.codec.digest.*` in our deps.

Fixes #218 