### PR TITLE
Lk/issue 269

### DIFF
--- a/datahost-ld-openapi/env/auth/resources/ldapi/env.edn
+++ b/datahost-ld-openapi/env/auth/resources/ldapi/env.edn
@@ -4,6 +4,6 @@
          :users {"idp" #ig/ref :tpximpact.datahost.ldapi.secrets/basic-auth-hash}}}
 
  :tpximpact.datahost.ldapi.secrets/basic-auth-hash
- {:gcloud-project "swirrl-ons-datahost"
-  :secret-name "basic-auth-hash"
+ {:gcloud-project #env GCLOUD_PROJECT
+  :secret-name #env BASIC_AUTH_PASSWORD_SECRET_NAME
   :version "latest"}}

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -52,5 +52,13 @@ It is recommended you configure the GCloud provider by generating a short-lived 
 
     export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
 
+## Secrets
+
+The LDAPI service is protected by basic authentication. The username is `idp` and the password is configured for each environment
+within a secret manager secret. The ldapi Terraform configuration only creates the secret and does not configure the secret value.
+The name of the secret is defined as an output `basic_auth_password_secret_name` of the corresponding environment root module.
+This output is displayed when running a `terraform apply`, and the corresponding secret should be configured manually via the CLI or web UI.
+The LDAPI application always uses the latest version of this secret to configure basic authentication on startup.
+
 
 

--- a/deploy/terraform/gcloud/swirrl-ons-datahost/main.tf
+++ b/deploy/terraform/gcloud/swirrl-ons-datahost/main.tf
@@ -37,7 +37,8 @@ locals {
     "roles/compute.loadBalancerAdmin",
     "roles/iam.serviceAccountDeleter",
     "roles/iam.serviceAccountCreator",
-    "roles/iam.securityAdmin"
+    "roles/iam.securityAdmin",
+    "roles/secretmanager.admin"
   ]
   swirrl_circleci_organisation_id = "294dc3ff-773f-44a8-820e-f12f3ba2e1ac"
 }

--- a/deploy/terraform/ldapi/environments/dev/outputs.tf
+++ b/deploy/terraform/ldapi/environments/dev/outputs.tf
@@ -1,0 +1,4 @@
+output "basic_auth_password_secret_name" {
+  description = "Name of the basic auth secret password to configure manually"
+  value = module.dev.basic_auth_password_secret_name
+}

--- a/deploy/terraform/ldapi/modules/env/main.tf
+++ b/deploy/terraform/ldapi/modules/env/main.tf
@@ -23,6 +23,7 @@ provider "aws" {
 
 module "server" {
   source = "../server"
+  gcloud_project = var.gcloud_project
   digest = var.digest
   name = "${var.name}-ldapi"
   zone = var.gcloud_zone

--- a/deploy/terraform/ldapi/modules/env/outputs.tf
+++ b/deploy/terraform/ldapi/modules/env/outputs.tf
@@ -1,0 +1,4 @@
+output "basic_auth_password_secret_name" {
+  description = "Name of the basic auth secret password to configure manually"
+  value = module.server.basic_auth_password_secret_name
+}

--- a/deploy/terraform/ldapi/modules/server/outputs.tf
+++ b/deploy/terraform/ldapi/modules/server/outputs.tf
@@ -7,3 +7,8 @@ output "zone" {
   description = "GCloud zone of the ldapi server"
   value = google_compute_instance.datahost_ldapi_instance.zone
 }
+
+output "basic_auth_password_secret_name" {
+  description = "Name of the basic auth secret password to configure manually"
+  value = google_secret_manager_secret.basic_auth_password.id
+}

--- a/deploy/terraform/ldapi/modules/server/variables.tf
+++ b/deploy/terraform/ldapi/modules/server/variables.tf
@@ -3,6 +3,11 @@ variable "name" {
   description = "Name of the server to create"
 }
 
+variable "gcloud_project" {
+  type = string
+  description = "Name of the host gcloud project for the server"
+}
+
 variable "digest" {
   type = string
   description = "SHA256 digest of the ldapi application container to deploy"


### PR DESCRIPTION
Create a secret for the basic auth password in each environment. The secret data must be configured separately.