### PR TITLE
ensure dataset column types match the ones in Release schema

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -261,8 +261,8 @@
   "Returns a map {:dataset DATASET (optional-key :error-response) ..., row-schema MALLI-SCHEMA},
   containing :error-response entry when validation failed."
   [release-schema appends]
-  (let [dataset (data-validation/as-dataset appends {})
-        row-schema (data-validation/make-row-schema release-schema)
+  (let [row-schema (data-validation/make-row-schema release-schema)
+        dataset (data-validation/as-dataset appends {:convert-types {:row-schema row-schema}})
         {:keys [explanation]} (data-validation/validate-dataset dataset row-schema
                                                                 {:fail-fast? true})]
     (cond-> {:dataset dataset :row-schema row-schema}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers/internal.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers/internal.clj
@@ -53,7 +53,7 @@
   - the existing dataset snapshot fits in memory
   - the new snapshot (existing snapshot + changes) fits in memory."
   [{:keys [triplestore change-store system-uris] :as sys}
-   {:keys [change-id change-kind path-params] change-ds :dataset :as change-info}]
+   {:keys [change-id change-kind path-params row-schema] change-ds :dataset :as change-info}]
   {:pre [(m/validate s.common/ChangeKind change-kind) (contains? change-info "dcterms:format")]}
   (let [prev-ds-snapshot-key (previous-dataset-snapshot-key sys (assoc path-params :change-id change-id))
         change-ds-fmt (get change-info "dcterms:format")
@@ -63,7 +63,8 @@
                   [(->change-info change-ds change-kind change-ds-fmt)])
         os ^ByteArrayOutputStream (ByteArrayOutputStream.)
         ds (data-compilation/compile-dataset {:changes changes :store change-store
-                                              :row-schema (:row-schema change-info)})
+                                              :convert-types {:row-schema row-schema}
+                                              :row-schema row-schema})
         _ (tc/write! ds os {:file-type :csv})
         is ^ByteArrayInputStream (ByteArrayInputStream. (.toByteArray os))
         insert-request (store/make-insert-request! change-store is)]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
@@ -122,6 +122,7 @@
    [:datahost.change/kind s.common/ChangeKind]])
 
 (def CompileDatasetOptions
+  "Note: the options will also be passed to [[as-dataset]]."
   (m/schema
    [:map
     [:changes [:sequential ChangeInfo]]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
@@ -281,13 +281,9 @@
   {:pre [(as-dataset-opts-valid? opts)]}
   (let [{convert-opts :convert-types} opts]
     (cond-> (-as-dataset v (merge {:file-type :csv :encoding "UTF-8"} opts))
-      convert-types (convert-types (:row-schema convert-opts)))))
+      convert-opts (convert-types (:row-schema convert-opts)))))
 
 (defn validate-ld-release-schema-input [ld-schema]
   (when-not (validate-ld-release-schema-input-valid? ld-schema)
     (throw (ex-info "Invalid Release schema input" {:ld-schema ld-schema}))))
 
-(comment
-  
-
-  )

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
@@ -74,13 +74,18 @@
 
   ```
     [:tuple [:maybe {:dataset.column/name \"Foo\"
-                     :dataset.column/type <URI>} :string]
+                     :dataset.column/type <URI>} :string
+                     :dataset.column/datatype :string]
             [:int {:dataset.column/name \"My Measure\"
-                   :dataset.column/type <URI>}]]
+                   :dataset.column/type <URI>
+                   :dataset.column/datatype :int}]]
   ```"
   (let [props-schema [:map
                       [:dataset.column/name :string]
-                      [:dataset.column/type (into [:enum ] (vals uris/column-types))]]
+                      [:dataset.column/type (into [:enum ] (vals uris/column-types))]
+                      [:dataset.column/datatype
+                       {:description "Keyword that [[tablecloth.api]] can use as a column type"}
+                       :keyword]]
         validate-seq (m/validator (m/schema [:sequential props-schema]
                                             {:registry s.common/registry}))]
     [:and
@@ -131,6 +136,9 @@
                               schema (extract-column-datatype ld-val)]
                           (assoc r col-name
                                  (mu/update-properties schema assoc
+                                                       :dataset.column/datatype (if (vector? schema)
+                                                                                  (second schema)
+                                                                                  schema)
                                                        :dataset.column/name col-name
                                                        :dataset.column/type (first (get ld-val (column-key :type)))))))
                       {}
@@ -244,9 +252,22 @@
   [:map
    [:file-type {:optional true} [:enum :csv]]
    [:encoding {:optional true} [:enum "UTF-8"]]
-   [:store {:optional true} [:fn some?]]])
+   [:store {:optional true} [:fn some?]]
+   [:convert-types {:optional true} [:map
+                                     [:row-schema DatasetRow]]]])
 
 (def ^:private as-dataset-opts-valid? (m/validator AsDatasetOpts))
+
+
+(defn convert-types
+  [dataset row-schema]
+  {:pre [(m/validate DatasetRow row-schema)]}
+  (let [cols (for [col (m/children row-schema)
+                   :let [props (m/properties col)]]
+               props)]
+    (tc/convert-types dataset
+                      (map :dataset.column/name cols)
+                      (map :dataset.column/datatype cols))))
 
 (defn as-dataset
   "Tries to turn passed value into a dataset.
@@ -255,11 +276,18 @@
   - `java.io.File`
   - `java.net.URL` (e.g. a resource)
 
-  See also: [[tc/dataset]]"
+  See also: [[AsDatasetOpts]], [[tc/dataset]]"
   [v opts]
   {:pre [(as-dataset-opts-valid? opts)]}
-  (-as-dataset v (merge {:file-type :csv :encoding "UTF-8"} opts)))
+  (let [{convert-opts :convert-types} opts]
+    (cond-> (-as-dataset v (merge {:file-type :csv :encoding "UTF-8"} opts))
+      convert-types (convert-types (:row-schema convert-opts)))))
 
 (defn validate-ld-release-schema-input [ld-schema]
   (when-not (validate-ld-release-schema-input-valid? ld-schema)
     (throw (ex-info "Invalid Release schema input" {:ld-schema ld-schema}))))
+
+(comment
+  
+
+  )

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_compilation_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/util/data_compilation_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]
+   [malli.error :as me]
    [tablecloth.api :as tc]
    [tpximpact.datahost.ldapi.util.data-compilation :as dc]
    [tpximpact.datahost.ldapi.util.data-validation
@@ -37,9 +38,11 @@
   (let [system-uris (system-uris/make-system-uris (URI. "https://example.org/data/"))
         row-schema (m/schema [:tuple
                               [:maybe {:dataset.column/name "n"
-                                       :dataset.column/type (:measure uris/column-types)} :int]
+                                       :dataset.column/type (:measure uris/column-types)
+                                       :dataset.column/datatype :int} :int]
                               [:int {:dataset.column/name "dim"
-                                     :dataset.column/type (:dimension uris/column-types)}]])]
+                                     :dataset.column/type (:dimension uris/column-types)
+                                     :dataset.column/datatype :int}]])]
     (assert (#'data-validation/row-schema-valid? row-schema))
 
     (testing "We can create result from appends"


### PR DESCRIPTION
Tablecloth guesses the column types based on values present in the dataset. If we have a column with one row and value 75, in a column where we expect a floating point value, the column type will be int.

This change updates the `as-dataset` function to optionally take a `:convert-types` option (along with DataseRow) to do the conversion.