### PR TITLE
Accept text/csv resource redirect to file should be 302 (Found)

### DIFF
--- a/datahost-ld-openapi/hurl-scripts/int-011.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-011.hurl
@@ -101,7 +101,7 @@ GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
 Accept: application/json
 Authorization: {{auth_token}}
 
-HTTP 308
+HTTP 302
 Location: /data/{{series}}/release/release-1.json
 
 # Release requested as CSV via ACCEPTS header gets redirected to correct route
@@ -109,7 +109,7 @@ GET {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
 Accept: text/csv
 Authorization: {{auth_token}}
 
-HTTP 308
+HTTP 302
 Location: /data/{{series}}/release/release-1.csv
 
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/middleware.clj
@@ -230,7 +230,7 @@
     (if-let [first-accept (find-first-accept-header accept)]
       (if (and (nil? (:extension path-params))
                (contains? accepts->extension first-accept))
-        {:status 308
+        {:status 302
          :headers {"Location" (str path "." (get accepts->extension first-accept))}}
         (handler request))
       (handler request))))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -27,7 +27,7 @@
    :parameters {:path [:map
                        routes-shared/series-slug-param-spec
                        routes-shared/release-slug-param-spec]}
-   :responses {308 {}}
+   :responses {302 {}}
    :tags ["Consumer API"]})
 
 (defn get-release-route-config [triplestore change-store system-uris]


### PR DESCRIPTION
Accept text/csv resource redirect to the file route `/doc/foo/release/baz.csv` should be 302 (Found); not 308 (Permanent Redirect).

This also addresses odd Chrome / Edge behaviour when following the redirect where the Accept header is changed from `text/csv` to `application/json` on the fly, so the client ends up being served a CSV file containing JSON data.