### PR TITLE
CSVW routes part 1: Release Accept header reoute redirects to file route

### DIFF
--- a/datahost-ld-openapi/hurl-scripts/int-002.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-002.hurl
@@ -51,8 +51,7 @@ file,common/name-age-01.csv;
 
 HTTP 201
 
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
-Accept: text/csv
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1.csv
 
 HTTP 302
 
@@ -78,8 +77,7 @@ file,common/name-age-02.csv;
 
 HTTP 201
 
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
-Accept: text/csv
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1.csv
 
 HTTP 302
 
@@ -105,8 +103,7 @@ file,common/name-age-03.csv;
 
 HTTP 201
 
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
-Accept: text/csv
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1.csv
 
 HTTP 302
 [Captures]

--- a/datahost-ld-openapi/hurl-scripts/int-010.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-010.hurl
@@ -86,9 +86,7 @@ jsonpath "$.['dcterms:description']" == "Another test revision"
 jsonpath "$.['dh:appliesToRelease']" endsWith "data/{{series}}/release/release-1"
 
 #Get metadata of all revisions in a release and ensure that two revisions are listed
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1.json
 Authorization: {{auth_token}}
 
 HTTP 200

--- a/datahost-ld-openapi/hurl-scripts/int-011.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-011.hurl
@@ -89,9 +89,7 @@ jsonpath "$.['dh:reasonForChange']" == "Comment..."
 
 
 #Associated Release gets the Revision inverse triple
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1.json
 Authorization: {{auth_token}}
 
 HTTP 200
@@ -270,7 +268,7 @@ jsonpath "$.['@id']" endsWith "commit/1"
 
 #ensure path header contains a URL when requesting the release
 #and redirects to revision 2
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1.csv
 Accept: text/csv
 Authorization: {{auth_token}}
 HTTP 302
@@ -283,8 +281,8 @@ header "Location" == "{{revision2_url}}"
 
 
 GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1-metadata.json
-Accept: application/json 
-Content-Type: application/json
+#Accept: application/json
+#Content-Type: application/json
 Authorization: {{auth_token}}
 HTTP 200
 [Asserts]

--- a/datahost-ld-openapi/hurl-scripts/int-011.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-011.hurl
@@ -96,6 +96,22 @@ HTTP 200
 [Asserts]
 jsonpath "$.['dh:hasRevision']" endsWith "{{revision1_url}}"
 
+# Release requested as JSON via ACCEPTS header gets redirected to correct route
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
+Accept: application/json
+Authorization: {{auth_token}}
+
+HTTP 308
+Location: /data/{{series}}/release/release-1.json
+
+# Release requested as CSV via ACCEPTS header gets redirected to correct route
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
+Accept: text/csv
+Authorization: {{auth_token}}
+
+HTTP 308
+Location: /data/{{series}}/release/release-1.csv
+
 
 #appends to the revision
 POST {{scheme}}://{{host_name}}{{revision1_url}}/appends

--- a/datahost-ld-openapi/hurl-scripts/int-012.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-012.hurl
@@ -236,8 +236,7 @@ jsonpath "$.['@id']" endsWith "commit/1"
 
 #ensure path header contains a URL when requesting the release
 #and redirects to revision 2
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
-Accept: text/csv
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1.csv
 Authorization: {{auth_token}}
 HTTP 302
 [Captures]

--- a/datahost-ld-openapi/hurl-scripts/int-013.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-013.hurl
@@ -67,18 +67,16 @@ HTTP 200
 body == "{{initial_doc}}"
 
 
-#check that a release added to a non existant series returns 404
-GET {{scheme}}://{{host_name}}/data/{{series}}2/release/release-1
-Accept: application/json
-Content-Type: application/json
+#check that a release added to a non existent series returns 404
+GET {{scheme}}://{{host_name}}/data/{{series}}2/release/release-1.json
 Authorization: {{auth_token}}
 
 HTTP 404
 [Asserts]
-body == "{\"message\":\"Not found\"}"
+body == "Not found"
 
 #getting a release that doesnt exists returns 404
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release1231
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release1231.json
 Accept: application/json
 Content-Type: application/json
 Authorization: {{auth_token}}
@@ -148,11 +146,11 @@ jsonpath "$['@context'].['appropriate-csvw']" == "https://publishmydata.com/def/
 jsonpath "$['@context'].['@base']" == "{{expected_scheme}}://{{expected_uri_root}}/data/"
 
 #Fetching a release that does exist works
-GET {{scheme}}://{{host_name}}/data/{{series}}2/release/release-1
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}2/release/release-1.json
 Authorization: {{auth_token}}
+
 HTTP 200
+
 [Asserts]
 jsonpath "$['dcterms:title']" == "Example Release"
 jsonpath "$['dcterms:description']" == "Description"
@@ -188,9 +186,7 @@ jsonpath "$['dcterms:description']" == "Description 2"
 [Captures]
 Release2Modified: jsonpath "$['dcterms:modified']"
 
-GET {{scheme}}://{{host_name}}/data/{{series}}2/release/release-2
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}2/release/release-2.json
 Authorization: {{auth_token}}
 {
     "dcterms:title": "A Second Release",
@@ -238,7 +234,6 @@ jsonpath "$['dcterms:modified']" == "{{Release2Modified2}}"
 #"Fetching csvw metadata for a release that does not exist returns 'not found'"
 
 GET {{scheme}}://{{host_name}}/data/{{series}}3/release/release-1-metadata.json
-Accept: text/csv
 Content-Type: application/json
 Authorization: {{auth_token}}
 
@@ -269,10 +264,7 @@ Authorization: {{auth_token}}
 
 HTTP 201
 
-GET {{scheme}}://{{host_name}}/data/{{series}}3/release/release-1
-Accept: text/csv
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}3/release/release-1.csv
 Authorization: {{auth_token}}
-
 
 HTTP 422

--- a/datahost-ld-openapi/hurl-scripts/int-014.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-014.hurl
@@ -305,9 +305,7 @@ Authorization: {{auth_token}}
 
 HTTP 404
 
-GET {{scheme}}://{{host_name}}/data/{{series}}5/release/release-1
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}5/release/release-1.json
 Authorization: {{auth_token}}
 
 HTTP 404
@@ -358,9 +356,7 @@ Authorization: {{auth_token}}
 
 HTTP 404
 
-GET {{scheme}}://{{host_name}}/data/{{series}}6/release/release-1
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}6/release/release-1.json
 Authorization: {{auth_token}}
 
 HTTP 404
@@ -432,9 +428,7 @@ Authorization: {{auth_token}}
 
 HTTP 404
 
-GET {{scheme}}://{{host_name}}/data/{{series}}7/release/release-1
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}7/release/release-1.json
 Authorization: {{auth_token}}
 
 HTTP 404
@@ -522,9 +516,7 @@ Authorization: {{auth_token}}
 
 HTTP 404
 
-GET {{scheme}}://{{host_name}}/data/{{series}}8/release/release-1
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}8/release/release-1.json
 Authorization: {{auth_token}}
 
 HTTP 404
@@ -673,9 +665,7 @@ Authorization: {{auth_token}}
 
 HTTP 404
 
-GET {{scheme}}://{{host_name}}/data/{{series}}9/release/release-1
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}9/release/release-1.json
 Authorization: {{auth_token}}
 
 HTTP 404

--- a/datahost-ld-openapi/hurl-scripts/int-015.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-015.hurl
@@ -95,9 +95,7 @@ jsonpath "$['dcterms:title']" == "Dummy Schema"
 
 #"The release was updated with a reference to the schema"
 
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
-Accept: application/json
-Content-Type: application/json
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1.json
 Authorization: {{auth_token}}
 
 HTTP 200

--- a/datahost-ld-openapi/hurl-scripts/issue-282.hurl
+++ b/datahost-ld-openapi/hurl-scripts/issue-282.hurl
@@ -17,7 +17,7 @@ Content-Type: application/json
 {"dcterms:description": "Release: {{release}}",
 "dcterms:title": "{{release}}"}
 
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/{{release}}
+GET {{scheme}}://{{host_name}}/data/{{series}}/release/{{release}}.json
 
 HTTP 200
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -84,15 +84,14 @@
 
 (defn get-release
   [triplestore _change-store system-uris
-   {path-params :path-params
-    {:strs [accept]} :headers
+   {{:keys [extension] :as path-params} :path-params
     {release-uri :dh/Release} :datahost.request/uris
     :as request}]
   (if-let [release (->> release-uri
                         (db/get-release-by-uri triplestore)
                         (matcha/index-triples)
                         (triples->ld-resource))]
-    (if (= accept "text/csv")
+    (if (= extension "csv")
       (let [change-info (db/get-latest-change-info triplestore release-uri)]
         (cond
           (nil? change-info) (-> (util.response/response "This release has no revisions yet")

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -9,7 +9,6 @@
    [integrant.core :as ig]
    [malli.util :as mu]
    [muuntaja.core :as m]
-   [muuntaja.format.core :as fc]
    [reitit.coercion.malli :as rcm]
    [reitit.dev.pretty :as pretty]
    [reitit.interceptor.sieppari :as sieppari]
@@ -29,33 +28,7 @@
    [tpximpact.datahost.ldapi.routes.series :as routes.s]
    [muuntaja.format.json :as json-format]
    [clojure.data.json :as json]
-   [clojure.java.io :as io]
-   [tpximpact.datahost.ldapi.handlers.delta :as handlers.delta])
-  (:import
-   (java.io InputStream InputStreamReader OutputStream)))
-
-(defn decode-str [_options]
-  (reify
-    fc/Decode
-    (decode [_ data charset]
-      (slurp (InputStreamReader. ^InputStream data ^String charset)))))
-
-(defn encode-str [_options]
-  (reify
-    fc/EncodeToBytes
-    (encode-to-bytes [_ data charset]
-      (.getBytes data ^String charset))
-    fc/EncodeToOutputStream
-    (encode-to-output-stream [_ data charset]
-      (fn [^OutputStream output-stream]
-        (.write output-stream
-                (.getBytes data ^String charset))))))
-
-(def csv-format
-  (fc/map->Format
-    {:name "text/csv"
-     :decoder [decode-str]
-     :encoder [encode-str]}))
+   [clojure.java.io :as io]))
 
 (defn jsonld-options [options]
   (assoc-in options

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -9,6 +9,7 @@
    [integrant.core :as ig]
    [malli.util :as mu]
    [muuntaja.core :as m]
+   [reitit.core :as r]
    [reitit.coercion.malli :as rcm]
    [reitit.dev.pretty :as pretty]
    [reitit.interceptor.sieppari :as sieppari]
@@ -305,19 +306,21 @@ specifications for each route.")
       {:get (routes.rel/get-release-list-route-config triplestore system-uris)}]
 
      ["/:series-slug/release"
-      ["/:release-slug"
-       {:get (routes.rel/get-release-route-config triplestore change-store system-uris)
-        :put (routes.rel/put-release-route-config clock triplestore system-uris)
+      ["/{release-slug}.{extension}"
+       {:get (routes.rel/get-release-route-config triplestore change-store system-uris)}]
+
+      ["/{release-slug}"
+       {:put (routes.rel/put-release-route-config clock triplestore system-uris)
         :post (routes.rel/post-release-delta-config {:triplestore triplestore
                                                      :change-store change-store
                                                      :clock clock
                                                      :system-uris system-uris})}]
 
-      ["/:release-slug/schema"
+      ["/{release-slug}/schema"
        {:get (routes.rel/get-release-ld-schema-config triplestore system-uris)
         :post (routes.rel/post-release-ld-schema-config clock triplestore system-uris)}]
 
-      ["/:release-slug/revisions"
+      ["/{release-slug}/revisions"
        {:post (routes.rev/post-revision-route-config triplestore system-uris)
         :get (routes.rev/get-revision-list-route-config triplestore system-uris)}]
 
@@ -346,6 +349,7 @@ specifications for each route.")
    {;;:reitit.middleware/transform dev/print-request-diffs ;; pretty diffs
     ;;:validate spec/validate ;; enable spec validation for route data
     ;;:reitit.spec/wrap spell/closed ;; strict top-level validation
+    :router r/linear-router
     :exception pretty/exception
     :data {:coercion (rcm/create
                       {;; set of keys to include in error messages

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -314,7 +314,8 @@ specifications for each route.")
         :post (routes.rel/post-release-delta-config {:triplestore triplestore
                                                      :change-store change-store
                                                      :clock clock
-                                                     :system-uris system-uris})}]
+                                                     :system-uris system-uris})
+        :get (routes.rel/get-accept-release-route-config)}]
 
       ["/{release-slug}/schema"
        {:get (routes.rel/get-release-ld-schema-config triplestore system-uris)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -1,5 +1,6 @@
 (ns tpximpact.datahost.ldapi.routes.middleware
   (:require
+   [clojure.string :as str]
    [malli.core :as m]
    [malli.error :as me]
    [reitit.coercion :as coercion]
@@ -191,6 +192,47 @@
       (shared/csvm-request {:triplestore triplestore
                             :system-uris system-uris
                             :request request})
+      (handler request))))
+
+(def accepts->extension {"text/csv" "csv"
+                         "application/json" "json"})
+
+(defn- find-first-accept-header
+  "Simple selection of single accept http header mime type. Significant
+  assumptions are made; most notably that the accept headers are already
+  sorted such that the most desired accept type is first in the collection.
+
+  Risk of incorrect mime type selection is greatly reduced because it's
+  quite likely that only one accept header type will ever be sent by API
+  clients.
+
+  Q values are ignored."
+  [accept-headers]
+  (let [prioritized-accept-mimes (str/split accept-headers #",")]
+    (some->> prioritized-accept-mimes
+             (filter (fn [prioritized-mime]
+                       (some #(.contains prioritized-mime %)
+                             (keys accepts->extension))))
+
+             (first)
+             (#(str/split % #";"))
+             (first))))
+
+(defn accepts->extension-redirect-middleware
+  "When a route using this middleware receives an allowed Accept: text/csv header, for
+  example, instead of serving the content from its route it redirects users to the same
+  route but with the corresponding .csv file extension. Same for application/json
+  (redirects with .json extension)"
+  [handler _id]
+  (fn [{{:strs [accept]} :headers
+        {:keys [path path-params]} :reitit.core/match
+        :as request}]
+    (if-let [first-accept (find-first-accept-header accept)]
+      (if (and (nil? (:extension path-params))
+               (contains? accepts->extension first-accept))
+        {:status 308
+         :headers {"Location" (str path "." (get accepts->extension first-accept))}}
+        (handler request))
       (handler request))))
 
 (def configurable-coerce-request-middleware

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -1,6 +1,5 @@
 (ns tpximpact.datahost.ldapi.routes.release
   (:require
-   [reitit.ring.malli :as ring.malli]
    [reitit.coercion.malli :as rcm]
    [tpximpact.datahost.ldapi.handlers :as handlers]
    [tpximpact.datahost.ldapi.handlers.delta :as handlers.delta]
@@ -17,6 +16,18 @@
    :parameters {:path [:map routes-shared/series-slug-param-spec]}
    :responses {200 {:content {"application/ld+json" string?}}
                404 {:body routes-shared/NotFoundErrorBody}}
+   :tags ["Consumer API"]})
+
+(defn get-accept-release-route-config []
+  {:summary (str "Retrieve data or metadata for an existing release via ACCEPT header."
+                 "Redirects to correct file route with file extension when allowed ACCEPT"
+                 "header is provided. e.g. text/csv")
+   :middleware [[(partial middleware/accepts->extension-redirect-middleware) :accepts-redirect]]
+   :handler identity
+   :parameters {:path [:map
+                       routes-shared/series-slug-param-spec
+                       routes-shared/release-slug-param-spec]}
+   :responses {308 {}}
    :tags ["Consumer API"]})
 
 (defn get-release-route-config [triplestore change-store system-uris]

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -68,7 +68,8 @@ has been succeeded by another.
    :coercion (rcm/create {:transformers {}, :validate false})
    :parameters {:path [:map
                        routes-shared/series-slug-param-spec
-                       routes-shared/release-slug-param-spec]}
+                       routes-shared/release-slug-param-spec
+                       routes-shared/extension-param-spec]}
    :responses {200 {:content
                     {"text/csv" any?
                      "application/ld+json" string?}}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -18,7 +18,7 @@
   [:release-slug [:string {:description "A URI safe identifier which is unique within its URI namespace/prefix, used to identify a release within a dataset-series."}]])
 
 (def extension-param-spec
-  [:extension [:string {:description "A file format extension e.g. csv, json"}]])
+  [:extension {:optional true} [:string {:description "A file format extension e.g. csv, json"}]])
 
 (def revision-id-param-spec
   [:revision-id [:int {:description "The revision identifier.  _Note: Consuming applications should not make any assumptions about the format of this identifier and should treat it as opaque._"}]])

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -17,6 +17,9 @@
 (def release-slug-param-spec
   [:release-slug [:string {:description "A URI safe identifier which is unique within its URI namespace/prefix, used to identify a release within a dataset-series."}]])
 
+(def extension-param-spec
+  [:extension [:string {:description "A file format extension e.g. csv, json"}]])
+
 (def revision-id-param-spec
   [:revision-id [:int {:description "The revision identifier.  _Note: Consuming applications should not make any assumptions about the format of this identifier and should treat it as opaque._"}]])
 
@@ -159,10 +162,11 @@
    :body "{\"@context\": [\"http://www.w3.org/ns/csvw\", {\"@language\": \"en\"}]}"})
 
 (def metadata-re-pattern #"-metadata.json$")
+(def metadata-strip-re-pattern #"-metadata$")
 
 (defn strip-metadata-uris [path-params]
   (->> path-params
-       (map (fn [[k v]] [k (string/replace v metadata-re-pattern "")]))
+       (map (fn [[k v]] [k (string/replace v metadata-strip-re-pattern "")]))
        (into {})))
 
 (defn csvm-request? [{:keys [request-method uri] :as request}]
@@ -171,8 +175,8 @@
 (defn csvm-request
   [{:keys [triplestore system-uris]
     {:keys [request-method uri path-params] :as request} :request :as _context}]
-  (let [path-params (strip-metadata-uris path-params)
-        uri (su/dataset-release-uri* system-uris path-params)]
+  (let [stripped-path-params (strip-metadata-uris path-params)
+        uri (su/dataset-release-uri* system-uris stripped-path-params)]
     ;; TODO: this should pull the resource metadata, not just check the
     ;; resource exists
     (if (db/resource-exists? triplestore uri)

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/integration_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/integration_test.clj
@@ -1,7 +1,6 @@
 (ns ^:hurl tpximpact.datahost.ldapi.integration-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [clojure.java.shell :as shell]
    [tpximpact.test-helpers :as th]
    [tpximpact.datahost.ldapi.test-util.hurl :as hurl :refer [hurl]]))
 

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_schema_test.clj
@@ -71,7 +71,7 @@
         (is (= nil missing))
 
         (testing "The release was updated with a reference to the schema"
-          (let [{body :body} (GET (format "/data/my-series-%s/release/release-%s" n n))
+          (let [{body :body} (GET (format "/data/my-series-%s/release/release-%s.json" n n))
                 body (json/read-str body)]
             (is (= schema-uri (get body "dh:hasSchema")))))
 

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -116,8 +116,6 @@
 
       (testing "Fetching a release that does not exist returns 'not found'"
         (let [resp (GET (str release-1-path ".json"))
-              foo 1
-              _ (println foo)
               {:keys [status body]} resp]
           (is (= 404 status))
           (is (= "Not found" body))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -113,13 +113,12 @@
           new-series-path (str "/data/" new-series-slug)
           release-1-id (str "release-" (UUID/randomUUID))
           release-1-path (str new-series-path "/release/" release-1-id)]
-      (testing "Fetching a release for a series that does not exist returns 'not found'"
-        (let [{:keys [status body]} (GET release-1-path)]
-          (is (= 404 status))
-          (is (= "Not found" body))))
 
       (testing "Fetching a release that does not exist returns 'not found'"
-        (let [{:keys [status body]} (GET release-1-path)]
+        (let [resp (GET (str release-1-path ".json"))
+              foo 1
+              _ (println foo)
+              {:keys [status body]} resp]
           (is (= 404 status))
           (is (= "Not found" body))))
 
@@ -177,7 +176,7 @@
                    (get body "dcterms:modified")))))
 
         (testing "Fetching a release that does exist works"
-          (let [response (GET release-1-path)
+          (let [response (GET (str release-1-path ".json"))
                 body (json/read-str (:body response))]
             (is (= 200 (:status response)))
             (is (= normalised-ednld (dissoc body "dcterms:issued" "dcterms:modified")))))
@@ -200,7 +199,7 @@
             (t/is (= nil missing2))))
 
         (testing "A release can be updated, query params take precedence"
-          (let [{body-str-before :body} (GET release-1-path)
+          (let [{body-str-before :body} (GET (str release-1-path ".json"))
                 {:keys [body] :as response} (PUT (str release-1-path "?title=A%20new%20title")
                                               {:content-type :json
                                                :body (json/write-str request-ednld)})
@@ -250,5 +249,5 @@
                                    "dcterms:description" "Description"})})
 
       (testing "Fetching existing release with no revisions"
-        (let [response (GET release-1-path {:headers {"accept" "text/csv"}})]
+        (let [response (GET (str release-1-path ".csv"))]
           (is (= 422 (:status response))))))))

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/test_util/hurl.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/test_util/hurl.clj
@@ -105,7 +105,7 @@
   [dir-path opts]
   (let [file-root (fs/path dir-path)
         paths (fs/match dir-path "regex:(issue-.*|pr-.*|int-.*)"
-                {:max-depth 1 :recursive false})]
+                        {:max-depth 1 :recursive false})]
     (println)
     (doall
      (for [p ^Path paths


### PR DESCRIPTION
Partially addresses issue https://github.com/Swirrl/datahost-prototypes/issues/184

Redirect Release route with accept header to CSV or JSON file route.

When a Release route receives an allowed `Accept: text/csv` it should not serve the content from its route but instead redirect users to the same file route with the `.csv` extension. Same for application/json (redirects with `.json` extension)

This PR is only the first step. The next step from the linked issue will be serving of the CSVW metadata itself:

_"In order to fullfill our obligations to the CSVW spec we should then also support the following route which is where we will map our datahost schema into CSVW."_

_`/data/dataset-series/release/:release-id.csv-metadata.json`_
