### PR TITLE
Change domain for ldapi and graphql dev environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,3 +209,21 @@ workflows:
           filters:
             branches:
               only: main
+      - deploy-graphql-vm:
+          context:
+            - swirrl-ons-datahost-gcloud
+          requires:
+            - deploy-graphql-service
+          env: ons
+          filters:
+            branches:
+              only: ons
+      - deploy-ldapi-vm:
+          context:
+            - swirrl-ons-datahost-gcloud
+          requires:
+            - deploy-ld-openapi-service
+          env: ons
+          filters:
+            branches:
+              only: ons

--- a/deploy/terraform/graphql/environments/dev/main.tf
+++ b/deploy/terraform/graphql/environments/dev/main.tf
@@ -18,7 +18,7 @@ module "dev" {
   digest = var.digest
   gcloud_zone = "europe-west2-a"
   dns = {
-    host = "graphql-prototype"
+    host = "graphql-dev"
     zone = "gss-data.org.uk"
   }
 }

--- a/deploy/terraform/graphql/environments/ons/.terraform.lock.hcl
+++ b/deploy/terraform/graphql/environments/ons/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.0.1"
+  constraints = "5.0.1"
+  hashes = [
+    "h1:SB38lIGsF3yHKujEBnTSsH4VOAskn8XZNPpuCPuhJYw=",
+    "zh:006daf4060087b5f0c13562beed33f524a6f9e04ebd72a782bfe60502076368f",
+    "zh:0f49636550aadd373c7e5c710600901c2f153ddd71b6c50482e1afdbb3f8d95d",
+    "zh:1999d2fad0a7a884aab0d191507cf895df0ea7201369a2ef37529f4253ce1065",
+    "zh:1b51774866cddca5a2da5a09a316e9ca078fc821f47611a184245ca892e9335d",
+    "zh:2875579acceba1403563c4281c76a3a9b53b970ed6494e5370e27efb6430bb50",
+    "zh:349eb9ab7c026b72154ce55c7bf9a69ebb3c3a4745ecfdb0c593400762ed1b0c",
+    "zh:38f96c14db5b3beb80748010c0a97dd097a303b24c8478a1286ce1f48a1a0375",
+    "zh:3d212e6e4fc54584e47faeccf501e5a68266c7fe9e36d89ad787c2e1f0e86197",
+    "zh:3ea61ab960ef34ff66457319b9083c8645a9f801f7b5578e7e3f616e26945f90",
+    "zh:584db6d88a07cac639f746104ccd5ed5c517ed99f892a143dad3bb64023098fc",
+    "zh:653def88ffa17b628459f942e743d30ab9fc2194af464d88258a784d9282f9f9",
+    "zh:9737008fea7ffbf5782fceb0108a283e91992c47bfcb93ec55ef43deaa7e509d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ce3ba0cabc1704c584cc46bf1432b14ba1d34b1a30e03a5694b5940cf1673ab8",
+    "zh:de3e6d4e1defc6032359fc229000a1458d777adb07974293f194dde069adcc04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.64.0"
+  constraints = "4.64.0"
+  hashes = [
+    "h1:fA1kuAkOfuDLSdpcyKpeBPZinyPWLpmzBcRyNiaSxYc=",
+    "zh:097fcb0a45fa41c2476deeb7a9adeadf5142e35e4d1a9eeb7b1720900a06807c",
+    "zh:177e6e34f10efb5cec16b4106af5aef5240f20c33d91d40f3ea73fdc6ce9a24a",
+    "zh:3331b0f62f900f8f1447e654a7318f3db03723739ac5dcdc446f1a1b1bf5fd0b",
+    "zh:39e5a19693f8d598d35968660837d1b55ca82d7c314cd433fd957d1c2a5b6616",
+    "zh:44d09cb871e7ec242610d84f93367755d0c532f744e5871a032cdba430e39ec7",
+    "zh:77769c0f8ace0be3f85b702b7d4cc0fd43d89bfbea1493166c4f288338222f0a",
+    "zh:a83ca3e204a85d1d04ee7a6432fdabc7b7e2ef7f46513b6309d8e30ea9e855a3",
+    "zh:bbf1e983d24877a690886aacd48085b37c8c61dc65e128707f36b7ae6de11abf",
+    "zh:c359fcf8694af0ec490a1784575eeb355d6e5a922b225f49d5307a06e9715ad0",
+    "zh:f0df551e19cf8cc9a021a4148518a610b856a50a55938710837fa55b4fbd252f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb171d37178d46d711f3e09107492343f8356c1237bc6df23114920dc23c4528",
+  ]
+}

--- a/deploy/terraform/graphql/environments/ons/main.tf
+++ b/deploy/terraform/graphql/environments/ons/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  # S3 backend state configuration
+  backend "s3" {
+    bucket = "swirrl-terraform-states"
+    key = "datahost/ons/graphql.tfstate"
+    region = "eu-west-2"
+
+    dynamodb_table = "swirrl-terraform-locks"
+    encrypt = true
+  }
+}
+
+module "ons" {
+  source = "../../modules/env"
+
+  name = "ons"
+  gcloud_project = "swirrl-ons-datahost"
+  digest = var.digest
+  gcloud_zone = "europe-west2-a"
+  dns = {
+    host = "graphql-prototype"
+    zone = "gss-data.org.uk"
+  }
+}

--- a/deploy/terraform/graphql/environments/ons/variables.tf
+++ b/deploy/terraform/graphql/environments/ons/variables.tf
@@ -1,0 +1,4 @@
+variable "digest" {
+  type = string
+  description = "SHA256 digest of the graphql application image to deploy"
+}

--- a/deploy/terraform/graphql/modules/load_balancer/main.tf
+++ b/deploy/terraform/graphql/modules/load_balancer/main.tf
@@ -118,7 +118,7 @@ data "aws_route53_zone" "graphql_zone" {
 
 resource "aws_route53_record" "graphql_record" {
   zone_id = data.aws_route53_zone.graphql_zone.zone_id
-  name = "graphql-prototype.gss-data.org.uk"
+  name = local.fqdn
   type = "A"
   ttl = 300
   records = [google_compute_global_address.lb_address.address]

--- a/deploy/terraform/ldapi/environments/dev/main.tf
+++ b/deploy/terraform/ldapi/environments/dev/main.tf
@@ -19,7 +19,7 @@ module "dev" {
 
   gcloud_zone = "europe-west2-a"
   dns = {
-    host = "ldapi-prototype"
+    host = "ldapi-dev"
     zone = "gss-data.org.uk"
   }
 }

--- a/deploy/terraform/ldapi/environments/ons/.terraform.lock.hcl
+++ b/deploy/terraform/ldapi/environments/ons/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.0.1"
+  constraints = "5.0.1"
+  hashes = [
+    "h1:SB38lIGsF3yHKujEBnTSsH4VOAskn8XZNPpuCPuhJYw=",
+    "zh:006daf4060087b5f0c13562beed33f524a6f9e04ebd72a782bfe60502076368f",
+    "zh:0f49636550aadd373c7e5c710600901c2f153ddd71b6c50482e1afdbb3f8d95d",
+    "zh:1999d2fad0a7a884aab0d191507cf895df0ea7201369a2ef37529f4253ce1065",
+    "zh:1b51774866cddca5a2da5a09a316e9ca078fc821f47611a184245ca892e9335d",
+    "zh:2875579acceba1403563c4281c76a3a9b53b970ed6494e5370e27efb6430bb50",
+    "zh:349eb9ab7c026b72154ce55c7bf9a69ebb3c3a4745ecfdb0c593400762ed1b0c",
+    "zh:38f96c14db5b3beb80748010c0a97dd097a303b24c8478a1286ce1f48a1a0375",
+    "zh:3d212e6e4fc54584e47faeccf501e5a68266c7fe9e36d89ad787c2e1f0e86197",
+    "zh:3ea61ab960ef34ff66457319b9083c8645a9f801f7b5578e7e3f616e26945f90",
+    "zh:584db6d88a07cac639f746104ccd5ed5c517ed99f892a143dad3bb64023098fc",
+    "zh:653def88ffa17b628459f942e743d30ab9fc2194af464d88258a784d9282f9f9",
+    "zh:9737008fea7ffbf5782fceb0108a283e91992c47bfcb93ec55ef43deaa7e509d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ce3ba0cabc1704c584cc46bf1432b14ba1d34b1a30e03a5694b5940cf1673ab8",
+    "zh:de3e6d4e1defc6032359fc229000a1458d777adb07974293f194dde069adcc04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.64.0"
+  constraints = "4.64.0"
+  hashes = [
+    "h1:fA1kuAkOfuDLSdpcyKpeBPZinyPWLpmzBcRyNiaSxYc=",
+    "zh:097fcb0a45fa41c2476deeb7a9adeadf5142e35e4d1a9eeb7b1720900a06807c",
+    "zh:177e6e34f10efb5cec16b4106af5aef5240f20c33d91d40f3ea73fdc6ce9a24a",
+    "zh:3331b0f62f900f8f1447e654a7318f3db03723739ac5dcdc446f1a1b1bf5fd0b",
+    "zh:39e5a19693f8d598d35968660837d1b55ca82d7c314cd433fd957d1c2a5b6616",
+    "zh:44d09cb871e7ec242610d84f93367755d0c532f744e5871a032cdba430e39ec7",
+    "zh:77769c0f8ace0be3f85b702b7d4cc0fd43d89bfbea1493166c4f288338222f0a",
+    "zh:a83ca3e204a85d1d04ee7a6432fdabc7b7e2ef7f46513b6309d8e30ea9e855a3",
+    "zh:bbf1e983d24877a690886aacd48085b37c8c61dc65e128707f36b7ae6de11abf",
+    "zh:c359fcf8694af0ec490a1784575eeb355d6e5a922b225f49d5307a06e9715ad0",
+    "zh:f0df551e19cf8cc9a021a4148518a610b856a50a55938710837fa55b4fbd252f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb171d37178d46d711f3e09107492343f8356c1237bc6df23114920dc23c4528",
+  ]
+}

--- a/deploy/terraform/ldapi/environments/ons/main.tf
+++ b/deploy/terraform/ldapi/environments/ons/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  # S3 backend state configuration
+  backend "s3" {
+    bucket = "swirrl-terraform-states"
+    key = "datahost/ons/ldapi.tfstate"
+    region = "eu-west-2"
+
+    dynamodb_table = "swirrl-terraform-locks"
+    encrypt = true
+  }
+}
+
+module "ons" {
+  source = "../../modules/env"
+
+  gcloud_project = "swirrl-ons-datahost"
+  name = "ons"
+  digest = var.digest
+
+  gcloud_zone = "europe-west2-a"
+  dns = {
+    host = "ldapi-prototype"
+    zone = "gss-data.org.uk"
+  }
+}

--- a/deploy/terraform/ldapi/environments/ons/variables.tf
+++ b/deploy/terraform/ldapi/environments/ons/variables.tf
@@ -1,0 +1,4 @@
+variable "digest" {
+  type = string
+  description = "SHA256 digest of the ldapi application container to deploy"
+}


### PR DESCRIPTION
Issue #254 - Change the hosts for the ldapi and graphql servers within their respective dev environments.

Use the module parameters to set the domain name within the graphql load balancer module.