### PR TITLE
CSVW metadata download: Part 2

### DIFF
--- a/datahost-ld-openapi/deps.edn
+++ b/datahost-ld-openapi/deps.edn
@@ -19,7 +19,7 @@
 				camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
 				metosin/jsonista {:mvn/version "0.3.7"}
 				org.glassfish/jakarta.json {:mvn/version "2.0.1"}
-				com.apicatalog/titanium-json-ld {:mvn/version "1.3.2"}
+				com.apicatalog/titanium-json-ld {:mvn/version "1.3.3"}
 				scicloj/tablecloth {:mvn/version "7.000-beta-50"}
 				net.openhft/zero-allocation-hashing {:mvn/version "0.16"}
 				metrics-clojure/metrics-clojure {:mvn/version "2.10.0"}

--- a/datahost-ld-openapi/hurl-scripts/int-002.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-002.hurl
@@ -115,3 +115,14 @@ Accept: text/csv
 HTTP 200
 [Asserts]
 body matches /max,44/
+
+
+GET {{scheme}}://{{host_name}}/doc/{{series}}/release/release-1.csv-metadata.json
+Authorization: {{auth_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.['@context']" == "http://www.w3.org/ns/csvw"
+jsonpath "$.['http://purl.org/dc/terms/title']" == "Fun schema"
+jsonpath "$.['tableSchema'].columns" count == 2
+jsonpath "$.['url']" == "/doc/{{series}}/release/release-1.csv"

--- a/datahost-ld-openapi/hurl-scripts/int-011.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-011.hurl
@@ -297,12 +297,11 @@ header "Location" == "{{revision2_url}}"
 
 
 GET {{scheme}}://{{host_name}}/doc/{{series}}/release/release-1.csv-metadata.json
-#Accept: application/json
-#Content-Type: application/json
 Authorization: {{auth_token}}
 
 HTTP 200
 [Asserts]
+jsonpath "$.['@context']" == "http://www.w3.org/ns/csvw"
 jsonpath "$.['http://purl.org/dc/terms/title']" == "Dummy Schema"
 jsonpath "$.['tableSchema'].columns" count == 8
 jsonpath "$.['url']" == "/doc/{{series}}/release/release-1.csv"

--- a/datahost-ld-openapi/hurl-scripts/int-011.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-011.hurl
@@ -102,7 +102,7 @@ Accept: application/json
 Authorization: {{auth_token}}
 
 HTTP 302
-Location: /data/{{series}}/release/release-1.json
+Location: /doc/{{series}}/release/release-1.json
 
 # Release requested as CSV via ACCEPTS header gets redirected to correct route
 GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
@@ -110,7 +110,7 @@ Accept: text/csv
 Authorization: {{auth_token}}
 
 HTTP 302
-Location: /data/{{series}}/release/release-1.csv
+Location: /doc/{{series}}/release/release-1.csv
 
 
 #appends to the revision

--- a/datahost-ld-openapi/hurl-scripts/int-011.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-011.hurl
@@ -296,14 +296,16 @@ header "Location" == "{{revision2_url}}"
 
 
 
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1-metadata.json
+GET {{scheme}}://{{host_name}}/doc/{{series}}/release/release-1.csv-metadata.json
 #Accept: application/json
 #Content-Type: application/json
 Authorization: {{auth_token}}
+
 HTTP 200
 [Asserts]
-body == "{\"@context\": [\"http://www.w3.org/ns/csvw\", {\"@language\": \"en\"}]}"
-
+jsonpath "$.['dcterms:title']" == "Dummy Schema"
+jsonpath "$.['tableSchema'].columns" count == 8
+#jsonpath "$.['dh:appliesToRelease']" endsWith "{{series}}/release/release-1"
 
 #ensure path header contains a URL when requesting revision 2
 GET {{scheme}}://{{host_name}}{{revision2_url}}

--- a/datahost-ld-openapi/hurl-scripts/int-011.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-011.hurl
@@ -303,9 +303,10 @@ Authorization: {{auth_token}}
 
 HTTP 200
 [Asserts]
-jsonpath "$.['dcterms:title']" == "Dummy Schema"
+jsonpath "$.['http://purl.org/dc/terms/title']" == "Dummy Schema"
 jsonpath "$.['tableSchema'].columns" count == 8
-#jsonpath "$.['dh:appliesToRelease']" endsWith "{{series}}/release/release-1"
+jsonpath "$.['url']" == "/doc/{{series}}/release/release-1.csv"
+
 
 #ensure path header contains a URL when requesting revision 2
 GET {{scheme}}://{{host_name}}{{revision2_url}}

--- a/datahost-ld-openapi/hurl-scripts/int-012.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-012.hurl
@@ -55,13 +55,6 @@ Accept: text/csv
 
 HTTP 200
 
-## TODO: revision CSV metadata
-#GET {{scheme}}://{{host_name}}/doc/{{series}}/release/release-1/revision/1-metadata.json
-
-#HTTP 200
-#[Asserts]
-#body == "{\"@context\": [\"http://www.w3.org/ns/csvw\", {\"@language\": \"en\"}]}"
-
 
 POST {{scheme}}://{{host_name}}/data/{{series}}/release/release-1/schema
 Content-Type: application/json

--- a/datahost-ld-openapi/hurl-scripts/int-012.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-012.hurl
@@ -55,13 +55,12 @@ Accept: text/csv
 
 HTTP 200
 
+## TODO: revision CSV metadata
+#GET {{scheme}}://{{host_name}}/doc/{{series}}/release/release-1/revision/1-metadata.json
 
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1/revision/1-metadata.json
-
-
-HTTP 200
-[Asserts]
-body == "{\"@context\": [\"http://www.w3.org/ns/csvw\", {\"@language\": \"en\"}]}"
+#HTTP 200
+#[Asserts]
+#body == "{\"@context\": [\"http://www.w3.org/ns/csvw\", {\"@language\": \"en\"}]}"
 
 
 POST {{scheme}}://{{host_name}}/data/{{series}}/release/release-1/schema
@@ -245,16 +244,6 @@ path: header "Link"
 variable "path" contains "type=\"application/csvm+json\""
 variable "path" contains "rel=\"describedBy\""
 header "Location" == "{{revision2_url}}"
-
-
-
-GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1-metadata.json
-Accept: application/json 
-Content-Type: application/json
-Authorization: {{auth_token}}
-HTTP 200
-[Asserts]
-body == "{\"@context\": [\"http://www.w3.org/ns/csvw\", {\"@language\": \"en\"}]}"
 
 
 #ensure path header contains a URL when requesting revision 2

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -100,7 +100,7 @@
           :else (let [rev-uri ^URI (:rev change-info)]
                   (-> (.getPath rev-uri)
                       (util.response/redirect)
-                      (shared/set-csvm-header request)))))
+                      (shared/set-csvm-link-header request)))))
       (as-json-ld {:status 200
                    :body (-> (json-ld/compact release (json-ld/simple-context system-uris))
                              (.toString))}))
@@ -185,7 +185,7 @@
                       (when (nil? key)
                         (throw (ex-info "No snapshot reference for revision" {:revision revision})))
                       (ring-io/piped-input-stream (partial change-store-to-ring-io-writer change-store key)))))}
-          (shared/set-csvm-header request))
+          (shared/set-csvm-link-header request))
 
       (as-json-ld {:status 200
                    :body (-> (json-ld/compact revision-ld (json-ld/simple-context system-uris))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
@@ -15,6 +15,10 @@
    :appropriate-csvw "https://publishmydata.com/def/appropriate-csvw/"
    "@base" (su/rdf-base-uri system-uris)})
 
+(defn datahost-csvw-context [system-uris]
+  (merge {"@vocab" "http://www.w3.org/ns/csvw#"}
+         (simple-context system-uris)))
+
 (defn simple-collection-context [system-uris]
   "Use this context when the top level payload will be a collection e.g. Series list"
   (merge (simple-context system-uris)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
@@ -3,6 +3,8 @@
             [tpximpact.datahost.system-uris :as su])
   (:import (com.apicatalog.jsonld JsonLd)
            (com.apicatalog.jsonld.document JsonDocument)
+           (com.apicatalog.jsonld.json JsonMapBuilder JsonUtils)
+           (jakarta.json JsonObject)
            (java.io StringReader)))
 
 (defn simple-context [system-uris]
@@ -15,15 +17,17 @@
    :appropriate-csvw "https://publishmydata.com/def/appropriate-csvw/"
    "@base" (su/rdf-base-uri system-uris)})
 
-(defn datahost-csvw-context [system-uris]
-  (merge {"@vocab" "http://www.w3.org/ns/csvw#"}
-         (simple-context system-uris)))
-
 (defn simple-collection-context [system-uris]
   "Use this context when the top level payload will be a collection e.g. Series list"
   (merge (simple-context system-uris)
          {:contents {"@id" "dh:collection-contents",
                      "@container" "@set"}}))
+
+(def datahost-csvw-vocab-context
+  "Default CSVW @vocab, used during JSON-LD processing steps & later replaced by
+  correct CSVW @context during final stages of processing, because CSVW isn't JSON-LD"
+  {"@vocab" "http://www.w3.org/ns/csvw#"
+   "columns" {"@container" "@set"}})
 
 (defn ->json-document
   ^JsonDocument [edn]
@@ -42,3 +46,10 @@
       (.compactArrays true)
       (.compactToRelative true)
       (.get)))
+
+(defn update-with-csvw-context
+  "Once JSON-LD processing is complete. @context can be updated with legal CSVW context."
+  [^JsonObject json-obj]
+  (let [builder (JsonMapBuilder/create json-obj)]
+    (.put builder "@context" (JsonUtils/toJsonValue "http://www.w3.org/ns/csvw"))
+    (.build builder)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -349,6 +349,11 @@ specifications for each route.")
 
     ["/doc" {:muuntaja leave-keys-alone-muuntaja-coercer}
      ["/:series-slug/release"
+
+      ;; /doc/dataset-series/release/:release-id.csv-metadata.json
+      ["/{release-slug}.csv-metadata.{extension}"
+       {:get (routes.rel/get-release-csvw-metadata-config triplestore system-uris)}]
+
       ["/{release-slug}.{extension}"
        {:get (routes.rel/get-release-route-config triplestore change-store system-uris)}]]]]
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/router.clj
@@ -345,7 +345,12 @@ specifications for each route.")
         {:post (routes.rev/post-revision-retractions-route-config triplestore change-store system-uris)}]
 
        ["/:revision-id/corrections"
-        {:post (routes.rev/post-revision-corrections-route-config triplestore change-store system-uris)}]]]]]
+        {:post (routes.rev/post-revision-corrections-route-config triplestore change-store system-uris)}]]]]
+
+    ["/doc" {:muuntaja leave-keys-alone-muuntaja-coercer}
+     ["/:series-slug/release"
+      ["/{release-slug}.{extension}"
+       {:get (routes.rel/get-release-route-config triplestore change-store system-uris)}]]]]
 
    {;;:reitit.middleware/transform dev/print-request-diffs ;; pretty diffs
     ;;:validate spec/validate ;; enable spec validation for route data

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -218,11 +218,11 @@
              (#(str/split % #";"))
              (first))))
 
-(defn accepts->extension-redirect-middleware
+(defn accepts->file-doc-middleware
   "When a route using this middleware receives an allowed Accept: text/csv header, for
   example, instead of serving the content from its route it redirects users to the same
-  route but with the corresponding .csv file extension. Same for application/json
-  (redirects with .json extension)"
+  route but with the corresponding doc route with a .csv file extension. Same for
+  application/json (redirects with .json extension)"
   [handler _id]
   (fn [{{:strs [accept]} :headers
         {:keys [path path-params]} :reitit.core/match
@@ -231,7 +231,8 @@
       (if (and (nil? (:extension path-params))
                (contains? accepts->extension first-accept))
         {:status 302
-         :headers {"Location" (str path "." (get accepts->extension first-accept))}}
+         :headers {"Location" (-> (str path "." (get accepts->extension first-accept))
+                                  (str/replace #"^\/data" "/doc"))}}
         (handler request))
       (handler request))))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -22,7 +22,7 @@
   {:summary (str "Retrieve data or metadata for an existing release via ACCEPT header."
                  "Redirects to correct file route with file extension when allowed ACCEPT"
                  "header is provided. e.g. text/csv")
-   :middleware [[(partial middleware/accepts->extension-redirect-middleware) :accepts-redirect]]
+   :middleware [[(partial middleware/accepts->file-doc-middleware) :accepts-redirect]]
    :handler identity
    :parameters {:path [:map
                        routes-shared/series-slug-param-spec

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -74,8 +74,7 @@ It is currently considered an error to put data into a revision which
 has been succeeded by another.
 "
    :handler (partial handlers/get-release triplestore change-store system-uris)
-   :middleware [[(partial middleware/csvm-request-response triplestore system-uris) :csvm-response]
-                [(partial middleware/entity-uris-from-path system-uris #{:dh/Release}) :entity-uris]]
+   :middleware [[(partial middleware/entity-uris-from-path system-uris #{:dh/Release}) :entity-uris]]
    :coercion (rcm/create {:transformers {}, :validate false})
    :parameters {:path [:map
                        routes-shared/series-slug-param-spec
@@ -131,13 +130,26 @@ set `dcterms:modified` times for you."
   {:summary "Retrieve release schema"
    :description "Returns the Datahost TableSchema associated with the release.
 
-NOTE: Datahost tableschemas are extended subsets of CSVW:TableSchema."
+NOTE: Datahost tableSchemas are extended subsets of CSVW:TableSchema."
    :handler (partial handlers/get-release-schema triplestore system-uris)
    :parameters {:path [:map
                        routes-shared/series-slug-param-spec
                        routes-shared/release-slug-param-spec]}
    :responses {200 {:description "Release schema successfully retrieved"
                     :content {"application/ld+json" string?}}
+               404 {:body routes-shared/NotFoundErrorBody}}
+   :tags ["Consumer API"]})
+
+(defn get-release-csvw-metadata-config
+  [triplestore system-uris]
+  {:summary "Retrieve release CSVW metadata as JSON"
+   :description "Returns the Datahost CSVW metadata schema associated with the release."
+   :handler (partial handlers/get-release-csvw-metadata triplestore system-uris)
+   :parameters {:path [:map
+                       routes-shared/series-slug-param-spec
+                       routes-shared/release-slug-param-spec]}
+   :responses {200 {:description "Release CSVW metadata schema successfully retrieved"
+                    :content {"application/csvm+json" string?}}
                404 {:body routes-shared/NotFoundErrorBody}}
    :tags ["Consumer API"]})
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -150,7 +150,7 @@
 (defn base-url [request]
   (request/request-url (select-keys request [:scheme :headers :uri])))
 
-(defn set-csvm-header [response request]
+(defn set-csvm-link-header [response request]
   (let [csvm-url (-> request (update :uri str "-metadata.json") base-url)]
     (update response :headers assoc "link" (str "<" csvm-url ">; "
                                                 "rel=\"describedBy\"; "

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/triples.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/util/triples.clj
@@ -1,7 +1,8 @@
 (ns tpximpact.datahost.ldapi.util.triples
   (:require
    [grafter.matcha.alpha :as matcha]
-   [grafter.vocabularies.rdf :as vocab.rdf]))
+   [grafter.vocabularies.rdf :as vocab.rdf]
+   [tpximpact.datahost.ldapi.compact :as compact]))
 
 (defn triples->ld-resource
   "Given triples returned from a DB query, transform them into a single resource
@@ -44,3 +45,28 @@
                        (matcha/optional [[?s vocab.rdf/rdf:a ?t]])]
                       matcha-db)
         (map #(dissoc % vocab.rdf/rdf:a)))))
+
+(defn- dissoc-non-csvw-uris [resource-map]
+  (dissoc resource-map
+          vocab.rdf/rdf:a
+          vocab.rdf/rdf:type
+          :grafter.rdf/uri
+          (compact/expand :dh/appliesToRelease)
+          (compact/expand :appropriate-csvw/modeling-of-dialect)))
+
+(defn triples->csvw-resource
+  "Given triples returned from a DB query, transform them into a single resource
+   map (e.g. Release or Revision) that's ready for CSVW JSON metadata serialization"
+  ([matcha-db]
+   (-> (matcha/build-1 ?s
+                       {?p ?o}
+                       [[?s ?p ?o]]
+                       matcha-db)
+       (dissoc-non-csvw-uris)))
+  ([matcha-db subject]
+   (-> (matcha/build-1 ?s
+                       {?p ?o}
+                       [[?s ?p ?o]
+                        (matcha/values ?s [subject])]
+                       matcha-db)
+       (dissoc-non-csvw-uris))))


### PR DESCRIPTION
Second part of issue https://github.com/Swirrl/datahost-prototypes/issues/184.

An HTTP `GET` request to:

`/doc/series-187/release/release-1.csv-metadata.json`

... responds with CSVW metadata. 

The metadata also contains a `csvw:url` key which points to the associated CSV data file, e.g.:

`/doc/series-187/release/release-1.csv`.

The CSVW metadata route loads schema triple data, processes it using JSON-LD; converts the datahost schema into a CSVW schema and finally replaces the Datahost JSON-LD `@context` value with the legal CSVW `@context`.


