### PR TITLE
Replace asserts with explicit throws

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -519,7 +519,8 @@
            [:bind ['(coalesce (+ ?highest 1) 1) '?next]]]})
 
 (defn- select-max-n-query [parent-uri child-pred]
-  (assert parent-uri)
+  (when (nil? parent-uri)
+    (throw (java.lang.IllegalArgumentException. "'parent-uri' must be non nil.")))
   {:prefixes (select-keys default-prefixes [:dh :xsd])
    :select ['?n]
    :where [[:where {:select '[[(max (:xsd/integer (replace (str ?child) "^.*/([^/]*)$" "$1"))) ?highest]]
@@ -621,7 +622,8 @@
   - :previous-snapshot-key (when available) - to remove the snapshot
     key from the revision."
   [triplestore ^URI uri {key :new-snapshot-key prev-key :previous-snapshot-key}]
-  (assert key)
+  (when (nil? key)
+    (throw (IllegalArgumentException. "'key' must be non nil.")))
   (let [insert-statements (dataset-snapshot-statements uri key)]
     (log/debug "tag-revision-with-snapshot:" (.getPath uri) (format "key='%s'" key))
     (with-open [conn (repo/->connection triplestore)]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -294,7 +294,9 @@
         ;; is a NOOP. This fails further down in the `let` body in
         ;; #'internal/post-change--generate-csv-snapshot
         ;; We don't need to proceed further if there's no release-schema!
-        _ (assert release-schema (str "No release schema found for: " release-uri))
+        _ (when (nil? release-schema)
+            (throw (ex-info (str "No release schema found for: " release-uri)
+                            {:release-uri release-uri})))
         appends ^InputStream (->byte-array-input-stream appends)
         insert-req (store/make-insert-request! change-store appends)
         {validation-err :error-response

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_compilation.clj
@@ -226,9 +226,10 @@
                             {:columns (vec (tc/column-names base-ds))})))
         base-ds (ensure-components-hash-column base-ds (:row-schema opts))]
     ;; let's ensure data issues in dev are immediately revealed
-    (assert (= (tc/row-count (tc/unique-by base-ds hash-column-name))
-               (tc/row-count base-ds))
-            "Possible data issue: are combinations of all non-measure values unique?")
+    (when-not (= (tc/row-count (tc/unique-by base-ds hash-column-name))
+                 (tc/row-count base-ds))
+      (throw (ex-info "Possible data issue: are combinations of all non-measure values unique?"
+                      {:opts opts})))
     (-> (reduce (partial compile-reducer ds-opts)
                 base-ds
                 (next changes))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj
@@ -203,8 +203,9 @@
                                                           :explanation (-> (m/explain schema cols)
                                                                            (me/humanize))}))))
                        validator)]
-    (assert (every? some? column-names)
-            "Could not extract column names from row schema")
+    (when-not (every? some? column-names)
+      (throw (ex-info "Could not extract column names from row schema"
+                      {:row-schema schema :column-names column-names})))
     (validate-found-columns schema column-names (tc/column-names dataset))
     (try
       {:dataset (-> dataset


### PR DESCRIPTION
This PR replace some of the asserts with explicit throws where it makes sense.

The line [mentioned](https://github.com/Swirrl/datahost-prototypes/blob/af93a8b9d2927965b78982be36fa416444b099e7/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/data_validation.clj#L128) in the issue has been updated in #290 

Fixes #281