### PR TITLE
Update application routes to use singular for individual resources

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -683,7 +683,7 @@
   (with-open [conn ^RepositoryConnection (repo/->connection triplestore)]
     (let [prev-change-id (last-change-num conn rev-uri)
           change-id (inc prev-change-id)
-          change-uri (su/change-uri* system-uris (assoc api-params :change-id change-id))
+          change-uri (su/commit-uri* system-uris (assoc api-params :commit-id change-id))
           _ (log/debug (format "will insert-change for '%s', new change id = %s"
                                (.getPath ^URI rev-uri) change-id))
           change (request->change kind api-params ld-root rev-uri change-uri)
@@ -726,7 +726,7 @@
 
       (number? c)                          ; we got a definitive answer
       (get-change triplestore
-                  (su/change-uri* system-uris (assoc params :revision-id prev-rev-id :change-id c)))
+                  (su/commit-uri* system-uris (assoc params :revision-id prev-rev-id :commit-id c)))
 
       (= :find c)                       ; we need to find change-id
       (let [prev-rev-uri (su/dataset-revision-uri* system-uris (assoc params :revision-id prev-rev-id))
@@ -738,10 +738,10 @@
                                   (.getPath revision-uri))
                           {:params params :revision-uri revision-uri})))
         (get-change triplestore
-                    (su/change-uri* system-uris
-                                            (assoc params
-                                                   :revision-id prev-rev-id
-                                                   :change-id prev-change-id) )))
+                    (su/commit-uri* system-uris
+                                    (assoc params
+                                      :revision-id prev-rev-id
+                                      :commit-id prev-change-id))))
 
       :else (throw (ex-info "Error: illegal state" {:params params})))))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -352,7 +352,7 @@
                                                                 {:series-slug series-slug
                                                                  :release-slug release-slug
                                                                  :revision-id revision-id
-                                                                 :change-id change-id})
+                                                                 :commit-id change-id})
                                               (rc/match->path))}
                      :body inserted-jsonld-doc})))))
 
@@ -361,9 +361,9 @@
     (when-let [dataset (csv-file-location->dataset change-store appends)]
       (write-dataset-to-outputstream dataset))))
 
-(defn get-change [triplestore change-store system-uris {{:keys [series-slug release-slug revision-id change-id]} :path-params
+(defn get-change [triplestore change-store system-uris {{:keys [series-slug release-slug revision-id commit-id]} :path-params
                         {:strs [accept]} :headers :as request}]
-  (if-let [change (->> (su/change-uri system-uris series-slug release-slug revision-id change-id)
+  (if-let [change (->> (su/commit-uri system-uris series-slug release-slug revision-id commit-id)
                        (db/get-change triplestore)
                        matcha/index-triples
                        triples->ld-resource)]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -327,8 +327,9 @@ specifications for each route.")
        :delete (routes.s/delete-series-route-config triplestore change-store system-uris)}]
 
      ["/:series-slug/releases"
-      ["" {:get (routes.rel/get-release-list-route-config triplestore system-uris)}]
+      {:get (routes.rel/get-release-list-route-config triplestore system-uris)}]
 
+     ["/:series-slug/release"
       ["/:release-slug"
        {:get (routes.rel/get-release-route-config triplestore change-store system-uris)
         :put (routes.rel/put-release-route-config clock triplestore system-uris)}]
@@ -338,23 +339,24 @@ specifications for each route.")
         :post (routes.rel/post-release-ld-schema-config clock triplestore system-uris)}]
 
       ["/:release-slug/revisions"
-       ["" {:post (routes.rev/post-revision-route-config triplestore system-uris)
-            :get (routes.rev/get-revision-list-route-config triplestore system-uris)}]
+       {:post (routes.rev/post-revision-route-config triplestore system-uris)
+        :get (routes.rev/get-revision-list-route-config triplestore system-uris)}]
 
+      ["/:release-slug/revision"
        ["/:revision-id"
         {:name ::revision
          :get (routes.rev/get-revision-route-config triplestore change-store system-uris)}]
 
-       ["/:revision-id/changes"
-        ["/:change-id"
-         {:name ::change
-          :get (routes.rev/get-revision-changes-route-config triplestore change-store system-uris)}]]
+       ["/:revision-id/commit/:commit-id"
+        {:name ::change
+         :get (routes.rev/get-revision-changes-route-config triplestore change-store system-uris)}]
 
        ["/:revision-id/appends"
-        ["" {:post (routes.rev/post-revision-appends-changes-route-config triplestore change-store system-uris)}]]
+        {:post (routes.rev/post-revision-appends-changes-route-config triplestore change-store system-uris)}]
 
        ["/:revision-id/retractions"
         {:post (routes.rev/post-revision-retractions-changes-route-config triplestore change-store system-uris)}]
+
        ["/:revision-id/corrections"
         {:post (routes.rev/post-revision-corrections-changes-route-config triplestore change-store system-uris)}]]]]]
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
@@ -16,7 +16,7 @@
   (str (.getPath ld-root) series-slug))
 
 (defn- release-key [ld-root series-slug release-slug]
-  (str (dataset-series-key ld-root series-slug) "/releases/" release-slug))
+  (str (dataset-series-key ld-root series-slug) "/release/" release-slug))
 
 (defn- release-schema-key
   ([ld-root {:keys [series-slug release-slug]}]
@@ -25,10 +25,10 @@
    (str (release-key ld-root series-slug release-slug) "/schema" )))
 
 (defn- revision-key [ld-root series-slug release-slug revision-id]
-  (str (release-key ld-root series-slug release-slug) "/revisions/" revision-id))
+  (str (release-key ld-root series-slug release-slug) "/revision/" revision-id))
 
-(defn change-key [ld-root series-slug release-slug revision-id change-id]
-  (str (revision-key ld-root series-slug release-slug revision-id) "/changes/" change-id))
+(defn commit-key [ld-root series-slug release-slug revision-id commit-id]
+  (str (revision-key ld-root series-slug release-slug revision-id) "/commit/" commit-id))
 
 (defprotocol AppUri
   "Build LD API application URIs based upon a configurable base URI state"
@@ -48,9 +48,9 @@
 
   (dataset-revision-uri* [this api-params])
 
-  (change-uri [this series-slug release-slug revision-id change-id])
+  (commit-uri [this series-slug release-slug revision-id commit-id])
 
-  (change-uri* [this api-params]))
+  (commit-uri* [this api-params]))
 
 (defn make-system-uris
   "Returns an object that builds URIs based upon the configured RDF base URI"
@@ -66,10 +66,10 @@
       (dataset-series-uri this series-slug))
 
     (dataset-release-uri [_ series-uri release-slug]
-      (URI. (format "%s/releases/%s" series-uri release-slug)))
+      (URI. (format "%s/release/%s" series-uri release-slug)))
 
     (dataset-release-uri* [this {:keys [series-slug release-slug] :as _api-params}]
-      (URI. (format "%s/releases/%s" (dataset-series-uri this series-slug) release-slug)))
+      (URI. (format "%s/release/%s" (dataset-series-uri this series-slug) release-slug)))
 
     (release-schema-uri [_ {:keys [series-slug release-slug]}]
       (.resolve base-uri (release-schema-key base-uri series-slug release-slug)))
@@ -78,15 +78,15 @@
       (.resolve base-uri (revision-key base-uri series-slug release-slug revision-id)))
 
     (dataset-revision-uri* [this {:keys [series-slug release-slug revision-id]}]
-      (URI. (format "%s/releases/%s/revisions/%s" (dataset-series-uri this series-slug) release-slug revision-id)))
+      (URI. (format "%s/release/%s/revision/%s" (dataset-series-uri this series-slug) release-slug revision-id)))
 
-    (change-uri [_ series-slug release-slug revision-id change-id]
-      (assert change-id)
-      (.resolve base-uri (change-key base-uri series-slug release-slug revision-id change-id)))
+    (commit-uri [_ series-slug release-slug revision-id commit-id]
+      (assert commit-id)
+      (.resolve base-uri (commit-key base-uri series-slug release-slug revision-id commit-id)))
 
-    (change-uri* [_this {:keys [series-slug release-slug revision-id change-id]}]
-      (assert change-id)
-      (.resolve base-uri (change-key base-uri series-slug release-slug revision-id change-id)))))
+    (commit-uri* [_this {:keys [series-slug release-slug revision-id commit-id]}]
+      (assert commit-id)
+      (.resolve base-uri (commit-key base-uri series-slug release-slug revision-id commit-id)))))
 
 (defmethod ig/init-key ::uris [_ opts]
   (make-system-uris (:rdf-base-uri opts)))
@@ -105,7 +105,7 @@
   (dataset-revision-uri* system-uris params))
 
 (defmethod -resource-uri :dh/Change [_ system-uris {:keys [series-slug release-slug revision-id change-id]}]
-  (change-uri system-uris series-slug release-slug revision-id change-id))
+  (commit-uri system-uris series-slug release-slug revision-id change-id))
 
 (defn resource-uri
   "Returns an uri for resource, where resource in

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
@@ -17,7 +17,7 @@
                                           {"@base" "https://example.org/data/"}],
                               "dcterms:title" "My series"
                               "dcterms:description" (format "some-description-%s" n)}}))
-    (PUT (format "/data/my-series-%s/releases/release-%s" n n)
+    (PUT (format "/data/my-series-%s/release/release-%s" n n)
          (prepare-req {:content-type :json
                        :body {"@context" ["https://publishmydata.com/debf/datahost/context"
                                           {"@base" (format "https://example.org/data/my-series-%s/" n)}]
@@ -30,7 +30,7 @@
   [tag rdf-base-uri]
   {"@type" "dh:TableSchema"
    "appropriate-csvw:modeling-of-dialect" "UTF-8,RFC4180"
-   "dh:appliesToRelease" (format "%smy-series-%s/releases/release-%s" rdf-base-uri tag tag)
+   "dh:appliesToRelease" (format "%smy-series-%s/release/release-%s" rdf-base-uri tag tag)
    "dcterms:title" "Fun schema"
    "dh:columns" [{"@type" "dh:DimensionColumn"
                   "csvw:datatype" "string"
@@ -55,7 +55,7 @@
                     "csvw:titles" titles
                     "@type" typ})]
     (testing "Creating a schema from file upload"
-      (let [schema-fragment (format "my-series-%s/releases/release-%s/schema" n n)
+      (let [schema-fragment (format "my-series-%s/release/release-%s/schema" n n)
             schema-resource-path (str "/data/" schema-fragment)
             schema-uri (str rdf-base-uri schema-fragment)
             rel-schema {"@context" ["https://publishmydata.com/def/datahost/context"
@@ -71,12 +71,12 @@
         (is (= nil missing))
 
         (testing "The release was updated with a reference to the schema"
-          (let [{body :body} (GET (format "/data/my-series-%s/releases/release-%s" n n))
+          (let [{body :body} (GET (format "/data/my-series-%s/release/release-%s" n n))
                 body (json/read-str body)]
             (is (= schema-uri (get body "dh:hasSchema")))))
 
         (testing "The schema can be retrieved"
-          (let [{body :body} (GET (format "/data/my-series-%s/releases/release-%s/schema" n n))
+          (let [{body :body} (GET (format "/data/my-series-%s/release/release-%s/schema" n n))
                 body (json/read-str body)
                 [missing _extra _matching] (diff expected-doc body)]
             (is (= nil missing))))))))
@@ -86,7 +86,7 @@
         _ (setup-release n)
         {{:keys [GET POST]} :tpximpact.datahost.ldapi.test/http-client
          ld-api-app :tpximpact.datahost.ldapi.router/handler} @th/*system*
-        schema-path (format "/data/my-series-%s/releases/release-%s/schema" n n)
+        schema-path (format "/data/my-series-%s/release/release-%s/schema" n n)
         schema {"dcterms:title" "Fun schema"
                 "dcterms:description" "Description"
                 "dh:columns" [{"@type" "dh:MeasureColumn"
@@ -100,7 +100,7 @@
 
         _response (POST schema-path (th/jsonld-body-request schema))
 
-        fetch-response (GET (format "/data/my-series-%s/releases/release-%s/schema" n n))
+        fetch-response (GET (format "/data/my-series-%s/release/release-%s/schema" n n))
         fetched-doc (json/read-str (:body fetch-response))
         [missing _ _ ] (diff schema fetched-doc)]
     (t/is (= nil missing))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/resources.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/resources.clj
@@ -47,7 +47,7 @@
   (str "/data/" slug))
 
 (defmethod resource-path :dh/Release [{:keys [slug] :as release}]
-  (str (resource-path (get-parent release)) "/releases/" slug))
+  (str (resource-path (get-parent release)) "/release/" slug))
 
 (defmethod resource-path :dh/TableSchema [schema]
   (str (resource-path (get-parent schema)) "/schema"))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/revision_test.clj
@@ -18,9 +18,9 @@
    [tpximpact.datahost.system-uris :as su]
    [tpximpact.datahost.time :as time]
    [tpximpact.test-helpers :as th])
-  (:import (java.io BufferedReader StringReader)
-           (java.net URI)
-           (java.util UUID)))
+  (:import [java.io BufferedReader StringReader ByteArrayInputStream]
+           [java.net URI]
+           [java.util UUID]))
 
 (defn find-first
   [f coll]
@@ -47,7 +47,7 @@
 (defn- create-release [handler series-slug]
   (let [release-slug (str "test-release-" (UUID/randomUUID))
         request-json {"dcterms:title" "Test release" "dcterms:description" "Description"}
-        request {:uri (format "/data/%s/releases/%s" series-slug release-slug)
+        request {:uri (format "/data/%s/release/%s" series-slug release-slug)
                  :request-method :put
                  :headers {"accept" "application/ld+json"
                            "content-type" "application/json"}
@@ -80,8 +80,8 @@
                             {:content-type :application/json
                              :body (json/write-str {"dcterms:title" revision-title})})
         new-revision-location (-> revision-resp :headers (get "Location"))
-        [revision-id change-id] (re-find #"\/data\/.*\/revisions\/(\d+)\/changes\/(\d+)"
-                                         "/data/whatever/revisions/3/changes/1")
+        [revision-id change-id] (re-find #"\/data\/.*\/revision\/(\d+)\/commit\/(\d+)"
+                                         "/data/whatever/revision/3/commit/1")
         _ (assert revision-id)
         _ (assert change-id)
         change-ednld {"description" (str revision-title " -- changes")}
@@ -113,7 +113,7 @@
           series-slug (create-series handler)
           [release-slug release-doc] (create-release handler series-slug)
           release-uri (resource-id release-doc)
-          request1 {:uri (format "/data/%s/releases/%s/revisions" series-slug release-slug)
+          request1 {:uri (format "/data/%s/release/%s/revisions" series-slug release-slug)
                     :request-method :post
                     :headers {"accept" "application/ld+json"
                               "content-type" "application/json"}
@@ -125,13 +125,13 @@
       (t/is (= "Test revision" (get revision-doc "dcterms:title")))
       (t/is (= "Description" (get revision-doc "dcterms:description")))
       (t/is (= release-uri (URI. (get revision-doc "dh:appliesToRelease"))))
-      (t/is (str/ends-with? (get revision-doc "@id") "/revisions/1")
+      (t/is (str/ends-with? (get revision-doc "@id") "/revision/1")
             "auto-increment revision ID is assigned")
 
       (testing "A single revision can be can be retrieved via the list API"
         ;; NOTE: this test is essential for ensuring that single item collections
         ;; are serialized within an array wrapper and not as a hash-map
-        (let [all-revisions-request {:uri (format "/data/%s/releases/%s/revisions" series-slug release-slug)
+        (let [all-revisions-request {:uri (format "/data/%s/release/%s/revisions" series-slug release-slug)
                                      :headers {"accept" "application/ld+json"}
                                      :request-method :get}
               {:keys [body status]} (handler all-revisions-request)
@@ -145,7 +145,7 @@
           (t/is (= (count (get release-doc "contents")) 1))
           (t/is (= nil missing))))
 
-      (let [request2 {:uri (format "/data/%s/releases/%s/revisions" series-slug release-slug)
+      (let [request2 {:uri (format "/data/%s/release/%s/revisions" series-slug release-slug)
                       :request-method :post
                       :headers {"accept" "application/ld+json"
                                 "content-type" "application/json"}
@@ -155,21 +155,21 @@
             revision-doc2 (json/read-str body)]
         (t/is (= 201 status)
               "second revision was successfully created")
-        (t/is (str/ends-with? (get revision-doc2 "@id") "/revisions/2")
+        (t/is (str/ends-with? (get revision-doc2 "@id") "/revision/2")
               "subsequent revision has next auto-increment revision ID assigned"))
 
-      (let [release-request {:uri (format "/data/%s/releases/%s" series-slug release-slug)
+      (let [release-request {:uri (format "/data/%s/release/%s" series-slug release-slug)
                              :headers {"accept" "application/ld+json"}
                              :request-method :get}
             {:keys [body]} (handler release-request)
             release-doc (json/read-str body)
             release-revisions (get-release-revisions release-doc)]
-        (t/is (= #{(format "https://example.org/data/%s/releases/%s/revisions/1" series-slug release-slug)
-                   (format "https://example.org/data/%s/releases/%s/revisions/2" series-slug release-slug)}
+        (t/is (= #{(format "https://example.org/data/%s/release/%s/revision/1" series-slug release-slug)
+                   (format "https://example.org/data/%s/release/%s/revision/2" series-slug release-slug)}
                  release-revisions)))
 
       (testing "Multiple revisions can be can be retrieved via the list API"
-        (let [all-revisions-request {:uri (format "/data/%s/releases/%s/revisions" series-slug release-slug)
+        (let [all-revisions-request {:uri (format "/data/%s/release/%s/revisions" series-slug release-slug)
                                      :headers {"accept" "application/ld+json"}
                                      :request-method :get}
               {:keys [body status]} (handler all-revisions-request)
@@ -210,7 +210,7 @@
       (testing "Creating a revision for an existing release and series"
         ;; RELEASE
         (let [release-slug (str "release-" (UUID/randomUUID))
-              release-url (str "/data/" series-slug "/releases/" release-slug)
+              release-url (str "/data/" series-slug "/release/" release-slug)
               release-resp (PUT release-url
                              {:content-type :application/json
                               :headers {"accept" "application/ld+json"}
@@ -265,7 +265,7 @@
                 normalised-revision-ld {"dcterms:title" revision-title
                                         "dcterms:description" revision-description
                                         "@type" "dh:Revision"
-                                        "dh:appliesToRelease" (str rdf-base-uri series-slug "/releases/" release-slug)
+                                        "dh:appliesToRelease" (str rdf-base-uri series-slug "/release/" release-slug)
                                         "dh:publicationDate" "2023-09-01"
                                         "dcterms:license" "http://license-link"
                                         "dh:reasonForChange" "Comment.."}
@@ -295,7 +295,7 @@
               (let [release-resp (GET release-url {:headers {"accept" "application/ld+json"}})
                     release-doc (json/read-str (:body release-resp))
                     release-revisions (get-release-revisions release-doc)]
-                (t/is (= #{(str rdf-base-uri series-slug "/releases/" release-slug "/revisions/1")}
+                (t/is (= #{(str rdf-base-uri series-slug "/release/" release-slug "/revision/1")}
                          release-revisions))))
 
             (testing "Changes append resource created with CSV appends file"
@@ -308,7 +308,7 @@
                     new-change-resource-location (-> change-api-response :headers (get "Location"))]
 
                 (is (= 201 (:status change-api-response)))
-                (is (= (str new-revision-location "/changes/1")
+                (is (= (str new-revision-location "/commit/1")
                        new-change-resource-location)
                     "Created with the resource URI provided in the Location header")
 
@@ -321,7 +321,7 @@
                         "responds CSV contents")))))
 
             (testing "Ensure we can add more than 1 change to a revision."
-              ; /data/:series-slug/releases/:release-slug/revisions/:revision-id/appends
+              ; /data/:series-slug/release/:release-slug/revision/:revision-id/appends
               (let [query-params {"description" "A second change"}
                     change-api-response (POST (str new-revision-location "/appends")
                                           {:query-params query-params
@@ -353,7 +353,7 @@
                 new-revision-location-2 (-> revision-resp-2 :headers (get "Location"))]
 
             (is (= 201 (:status revision-resp-2)))
-            (is (re-find #".*\/revisions\/2" inserted-revision-id-2))
+            (is (re-find #".*\/revision\/2" inserted-revision-id-2))
             (is (str/ends-with? new-revision-location-2 inserted-revision-id-2)
                 "Created with the resource URI provided in the Location header")
 
@@ -364,7 +364,7 @@
                                                  :headers {"content-type" "text/csv"}
                                                  :body (th/file-upload csv-2021-path)})]
                   (is (= 201 (:status change-api-response)))
-                  (is (id-matches? (:body change-api-response) "/changes/1"))))
+                  (is (id-matches? (:body change-api-response) "/commit/1"))))
 
               (testing "Fetching Release as CSV with multiple Revisions and CSV append changes"
 
@@ -385,7 +385,7 @@
                        valid-row-sample))))
 
             (testing "Fetching Revision as accumulated CSV from all revisions so far."
-              (let [response (GET (str release-url "/revisions/2") {:headers {"accept" "text/csv"}})
+              (let [response (GET (str release-url "/revision/2") {:headers {"accept" "text/csv"}})
                     resp-body-seq (line-seq (BufferedReader. (StringReader. (:body response))))]
                 (is (= 200 (:status response)))
                 ;; length of all csv files minus duplicated headers
@@ -401,19 +401,19 @@
             (testing "POST retractions against against 3rd Revision"
               (change-test http-client release-url :dh/ChangeKindRetract "revision #3"
                            csv-2021-deletes-path
-                           "/revisions/3/changes/1"))
+                           "/revision/3/commit/1"))
 
             (testing "POST corrections against 4th Revision"
               (change-test http-client release-url :dh/ChangeKindCorrect "revision #4"
                            csv-2021-corrections-path
-                           "/revisions/4/changes/1")
+                           "/revision/4/commit/1")
 
               (testing "verifying the snapshot CSV"
                 (let [measure-column "Aged 16 to 64 years level 3 or above qualifications"
-                      resp (GET (str release-url "/revisions/4") {:headers {"accept" "text/csv"}})
+                      resp (GET (str release-url "/revision/4") {:headers {"accept" "text/csv"}})
                       ds (data-validation/as-dataset (-> (:body resp)
                                                          .getBytes
-                                                         (java.io.ByteArrayInputStream.))
+                                                         (ByteArrayInputStream.))
                                                      {})]
                   (is (= 200 (:status resp)))
                   (is (= (+ (dec (count csv-2019-seq))
@@ -436,7 +436,7 @@
                                      (get (json/read-str (:body resp)) "@id"))]
               ;; This Release already has 4 Revisions, so we expect another 10 in the series
               (is (= (for [i (range 5 15)]
-                       (format "%s/releases/%s/revisions/%d" series-slug release-slug i))
+                       (format "%s/release/%s/revision/%d" series-slug release-slug i))
                      new-revision-ids)
                   "Expected Revision IDs integers increase in an orderly sequence")))
 
@@ -453,8 +453,9 @@
     (let [new-series-slug (str "new-series-" (UUID/randomUUID))
           new-series-path (str "/data/" new-series-slug)
           release-1-id (str "release-" (UUID/randomUUID))
-          release-1-path (str new-series-path "/releases/" release-1-id)
+          release-1-path (str new-series-path "/release/" release-1-id)
           revision-post-url (str release-1-path "/revisions")
+          revision-get-url (str release-1-path "/revision")
           _
           (PUT new-series-path
                {:content-type :json
@@ -477,7 +478,7 @@
 
       (testing "Fetching csvw metadata for a revision that does not exist returns 'not found'"
 
-        (let [{:keys [status body]} (GET (str revision-post-url "/does-not-exist"))]
+        (let [{:keys [status body]} (GET (str revision-get-url "/does-not-exist"))]
           (is (= 404 status))
           (is (= "Not found" body))))
 


### PR DESCRIPTION
Closes #277 - Update the application routes to use the singular case to address individual resources e.g. a release now has a path of /{series-slug}/release/{release-slug}. Routes which return a collection of resources still use the plural case.

Rename 'change' to 'commit' within revision change routes. This is the first stage of an upcoming series of changes in terminology from 'change' to 'commit'. The rest of the code still widely refers to commits as changes to minimise the required changes here.

Update the implementation of the AppUri protocol to reflect the new URI structure for resources. Rename the change-uri(*) method(s) to commit-uri(*) and rename the api parameters change-id key to commit-id within commit-uri*.

Update all tests to use the new URIs.

WARNING: Do not merge this PR until the initial release into the ONS environment has been completed. It contains breaking changes to the API.