### PR TITLE
ldapi: redirect to latest rev. when requesting release as text/csv

### DIFF
--- a/datahost-ld-openapi/env/test/resources/test-system.edn
+++ b/datahost-ld-openapi/env/test/resources/test-system.edn
@@ -3,7 +3,7 @@
 
  ;; test rdf-base-uri intentionally uses a weird value that doesn't include `data`
  ;; in order to prove that RDF URIs are not necessarily tied to routing.
- :tpximpact.datahost.system-uris/uris {:rdf-base-uri #uri "https://crunk.org/atad/"}
+ :tpximpact.datahost.system-uris/uris {:rdf-base-uri #uri "http://localhost:3000/data/"}
 
  :tpximpact.datahost.ldapi.test/http-client
  {:port #ig/ref :tpximpact.datahost.ldapi.jetty/http-port}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -101,7 +101,6 @@
           :else (let [rev-uri ^URI (-> change-infos last :rev)]
                   (-> (.getPath rev-uri)
                       (util.response/redirect)
-                      (util.response/header "accept" accept)
                       (shared/set-csvm-header request)))))
       (as-json-ld {:status 200
                    :body (-> (json-ld/compact release (json-ld/simple-context system-uris))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -6,6 +6,7 @@
    [tablecloth.api :as tc]
    [reitit.core :as rc]
    [ring.util.request :as util.request]
+   [ring.util.response :as util.response]
    [tpximpact.datahost.system-uris :as su]
    [tpximpact.datahost.ldapi.compact :as cmp]
    [tpximpact.datahost.ldapi.db :as db]
@@ -82,7 +83,7 @@
     (errors/not-found-response request)))
 
 (defn get-release
-  [triplestore change-store system-uris
+  [triplestore _change-store system-uris
    {path-params :path-params
     {:strs [accept]} :headers
     {release-uri :dh/Release} :datahost.request/uris
@@ -92,18 +93,16 @@
                         (matcha/index-triples)
                         (triples->ld-resource))]
     (if (= accept "text/csv")
-      (-> {:status 200
-           :headers {"content-type" "text/csv"
-                     "content-disposition" "attachment ; filename=release.csv"}
-           :body (let [change-infos (db/get-changes-info triplestore release-uri Integer/MAX_VALUE)]
-                   (if (empty? change-infos)
-                     "" ;TODO: return table header here, need to get schema first
-                     (let [key (:snapshotKey (last change-infos))]
-                       (when (nil? key)
-                         (throw (ex-info "No CSV snapshot for release found."
-                                         {:path-params path-params})))
-                       (ring-io/piped-input-stream (partial change-store-to-ring-io-writer change-store key)))))}
-          (shared/set-csvm-header request))
+      (let [change-infos (db/get-changes-info triplestore release-uri Integer/MAX_VALUE)]
+        (cond
+          (empty? change-infos) (-> (util.response/response "This release has no revisions yet")
+                                    (util.response/status 422)
+                                    (util.response/header "content-type" "text/plain"))
+          :else (let [rev-uri ^URI (-> change-infos last :rev)]
+                  (-> (.getPath rev-uri)
+                      (util.response/redirect)
+                      (util.response/header "accept" accept)
+                      (shared/set-csvm-header request)))))
       (as-json-ld {:status 200
                    :body (-> (json-ld/compact release (json-ld/simple-context system-uris))
                              (.toString))}))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -250,19 +250,6 @@
             :body (json/write-str {"dcterms:title" "Example Release"
                                    "dcterms:description" "Description"})})
 
-      (testing "Fetching a release csv that does exist works"
-        (let [response (GET release-1-path {:headers {"accept" "text/csv"}})
-              [_ _ path :as v] (re-find #"<http:\/\/(.+):\d+(\S+)>; rel=\"describedBy\"; type=\"application\/csvm\+json\""
-                                        (get-in response [:headers "link"]))]
-          (is (= 200 (:status response)))
-          ;; (is (not (empty? (:body response))))
-          ;; TODO: what is the csv release meant to be? `""` empty string
-          ;; seems off when the json returns something not-nil
-          (is (= release-1-csvm-path path))))
-
-      (testing "Fetching csvm for release that does exist works"
-        (let [response (GET release-1-csvm-path)
-              body (json/read-str (:body response))]
-          (is (= 200 (:status response)))
-          (is (= {"@context" ["http://www.w3.org/ns/csvw" {"@language" "en"}]}
-                 body)))))))
+      (testing "Fetching existing release with no revisions"
+        (let [response (GET release-1-path {:headers {"accept" "text/csv"}})]
+          (is (= 422 (:status response))))))))


### PR DESCRIPTION
The GET RELEASE endpoint now can return 422 when the release has no
revisions (and changes), as there's nothing to redirect to.

Some of the release specific tests were moved to revision test namespace
because of that.

Also: since we use the redirect URL, the rdf-base-uri can't be bogus
anymore (in test context).

Fixes #264