### PR TITLE
ldapi: don't require port number in regex

### DIFF
--- a/datahost-ld-openapi/hurl-scripts/int-011.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-011.hurl
@@ -277,7 +277,7 @@ HTTP 302
 [Captures]
 path: header "Link"
 [Asserts]
-variable "path" matches /<http:\/\/(.+):\d+(\S+)>; rel="describedBy"; type="application\/csvm\+json"/
+variable "path" matches /<http:\/\/(.+)(:\d+){0,1}(\S+)>; rel="describedBy"; type="application\/csvm\+json"/
 header "Location" == "{{revision2_url}}"
 
 

--- a/datahost-ld-openapi/hurl-scripts/int-012.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-012.hurl
@@ -243,7 +243,7 @@ HTTP 302
 [Captures]
 path: header "Link"
 [Asserts]
-variable "path" matches /<http:\/\/(.+):\d+(\S+)>; rel="describedBy"; type="application\/csvm\+json"/
+variable "path" matches /<http:\/\/(.+):(:\d+){0,1}(\S+)>; rel="describedBy"; type="application\/csvm\+json"/
 header "Location" == "{{revision2_url}}"
 
 


### PR DESCRIPTION
The regex was too strict and caused integration test job to fail. The job sets up the service on default HTTP port, so it's not explicitly specified in URIs.