### PR TITLE
Added a line to hurl-gen.py that copies the python arguments used to generate Hurl scripts.

### DIFF
--- a/datahost-ld-openapi/bin/hurl-data/hurl-gen.py
+++ b/datahost-ld-openapi/bin/hurl-data/hurl-gen.py
@@ -105,6 +105,7 @@ def main(args):
             change = change.replace("$CHANGE_FILE", file)
             result.append(change)
     result.append('''# run locally: hurl FILE_NAME --variable series=series-01 --variable scheme=http --variable host_name=localhost:3000 --variable auth_token="string" ''')
+    result.append("# This Hurl script was created using hurl-gen.py with the following arguments- " + ' '.join(args))
     return result
 
 if __name__ == '__main__':


### PR DESCRIPTION


This is for reverse engineering the generation process if the hurl script needs to be changed