### PR TITLE
Delete series and all child resources

### DIFF
--- a/datahost-ld-openapi/deps.edn
+++ b/datahost-ld-openapi/deps.edn
@@ -53,7 +53,6 @@
   :test {:extra-paths ["test" "env/test/resources"]
          :extra-deps {lambdaisland/kaocha {:mvn/version "1.85.1342"}
                       lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
-											com.gfredericks/test.chuck {:mvn/version "0.2.13"}
 											org.clojure/data.csv {:mvn/version "1.0.1"}}
          :exec-fn kaocha.runner/exec-fn
          :exec-args {:tests [{:id :unit

--- a/datahost-ld-openapi/deps.edn
+++ b/datahost-ld-openapi/deps.edn
@@ -52,7 +52,9 @@
 
   :test {:extra-paths ["test" "env/test/resources"]
          :extra-deps {lambdaisland/kaocha {:mvn/version "1.85.1342"}
-                      lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}}
+                      lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
+											com.gfredericks/test.chuck {:mvn/version "0.2.13"}
+											org.clojure/data.csv {:mvn/version "1.0.1"}}
          :exec-fn kaocha.runner/exec-fn
          :exec-args {:tests [{:id :unit
                               :test-paths ["test"]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -257,6 +257,16 @@
              [resource-uri :dcterms/description '?description]
              [resource-uri :dcterms/modified '?modified]]}))
 
+(defn- submit-update [triplestore update-query]
+  (let [qs (f/format-update update-query :pretty? true)]
+    (with-open [conn (repo/->connection triplestore)]
+      (pr/update! conn qs))))
+
+(defn- submit-updates [triplestore update-queries]
+  (let [qs (f/format-updates update-queries :pretty? true)]
+    (with-open [conn (repo/->connection triplestore)]
+      (pr/update! conn qs))))
+
 (defn- update-resource-title-description-modified [triplestore resource]
   (let [q (update-resource-title-description-modified-query resource)
         qs (f/format-update q :pretty? true)]
@@ -372,6 +382,51 @@
       (let [created-series (insert-series clock triplestore request-series)]
         {:op :create :jsonld-doc (series->response-body created-series ld-root)}))))
 
+(defn delete-series-changes-query [series-uri]
+  {:prefixes (compact/as-flint-prefixes)
+   :delete [['?change '?p '?o]
+            ['?revision :dh/hasChange '?change]]
+   :where [['?release :dcat/inSeries series-uri]
+           ['?revision :dh/appliesToRelease '?release]
+           ['?revision :dh/hasChange '?change]
+           ['?change '?p '?o]]})
+
+(defn delete-series-revisions-query [series-uri]
+  {:prefixes (compact/as-flint-prefixes)
+   :delete [['?revision '?p '?o]
+            ['?release :dh/hasRevision '?revision]]
+   :where [['?release :dcat/inSeries series-uri]
+           ['?revision :dh/appliesToRelease '?release]
+           ['?revision '?p '?o]]})
+
+(defn delete-series-releases-schemas-query [series-uri]
+  {:prefixes (compact/as-flint-prefixes)
+   :delete [['?schema '?p '?o]
+            ['?release :dh/hasSchema '?schema]]
+   :where [['?release :dcat/inSeries series-uri]
+           ['?release :dh/hasSchema '?schema]
+           ['?schema '?p '?o]]})
+
+(defn delete-series-releases-query [series-uri]
+  {:prefixes (compact/as-flint-prefixes)
+   :delete [['?release '?p '?o]]
+   :where [['?release :dcat/inSeries series-uri]
+           ['?release '?p '?o]]})
+
+(defn delete-series-query [series-uri]
+  {:delete [[series-uri '?p '?o]]
+   :where [[series-uri '?p '?o]]})
+
+(defn delete-series!
+  [triplestore system-uris series-slug]
+  (let [series-uri (su/dataset-series-uri system-uris series-slug)
+        queries [(delete-series-changes-query series-uri)
+                 (delete-series-releases-schemas-query series-uri)
+                 (delete-series-revisions-query series-uri)
+                 (delete-series-releases-query series-uri)
+                 (delete-series-query series-uri)]]
+    (submit-updates triplestore queries)))
+
 (defn upsert-release!
   "Returns a map {:op ... :jsonld-doc ...} where :op conforms to
   `tpximpact.datahost.ldapi.schemas.api/UpsertOp`"
@@ -416,7 +471,7 @@
   "Given a release (as path-params) attempts to fetch the latest
   revision-id and the key of the dataset snapshot (as
   in :dh/revisionSnapshotCSV).
-  
+
   Returns a map of {:data-key ... :revision-id ...} or nil"
   [triplestore system-uris path-params]
   (let [release-uri (su/dataset-release-uri* system-uris  path-params)
@@ -524,7 +579,7 @@
                    [['?e
                      (URI. "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
                      (compact/expand :dh/Change)]
-                    ['?e 
+                    ['?e
                      (compact/expand :dh/appliesToRevision)
                      revision-uri]])]]})
 
@@ -583,7 +638,7 @@
       (int? c)                          ; we got a definitive answer
       (get-change triplestore
                   (su/change-uri* system-uris (assoc params :revision-id prev-rev-id :change-id c)))
-      
+
       (= :find c)                       ; we need to find change-id
       (let [prev-rev-uri (su/dataset-revision-uri* system-uris (assoc params :revision-id prev-rev-id))
             prev-change-id (with-open [conn (repo/->connection triplestore)]
@@ -598,7 +653,7 @@
                                             (assoc params
                                                    :revision-id prev-rev-id
                                                    :change-id prev-change-id) )))
-      
+
       :else (throw (ex-info "Error: illegal state" {:params params})))))
 
 (defn- release-schema-statements [schema]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -72,6 +72,13 @@
     (as-json-ld {:status (op->response-code op)
                  :body jsonld-doc})))
 
+(defn delete-dataset-series [triplestore system-uris {{:keys [series-slug]} :path-params :as request}]
+  (if-let [_series (db/get-dataset-series triplestore (su/dataset-series-uri system-uris series-slug))]
+    (do
+      (db/delete-series! triplestore system-uris series-slug)
+      {:status 204})
+    (errors/not-found-response request)))
+
 (defn get-release
   [triplestore change-store system-uris
    {path-params :path-params

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -72,10 +72,11 @@
     (as-json-ld {:status (op->response-code op)
                  :body jsonld-doc})))
 
-(defn delete-dataset-series [triplestore system-uris {{:keys [series-slug]} :path-params :as request}]
+(defn delete-dataset-series [triplestore change-store system-uris {{:keys [series-slug]} :path-params :as request}]
   (if-let [_series (db/get-dataset-series triplestore (su/dataset-series-uri system-uris series-slug))]
-    (do
-      (db/delete-series! triplestore system-uris series-slug)
+    (let [orphaned-change-keys (db/delete-series! triplestore system-uris series-slug)]
+      (doseq [change-key orphaned-change-keys]
+        (store/-delete change-store change-key))
       {:status 204})
     (errors/not-found-response request)))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -201,7 +201,7 @@
      ["/:series-slug"
       {:get (routes.s/get-series-route-config triplestore system-uris)
        :put (routes.s/put-series-route-config clock triplestore system-uris)
-       :delete (routes.s/delete-series-route-config triplestore system-uris)}]
+       :delete (routes.s/delete-series-route-config triplestore change-store system-uris)}]
 
      ["/:series-slug/releases"
       ["" {:get (routes.rev/get-release-list-route-config triplestore system-uris)}]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -200,7 +200,8 @@
 
      ["/:series-slug"
       {:get (routes.s/get-series-route-config triplestore system-uris)
-       :put (routes.s/put-series-route-config clock triplestore system-uris)}]
+       :put (routes.s/put-series-route-config clock triplestore system-uris)
+       :delete (routes.s/delete-series-route-config triplestore system-uris)}]
 
      ["/:series-slug/releases"
       ["" {:get (routes.rev/get-release-list-route-config triplestore system-uris)}]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
@@ -44,9 +44,9 @@
                            [:status [:enum "error"]]
                            [:message string?]]}}})
 
-(defn delete-series-route-config [triplestore system-uris]
+(defn delete-series-route-config [triplestore change-store system-uris]
   {:summary "Delete a series and all its child resources"
-   :handler (partial handlers/delete-dataset-series triplestore system-uris)
+   :handler (partial handlers/delete-dataset-series triplestore change-store system-uris)
    :parameters {:path {:series-slug string?}}
    :responses {204 {:description "Series existed and was successfully deleted"}
                404 {:description "Series does not exist"}}})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/series.clj
@@ -43,3 +43,10 @@
                     :body [:map
                            [:status [:enum "error"]]
                            [:message string?]]}}})
+
+(defn delete-series-route-config [triplestore system-uris]
+  {:summary "Delete a series and all its child resources"
+   :handler (partial handlers/delete-dataset-series triplestore system-uris)
+   :parameters {:path {:series-slug string?}}
+   :responses {204 {:description "Series existed and was successfully deleted"}
+               404 {:description "Series does not exist"}}})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store.clj
@@ -24,7 +24,10 @@
   (-data-key [this data]
     "Returns a unique key for the given data. The key can be used to
     look up if the store already contains the data. The returned value
-    should be treated as an opaque object."))
+    should be treated as an opaque object.")
+
+  (-delete [this data-key]
+    "Deletes the data associated with data-key from this store"))
 
 (defn insert-data
   [store data]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/file.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/store/file.clj
@@ -78,7 +78,12 @@
         (throw (ex-info "Data not found for key" {:key data-key})))))
 
   (-data-key [_this data]
-    (file->digest data "SHA-256")))
+    (file->digest data "SHA-256"))
+
+  (-delete [_this data-key]
+    (let [location (file-location root-dir data-key)]
+      (when (.exists location)
+        (.delete location)))))
 
 (defn get-root-dir
   "Returns the root directory of a file store"

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/client/ring.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/client/ring.clj
@@ -1,0 +1,98 @@
+(ns tpximpact.datahost.ldapi.client.ring
+  (:require
+    [clojure.data.json :as json]
+    [clojure.set :as set]
+    [grafter-2.rdf4j.repository :as repo]
+    [tpximpact.datahost.ldapi.models.resources :as resources]
+    [tpximpact.datahost.ldapi.router :as router]
+    [tpximpact.datahost.ldapi.store.temp-file-store :as tfstore]
+    [tpximpact.datahost.system-uris :as su]
+    [tpximpact.datahost.time :as time])
+  (:import [java.io File]
+           [java.net URI]
+           [java.lang AutoCloseable]))
+
+(defrecord RingClient [handler clock repo store system-uris]
+  AutoCloseable
+  (close [_this]
+    (.close store)))
+
+(defn system-uris [client]
+  (:system-uris client))
+
+(defn repo [client]
+  (:repo client))
+
+(defn create-client []
+  (let [store (tfstore/create-temp-file-store)
+        repo (repo/sail-repo)
+        t (time/parse "2023-06-29T10:11:07Z")
+        clock (time/manual-clock t)
+        system-uris (su/make-system-uris (URI. "http://example.com/"))
+        handler (router/handler {:clock clock :triplestore repo :change-store store :system-uris system-uris})]
+    (->RingClient handler clock repo store system-uris)))
+
+(defn- response-body->string [body]
+  (if (string? body)
+    body
+    (slurp body)))
+
+(defmulti create-resource (fn [_client _at resource] (::resources/type resource)))
+
+(defmethod create-resource :dh/Change [{:keys [handler clock] :as _client} at change]
+  (time/set-now clock at)
+  (let [appends-file (File/createTempFile "change" nil)
+        data (resources/change-csv change)]
+    (try
+      (spit appends-file data)
+      (let [request {:uri (resources/create-resource-path change)
+                     :request-method :post
+                     :query-params (merge {"format" "text/csv"}
+                                          (set/rename-keys (resources/resource->doc change)
+                                                           {"dcterms:title" "title"
+                                                            "dcterms:description" "description"}))
+                     :headers {"content-type" "text/csv"}
+                     :body data}
+            response (handler request)]
+        (if (= 201 (:status response))
+          (resources/on-created change response)
+          (throw (ex-info "Failed to create change" {:response (update response :body response-body->string)}))))
+      (finally
+        (.delete appends-file)))))
+
+(defmethod create-resource :default [{:keys [handler clock] :as _client} at resource]
+  (time/set-now clock at)
+  (let [request {:uri (resources/create-resource-path resource)
+                 :request-method (resources/resource-create-method resource)
+                 :headers {"content-type" "application/json" "accept" "application/ld+json"}
+                 :body (json/write-str (resources/resource->doc resource))}
+        response (handler request)]
+    (if (contains? #{200 201} (:status response))
+      (resources/on-created resource response)
+      (throw (ex-info "Failed to create resource" {:resource resource :request request :response response})))))
+
+(defn delete-resource [{:keys [handler clock]} at resource]
+  (time/set-now clock at)
+  (let [request {:request-method :delete
+                 :uri (resources/resource-path resource)}
+        {:keys [status] :as response} (handler request)]
+    (when (>= status 400)
+      (throw (ex-info "Request failed" {:request request :response response})))))
+
+(defmulti get-resource (fn [_client resource] (::resources/type resource)))
+
+(defmethod get-resource :dh/Change [{:keys [handler] :as _client} change]
+  (let [request {:request-method :get
+                 :uri (resources/resource-path change)
+                 :headers {"accept" "text/csv"}}
+        {:keys [status body] :as response} (handler request)]
+    (when (= 200 status)
+      body)))
+
+(defmethod get-resource :default [{:keys [handler] :as client} resource]
+  (let [request {:request-method :get
+                 :uri (resources/resource-path resource)
+                 :headers {"accept" "application/json"}}
+        {:keys [status body] :as _response} (handler request)]
+    (when (= 200 status)
+      (json/read-str body))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/resources.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/resources.clj
@@ -1,0 +1,120 @@
+(ns tpximpact.datahost.ldapi.models.resources
+  (:require [clojure.data.csv :as csv]
+            [tpximpact.datahost.system-uris :as su])
+  (:import [java.io StringWriter]
+           [java.net URI]))
+
+(defn create-series [slug properties]
+  {::type :dh/DatasetSeries
+   :slug slug
+   :releases []
+   :properties properties})
+
+(defn create-release [slug properties]
+  {::type :dh/Release
+   :slug slug
+   :properties properties})
+
+(defn create-schema [properties]
+  {::type :dh/TableSchema
+   :properties properties})
+
+(defn create-revision [properties]
+  {::type :dh/Revision
+   :properties properties})
+
+(defn create-change [change-kind rows properties]
+  {::type :dh/Change
+   :change-kind change-kind
+   :properties properties
+   :rows rows})
+
+(defn set-parent [child parent]
+  (assoc child :parent parent))
+
+(defn get-parent [resource]
+  (:parent resource))
+
+(defn change-csv [{:keys [rows] :as _change}]
+  (with-open [w (StringWriter.)]
+    (csv/write-csv w rows)
+    (.flush w)
+    (str w)))
+
+(defmulti resource-path (fn [resource] (::type resource)))
+
+(defmethod resource-path :dh/DatasetSeries [{:keys [slug]}]
+  (str "/data/" slug))
+
+(defmethod resource-path :dh/Release [{:keys [slug] :as release}]
+  (str (resource-path (get-parent release)) "/releases/" slug))
+
+(defmethod resource-path :dh/TableSchema [schema]
+  (str (resource-path (get-parent schema)) "/schema"))
+
+(defmethod resource-path :dh/Revision [revision]
+  (:location revision))
+
+(defmethod resource-path :dh/Change [change]
+  (:location change))
+
+(defmulti create-resource-path (fn [resource] (::type resource)))
+
+(defmethod create-resource-path :default [resource]
+  (resource-path resource))
+
+(defmethod create-resource-path :dh/Revision [revision]
+  (str (resource-path (get-parent revision)) "/revisions"))
+
+(defmethod create-resource-path :dh/Change [{:keys [change-kind] :as change}]
+  (let [change-path (case change-kind
+                      :dh/ChangeKindAppend "appends"
+                      :dh/ChangeKindRetract "retractions"
+                      :dh/ChangeKindCorrect "corrections")]
+    (str (resource-path (get-parent change)) "/" change-path)))
+
+(defmulti resource-uri (fn [_system-uris resource] (::type resource)))
+
+(defmethod resource-uri :dh/DatasetSeries [system-uris {:keys [slug] :as _series}]
+  (su/dataset-series-uri system-uris slug))
+
+(defmethod resource-uri :dh/Release [system-uris {:keys [slug] :as release}]
+  (let [series-uri (resource-uri system-uris (get-parent release))]
+    (su/dataset-release-uri system-uris series-uri slug)))
+
+(defmethod resource-uri :dh/TableSchema [system-uris schema]
+  (let [{release-slug :slug :as release} (get-parent schema)
+        {series-slug :slug :as _series} (get-parent release)]
+    (su/release-schema-uri system-uris {:series-slug series-slug :release-slug release-slug})))
+
+(defn- location->resource-uri [system-uris location]
+  (let [^URI base-uri (su/rdf-base-uri system-uris)
+        rel-path (.replaceFirst location "/data/" "")]
+    (.resolve base-uri rel-path)))
+(defmethod resource-uri :dh/Revision [system-uris {:keys [location] :as _revision}]
+  (location->resource-uri system-uris location))
+
+(defmethod resource-uri :dh/Change [system-uris {:keys [location] :as _change}]
+  (location->resource-uri system-uris location))
+
+(defn resource->doc [resource]
+  (:properties resource))
+
+(defmulti on-created (fn [resource _create-response] (::type resource)))
+
+(defmethod on-created :dh/Revision [revision create-response]
+  (assoc revision :location (get-in create-response [:headers "Location"])))
+
+(defmethod on-created :dh/Change [change create-response]
+  (assoc change :location (get-in create-response [:headers "Location"])))
+
+(defmethod on-created :default [resource _create-response]
+  resource)
+
+(defmulti resource-create-method (fn [resource] (::type resource)))
+(defmethod resource-create-method :default [_resource] :put)
+(defmethod resource-create-method :dh/TableSchema [_schema] :post)
+
+(defmethod resource-create-method :dh/Revision [_revision] :post)
+
+(defmethod resource-create-method :dh/Change [_change] :post)

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/temp_file_store.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/store/temp_file_store.clj
@@ -15,6 +15,8 @@
     (store/get-data file-store data-key))
   (-data-key [_this data]
     (store/data-key file-store data))
+  (-delete [_this data-key]
+    (store/-delete file-store data-key))
 
   AutoCloseable
   (close [_]


### PR DESCRIPTION
Fixes #155 - Add DELETE route for series which deletes the route along with all child resources (releases, revisions etc.). Also deletes any changes within the change store only referenced by the deleted series.