### PR TITLE
Extra metadata

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/compact.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/compact.clj
@@ -27,4 +27,5 @@
 (add-prefix :dh (URI. "https://publishmydata.com/def/datahost/"))
 (add-prefix :appropriate-csvw (URI. "https://publishmydata.com/def/appropriate-csvw/"))
 (add-prefix :csvw (URI. "http://www.w3.org/ns/csvw#"))
+(add-prefix :rdfs (URI. "http://www.w3.org/2000/01/rdf-schema#"))
 (add-grafter-prefixes)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -139,11 +139,17 @@
              :construct (conj bgps
                               [revision-uri :dh/hasChange '?change]
                               [revision-uri :dcterms/description '?description]
-                              [revision-uri :dh/revisionSnapshotCSV '?snapshot])
+                              [revision-uri :dh/revisionSnapshotCSV '?snapshot]
+                              [revision-uri :dh/publicationDate '?publicationDate]
+                              [revision-uri :dcterms/license '?license]
+                              [revision-uri :dh/reasonForChange '?reasonForChange])
              :where (conj bgps
                           [:optional [[revision-uri :dh/hasChange '?change]]]
                           [:optional [[revision-uri :dcterms/description '?description]]]
-                          [:optional [['?change :dh/revisionSnapshotCSV '?snapshot]]])})]
+                          [:optional [['?change :dh/revisionSnapshotCSV '?snapshot]]]
+                          [:optional [[revision-uri :dh/publicationDate '?publicationDate]]]
+                          [:optional [[revision-uri :dcterms/license '?license]]]
+                          [:optional [[revision-uri :dh/reasonForChange '?reasonForChange]]])})]
     (datastore/eager-query triplestore
                            (f/format-query q :pretty? true))))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -54,13 +54,21 @@
                        [release-uri :dh/hasRevision '?revision]
                        [release-uri :dh/hasSchema '?schema]
                        [release-uri :dcterms/modified '?modified]
-                       [release-uri :dcterms/issued '?issued]]
+                       [release-uri :dcterms/issued '?issued]
+                       [release-uri :dcterms/license '?license]
+                       [release-uri :dh/coverage '?coverage]
+                       [release-uri :dh/geographyDefinition '?geoDefinition]
+                       [release-uri :dh/reasonForChange '?reasonForChange]]
            :where [[release-uri 'a :dh/Release]
                    [release-uri :dcterms/title '?title]
                    [release-uri :dcat/inSeries '?series]
                    [:optional [[release-uri :dh/hasRevision '?revision]]]
                    [:optional [[release-uri :dh/hasSchema '?schema]]]
                    [:optional [[release-uri :dcterms/description '?description]]]
+                   [:optional [[release-uri :dcterms/license '?license]]]
+                   [:optional [[release-uri :dh/coverage '?coverage]]]
+                   [:optional [[release-uri :dh/geographyDefinition '?geoDefinition]]]
+                   [:optional [[release-uri :dh/reasonForChange '?reasonForChange]]]
                    [release-uri :dcterms/modified '?modified]
                    [release-uri :dcterms/issued '?issued]]}]
     (datastore/eager-query triplestore
@@ -78,7 +86,7 @@
                                        [series-uri :rdfs/comment '?comment]
                                        [series-uri :dcterms/publisher '?publisher]
                                        [series-uri :dcat/theme '?theme]
-                                       [series-uri :dcterms/license '?licence]
+                                       [series-uri :dcterms/license '?license]
                                        [series-uri :dcat/keywords '?keywords]
                                        [series-uri :dh/nextUpdate '?nextUpdate]
                                        [series-uri :dh/relatedLinks '?links]
@@ -90,7 +98,7 @@
                                    [:optional [[series-uri :rdfs/comment '?comment]]]
                                    [:optional [[series-uri :dcterms/publisher '?publisher]]]
                                    [:optional [[series-uri :dcat/theme '?theme]]]
-                                   [:optional [[series-uri :dcterms/license '?licence]]]
+                                   [:optional [[series-uri :dcterms/license '?license]]]
                                    [:optional [[series-uri :dcat/keywords '?keywords]]]
                                    [:optional [[series-uri :dh/nextUpdate '?nextUpdate]]]
                                    [:optional [[series-uri :dh/relatedLinks '?links]]]
@@ -356,7 +364,7 @@
   (resource/->json-ld series (output-context ["dh" "dcterms" "rdf" "rdfs" "dcat" "csvw" "appropriate-csvw"] ld-root)))
 
 (defn release->response-body [release ld-root]
-  (resource/->json-ld release (output-context ["dh" "dcterms" "rdf" "dcat" "csvw" "appropriate-csvw"] ld-root)))
+  (resource/->json-ld release (output-context ["dh" "dcterms" "rdf" "rdfs" "dcat" "csvw" "appropriate-csvw"] ld-root)))
 
 (defn revision->response-body [revision ld-root]
   (resource/->json-ld revision (output-context ["dh" "dcterms" "rdf"] ld-root)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -111,6 +111,7 @@
 
 (defn put-release [clock triplestore system-uris {path-params :path-params
                                                   body-params :body-params :as request}]
+
   (if (db/resource-exists? triplestore (su/dataset-series-uri* system-uris path-params))
     (let [api-params (get-api-params request)
           incoming-jsonld-doc body-params

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
@@ -7,6 +7,7 @@
 
 (defn simple-context [system-uris]
   {:rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   :rdfs "http://www.w3.org/2000/01/rdf-schema#"
    :dh "https://publishmydata.com/def/datahost/"
    :dcat "http://www.w3.org/ns/dcat#"
    :dcterms "http://purl.org/dc/terms/"

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -38,7 +38,18 @@
 
 (def CreateSeriesInput
   "Input schema for creating a new series."
-  required-input-fragment)
+  (m/schema
+   [:map
+    ["dcterms:title" {:optional false} :title-string]
+    ["dcterms:description" {:optional false} :description-string]
+    ["rdfs:comment" {:optional true} :string]
+    ["dcterms:publisher" {:optional true} :datahost/url-string]
+    ["dcat:theme" {:optional true} :datahost/url-string]
+    ["dcterms:license" {:optional true} :datahost/url-string]
+    ["dh:contactName" {:optional true} :string]
+    ["dh:contactEmail" {:optional true} :email-string]
+    ["dh:contactPhone" {:optional true} :string]]
+   {:registry s.common/registry}))
 
 (def CreateReleaseInput
   "Input schema for creating a new release."

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
@@ -22,7 +22,7 @@
                                                 false))))})
      :datahost/timestamp (let [utc-tz (ZoneId/of "UTC")]
                            (m/-simple-schema
-                             {:type :datahost/timestamp
+                            {:type :datahost/timestamp
                              :pred (fn timestamp-pred [ts]
                                      (and (instance? ZonedDateTime ts)
                                           (= (.getZone ^ZonedDateTime ts) utc-tz)))}))
@@ -34,7 +34,7 @@
      ;; description allows newlines
      :description-string (let [regex #"^\w[\w\s\S\D]+$"]
                            [:re {:error/message (format "Should match regex: %s" (str regex))} regex])
-     :email-string (let [regex #"^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$"]
+     :email-string (let [regex #"^\S+@\S+\.\S+$"]
                      [:re {:error/message (format "Should match regex: %s" (str regex))} regex])
 
      :datahost/uri (m/-simple-schema

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/schemas/common.clj
@@ -8,8 +8,8 @@
 
 (def ^:private custom-registry-keys
   (let [slug-error-msg "should contain alpha numeric characters and hyphens only."]
-    {:datahost/slug-string [:and 
-                            :string 
+    {:datahost/slug-string [:and
+                            :string
                             [:re {:error/message slug-error-msg}
                              #"^[a-z,A-Z,\-,0-9]+$"]]
      :datahost/url-string (m/-simple-schema
@@ -22,11 +22,11 @@
                                                 false))))})
      :datahost/timestamp (let [utc-tz (ZoneId/of "UTC")]
                            (m/-simple-schema
-                            {:type :datahost/timestamp
+                             {:type :datahost/timestamp
                              :pred (fn timestamp-pred [ts]
                                      (and (instance? ZonedDateTime ts)
                                           (= (.getZone ^ZonedDateTime ts) utc-tz)))}))
-     
+
      ;; swagger-ui complains when namespaced keys are used,
      ;; so using non-namespaced
      :title-string (let [regex (str #"^\w[\w\s\D]+$")]
@@ -34,6 +34,9 @@
      ;; description allows newlines
      :description-string (let [regex #"^\w[\w\s\S\D]+$"]
                            [:re {:error/message (format "Should match regex: %s" (str regex))} regex])
+     :email-string (let [regex #"^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$"]
+                     [:re {:error/message (format "Should match regex: %s" (str regex))} regex])
+
      :datahost/uri (m/-simple-schema
                     {:type :uri
                      :pred #(instance? URI %)})}))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/series_test.clj
@@ -44,7 +44,17 @@
           system-uris (su/make-system-uris (URI. "https://example.org/data/"))
           handler (router/handler {:clock clock :triplestore repo :change-store temp-store :system-uris system-uris})
           request (create-put-request "new-series" {"dcterms:title" "A title"
-                                                    "dcterms:description" "Description"})
+                                                    "dcterms:description" "Description"
+                                                    "rdfs:comment" "Comment"
+                                                    "dcterms:publisher" "http://publisher-uri"
+                                                    "dcat:theme" "http://theme-uri"
+                                                    "dcterms:license" "http://uri-of-a-licence.org"
+                                                    "dcat:keywords" #{"keyword1" "keyword2"}
+                                                    "dh:nextUpdate" "2024-06-30"
+                                                    "dh:relatedLinks" #{"http://related-1" "http://related-2"}
+                                                    "dh:contactName" "Rob Chambers"
+                                                    "dh:contactEmail" "heyrob@example.com"
+                                                    "dh:contactPhone" "123234234234"})
           {:keys [status body]} (handler request)
           new-series-doc (json/read-str body)]
       (t/is (= 201 status))
@@ -53,6 +63,18 @@
       (t/is (= (str t) (get new-series-doc "dcterms:modified")))
       (t/is (= (str t) (get new-series-doc "dcterms:issued")))
       (t/is (= (get new-series-doc "dh:baseEntity") "https://example.org/data/new-series"))
+
+      (t/is (= "Comment" (get new-series-doc "rdfs:comment")))
+      (t/is (= "http://publisher-uri" (get new-series-doc "dcterms:publisher")))
+      (t/is (= "http://theme-uri" (get new-series-doc "dcat:theme")))
+      (t/is (= "http://uri-of-a-licence.org" (get new-series-doc "dcterms:license")))
+      (t/is (= #{"keyword1"  "keyword2"} (set (get new-series-doc "dcat:keywords"))))
+      (t/is (= "2024-06-30" (get new-series-doc "dh:nextUpdate")))
+      (t/is (= ["http://related-1"
+                "http://related-2"] (get new-series-doc "dh:relatedLinks")))
+      (t/is (= "Rob Chambers" (get new-series-doc "dh:contactName")))
+      (t/is (= "heyrob@example.com" (get new-series-doc "dh:contactEmail")))
+      (t/is (= "123234234234" (get new-series-doc "dh:contactPhone")))
 
       ;; fetch created series
       (let [request {:uri "/data/new-series"


### PR DESCRIPTION
This issue adds the extra metadata fields that Rob [requested in this doc](https://docs.google.com/spreadsheets/d/1YB6O3icfqKuW_BF4rb8dqnjZT0hNtpLJJ1MP3NO2TIg/edit#gid=0).

Note the predicates are added pretty fast-and-loose here. We would want to standardize/agree these if we were proceeding for real. For now this accomplishes the goal of allowing users to attach extra information to each resource. The new predicates that are "coined" as a result of this pr are (where `:dh` is `https://publishmydata.com/def/datahost/`):

`:dh/nextUpdate`
`:dh/relatedLinks`
`:dh/contactName`
`:dh/contactEmail`
`:dh/contactPhone`
`:dh/publicationDate`
`:dh/reasonForChange`

The decision to omit these extra metadata fields from collection endpoints was intentional, in the interest of keeping bulk responses smaller -- my thinking being that if a user wanted to full/verbose data on a given resource they can request it individually.