### PR TITLE
Updates to the UI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,12 +240,14 @@ jobs:
           command: |
             cd consumer-wireframes
             TAG=0.1.$CIRCLE_BUILD_NUM
-            docker build -t europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-fe-prototype:$TAG .
+            BRANCH=dluhc-integration
+            docker build -t europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-fe-prototype:$BRANCH -t europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-fe-prototype:$TAG .
       - run:
           name: Push application Docker image
           command: |
             TAG=0.1.$CIRCLE_BUILD_NUM
-            docker push europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-fe-prototype:$TAG
+            BRANCH=dluhc-integration
+            docker push europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-fe-prototype --all-tags
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
@@ -293,12 +295,12 @@ workflows:
             - swirrl-s3-jars-consumer
             - swirrl-dockerhub-consumer
             - gcp-artifact-registry
-          filters:
+          # filters:
             # tags:
             #   only: /^v.*/
-            branches:
-              only:
-                - /^(main|dluhc-integration)$/
+          #   branches:
+          #     only:
+          #       - /^(main|dluhc-integration)$/
           requires:
             - unit-test-ldapi
             - integration-test-ldapi

--- a/consumer-wireframes/_includes/basic.html
+++ b/consumer-wireframes/_includes/basic.html
@@ -9,6 +9,8 @@
     <link rel="stylesheet" href="/assets/css/style.css">
     <script src="/assets/js/config.js"></script>
     <h1 id = "getDomain" class="d-none visually-hidden">{{ consumerWireframes.environment }}</h1>
+    <!-- <h1 id = "getDomain" class="d-none visually-hidden">http://localhost:8889</h1> -->
+
     <!-- <script src="/assets/js/addData.js"></script>
     <script src="/assets/js/fetch.js"></script> -->
     <title>{{ site.title }} | IDP</title>

--- a/consumer-wireframes/_includes/basic.html
+++ b/consumer-wireframes/_includes/basic.html
@@ -10,6 +10,8 @@
     <script src="/assets/js/config.js"></script>
     <h1 id = "getDomain" class="d-none visually-hidden">{{ consumerWireframes.environment }}</h1>
     <!-- <h1 id = "getDomain" class="d-none visually-hidden">http://localhost:8889</h1> -->
+    <!-- <h1 id = "getDomain" class="d-none visually-hidden">https://dluhc-pmd5-prototype.publishmydata.com</h1> -->
+
 
     <!-- <script src="/assets/js/addData.js"></script>
     <script src="/assets/js/fetch.js"></script> -->

--- a/consumer-wireframes/_includes/dataset-release.html
+++ b/consumer-wireframes/_includes/dataset-release.html
@@ -34,7 +34,7 @@ layout: basic
                 <h2 class="pt-4">Latest data</h2>
 
 
-                <h3 class="h4 pt-3"><a class="btn btn-primary" onclick="downloadCSV(uri,'release')">Download dataset (CSV)</a>
+                <h3 id = "downloadButton" class="h4 pt-3"><a class="btn btn-primary" id = "downloadButtonMain" onclick="downloadCSV(uri,'release')">Download dataset (CSV)</a>
                     <!-- <a a class="btn btn-secondary " href="#">Download metadata (JSON, 20Kb)</a> -->
                 </h3>
                 <h3 class="h5 pt-3">
@@ -46,7 +46,7 @@ layout: basic
                 <div class="collapse" id="1986-2010explain">
                     <div class="card card-body">
                         <strong><span id="revisionReason"></span></strong><br>
-                        <h5>Download changes since last revision:</h5>
+                        <h5 id="changesTitle">Download changes since last revision:</h5>
                         <span id="changes"></span>
                         <!-- <p><a href="#">Appends.csv</a> (100 rows)</p>
                         <p><a href="#">Corrections.csv</a> (20 rows)</p>
@@ -125,11 +125,17 @@ layout: basic
 <script>
     const envDomain = document.getElementById("getDomain").innerHTML;
     let url = window.location.href
-    let uri = envDomain + url.split('?')[1];
-    let seriesUri = uri.match(/^((?:[^\/]*\/){4}[^\/]*)\//)[1];
-    let releaseUri = (uri + "/").match(/^((?:[^\/]*\/){6}[^\/]*)\//)[1];
-    console.log('release uri ' + releaseUri)
+    const urlParams = new URLSearchParams(window.location.search);
+    const seriesID = urlParams.get('series')
+    const releaseID = urlParams.get('release')
+    uri = envDomain + '/data/' + seriesID + '/release/' + releaseID
+    let seriesUri = envDomain + '/data/' + seriesID
+    let releaseUri = envDomain + '/data/' + seriesID + '/release/' + releaseID
     let schemaUri = releaseUri + '/schema'
+    let revisions = [];
+    let revision = '';
+    let latestRevisionWithChangeURL = '';
+
     document.getElementById('apiLink').href = uri
 
     const tableStructure = [{
@@ -187,31 +193,81 @@ layout: basic
         document.getElementById('subTitle').innerHTML = series["dcterms:title"]
         document.getElementById('titleBreadcrumb').innerHTML = release["dcterms:title"]
         document.getElementById('seriesBreadcrumb').innerHTML = series["dcterms:title"]
-        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?/data/${series["@id"]}`
+        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?series=${seriesID}`
         document.getElementById('modified').innerHTML = humanReadableDate + " <i class='text-muted font-weight-light'>(" + release["dcterms:modified"] + ")</i>"
-        document.getElementById('description').innerHTML = series["dcterms:description"]
-        document.getElementById('descriptionMetadata').innerHTML = release["dcterms:description"]
+        const description = release["dcterms:description"];
+        const maxDescriptionLength = 200;
+        if (series["rdfs:comment"] != null){
+                document.getElementById('description').innerHTML = series["rdfs:comment"]
+            }
+        if (description.length > maxDescriptionLength) {
+            const truncatedDescription = description.substring(0, maxDescriptionLength) + "...";
+            const remainingDescription = description.substring(maxDescriptionLength);
+            if (series["rdfs:comment"] == null){
+                document.getElementById('description').innerHTML = truncatedDescription
+            }
+            document.getElementById('descriptionMetadata').innerHTML = 
+            `<span id="truncatedDescription">${truncatedDescription}</span><span id="remainingDescription" style="display:none">${remainingDescription}</span>
+            <button id="expandDescription" class="btn btn-sm breadcrumb-item btn-link">(Show more)</button><button id="collapseDescription" class="btn btn-sm btn-link" style="display:none">(Show less)</button>`
+            
+            document.getElementById('expandDescription').addEventListener('click', () => {
+                document.getElementById('truncatedDescription').innerHTML = truncatedDescription.substring(0, maxDescriptionLength);
+                document.getElementById('remainingDescription').style.display = 'inline';
+                document.getElementById('expandDescription').style.display = 'none';
+                document.getElementById('collapseDescription').style.display = 'inline';
+            });
+            
+            document.getElementById('collapseDescription').addEventListener('click', () => {
+                document.getElementById('truncatedDescription').style.display = 'inline';
+                document.getElementById('truncatedDescription').innerHTML = truncatedDescription;
+                document.getElementById('remainingDescription').style.display = 'none';
+                document.getElementById('expandDescription').style.display = 'inline';
+                document.getElementById('collapseDescription').style.display = 'none';
+            });
+            
+        } else {
+            if (series["rdfs:comment"] == null){
+            document.getElementById('description').innerHTML = series["dcterms:description"]
+            }
+            document.getElementById('descriptionMetadata').innerHTML = description;
+        }
+
         if (release["dcterms:license"]){
             document.getElementById('license').innerHTML = release["dcterms:license"]
+        } else {
+        document.getElementById('license').parentNode.style.display = 'none';
         }
         if (release["dh:coverage"]){
             document.getElementById('coverage').innerHTML = release["dh:coverage"]
+        } else {
+        document.getElementById('coverage').parentNode.style.display = 'none';
         }
         if (release["dh:geographicalCoverageDefinition"]){
             document.getElementById('geodef').innerHTML = release["dh:geographyDefinition"]
+        } else {
+        document.getElementById('geodef').parentNode.style.display = 'none';
         }
         if (release["dh:reasonForChange"]){
             document.getElementById('reason').innerHTML = release["dh:reasonForChange"]
+        } else {
+        document.getElementById('reason').parentNode.style.display = 'none';
         }
         document.getElementById('id').innerHTML = release["@id"]
 
 
 
-        document.getElementById('revisions').href = `./revisions?/data/${release["@id"]}`
+        document.getElementById('revisions').href = `./revisions?series=${seriesID}&release=${releaseID}`
 
-
-        const latestRevision = release["dh:hasRevision"].length
-        const latestRevisionUri = `${releaseUri}/revision/${latestRevision}`
+        let latestRevisionUri = ""
+        if (Array.isArray(release["dh:hasRevision"])){
+            revisions = release["dh:hasRevision"]
+            const latestRevision = release["dh:hasRevision"].length
+            latestRevisionUri = `${releaseUri}/revision/${latestRevision}`
+        } else 
+        {
+            revision = release["dh:hasRevision"]
+            latestRevisionUri = `${releaseUri}/revision/1`
+        }
         console.log('latest revision uri: ' + latestRevisionUri);
         getRevision(latestRevisionUri, release)
     }
@@ -231,19 +287,50 @@ layout: basic
 
     populateRevision = (data, release) => {
         document.getElementById('revisionReason').innerHTML = data["dcterms:description"]
+        console.log(data)
+       
         let changes = ""
         let changeURI = ""
-        if (typeof data["dh:hasChange"] != "string") {
+        if (!data["dh:hasChange"] ){
+            console.log('no changes')
+            changes = document.getElementById("changesTitle")
+            changes.innerHTML = "There are no changes in this revision yet."
+            if (revisions.length == 0){
+                console.log('no revisions')
+                document.getElementById('downloadButton').innerHTML = "This release has no data yet.";
+                document.getElementById('downloadButton').classList.remove('btn-primary');
+                document.getElementById('downloadButton').classList.add('btn-secondary');
+                document.getElementById('downloadButton').removeAttribute('onclick');
+            } else {
+                for (i=revisions.length-1; i>0; i--){
+                    const revisionURL = uri + '/revision/' + i
+                    fetch(revisionURL, settings)
+                        .then((response) => {
+                            response.json().then(data => {
+                                if (data["dh:hasChange"]){
+                                    latestRevisionWithChangeURL = revisionURL
+                                    console.log(latestRevisionWithChangeURL)
+                                    return
+                                }
+                            })
+                })
+            }}
+
+        } else if (typeof data["dh:hasChange"] != "string") {
             html = ""
             for (i=0; i<data["dh:hasChange"].length; i++){
-                changeURI = data["dh:hasChange"][i]
+                changeID = data["dh:hasChange"][i].split('/').slice(8)
+            changeURI = uri + '/revision/' + changeID.join('/')
                 changes = document.getElementById("changes")
                 html += `<a class="btn btn-primary" onclick="downloadCSV('${changeURI}','change')">Download changes ${data["dh:hasChange"].length-i} (CSV)</a>`
 
             }
             changes.innerHTML = html
         } else {
-            changeURI = data["dh:hasChange"]
+            changeID = data["dh:hasChange"].split('/').slice(8)
+            console.log(changeID)
+            changeURI = uri + '/revision/' + changeID.join('/')
+            console.log('CHANGE URI: ' + changeURI)
             changes = document.getElementById("changes")
             changes.innerHTML = `<a class="btn btn-primary" onclick="downloadCSV('${changeURI}','change')">Download changes (CSV)</a>`
         }
@@ -292,5 +379,6 @@ layout: basic
         };
 
         request.send();
+
     }
 </script>

--- a/consumer-wireframes/_includes/dataset-revision.html
+++ b/consumer-wireframes/_includes/dataset-revision.html
@@ -48,7 +48,7 @@ layout: basic
                 <div class="collapse" id="1986-2010explain">
                     <div class="card card-body">
                         <strong><span id="revisionReason"></span></strong><br>
-                        <h5>Download changes since last revision:</h5>
+                        <h5 id="changesTitle">Download changes since last revision:</h5>
                         <span id="changes"></span>
                         <!-- <p><a href="#">Appends.csv</a> (100 rows)</p>
                         <p><a href="#">Corrections.csv</a> (20 rows)</p>
@@ -105,9 +105,13 @@ layout: basic
 <script>
     const envDomain = document.getElementById("getDomain").innerHTML;
     let url = window.location.href
-    uri = envDomain + url.split('?')[1]
-    let seriesUri = uri.match(/^((?:[^\/]*\/){4}[^\/]*)\//)[1];
-    let releaseUri = uri.match(/^((?:[^\/]*\/){6}[^\/]*)\//)[1];
+    const urlParams = new URLSearchParams(window.location.search);
+    const seriesID = urlParams.get('series')
+    const releaseID = urlParams.get('release')
+    const revisionID = urlParams.get('revision')
+    uri = envDomain + '/data/' + seriesID + '/release/' + releaseID + '/revision/' + revisionID
+    let seriesUri = envDomain + '/data/' + seriesID
+    let releaseUri = envDomain + '/data/' + seriesID + '/release/' + releaseID
     document.getElementById('apiLink').href = uri
     console.log(releaseUri)
     console.log(seriesUri)
@@ -151,25 +155,36 @@ layout: basic
         document.getElementById('title').innerHTML = revision["dcterms:title"]
         document.getElementById('titleBreadcrumb').innerHTML = revision["dcterms:title"]
         document.getElementById('seriesBreadcrumb').innerHTML = series["dcterms:title"]
-        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?/data/${series["@id"]}`
+        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?series=${seriesID}`
         document.getElementById('description').innerHTML = revision["dcterms:description"]
         document.getElementById('revisionReason').innerHTML = revision["dcterms:description"]
         document.getElementById('descriptionMetadata').innerHTML = revision["dcterms:description"]
         if (revision["dh:publicationDate"]) {
             document.getElementById('pubdate').innerHTML = revision["dh:publicationDate"]
+        } else {
+        document.getElementById('pubdate').parentNode.style.display = 'none';
         }
         if (revision["dcterms:license"]) {
             document.getElementById('license').innerHTML = revision["dcterms:license"]
+        } else {
+        document.getElementById('license').parentNode.style.display = 'none';
         }
         if (revision["dh:reasonForChange"]) {
             document.getElementById('reason').innerHTML = revision["dh:reasonForChange"]
+        } else {
+        document.getElementById('reason').parentNode.style.display = 'none';
         }
         document.getElementById('id').innerHTML = revision["@id"]
 
 
         let changes = ""
         let changeURI = ""
-        if (typeof revision["dh:hasChange"] != "string") {
+        if (revision["dh:hasChange"] == undefined) {
+            document.getElementById("changes").innerHTML = ""
+            changes = document.getElementById("changesTitle")
+            changes.innerHTML = "There are no changes in this revision yet."
+        }
+        else if (typeof revision["dh:hasChange"] != "string") {
             html = ""
             for (i = 0; i < revision["dh:hasChange"].length; i++) {
                 changeURI = revision["dh:hasChange"][i]
@@ -187,11 +202,11 @@ layout: basic
         }
 
         document.getElementById('releaseBreadcrumb').innerHTML = release["dcterms:title"]
-        document.getElementById('releaseBreadcrumbID').href = `/datasets/dataset-series/dataset-release?/data/${release["@id"]}`
+        document.getElementById('releaseBreadcrumbID').href = `/datasets/dataset-series/dataset-release?series=${seriesID}&release=${releaseID}`
         document.getElementById('releaseTitle').innerHTML = release["dcterms:title"]
 
         document.getElementById('seriesBreadcrumb').innerHTML = series["dcterms:title"]
-        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?/data/${series["@id"]}`
+        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?series=${seriesID}`
         document.getElementById('seriesTitle').innerHTML = series["dcterms:title"]
 
 
@@ -213,7 +228,7 @@ layout: basic
 
     populateRelease = data => {
         document.getElementById('releaseBreadcrumb').innerHTML = data["dcterms:title"]
-        document.getElementById('releaseBreadcrumbID').href = `/datasets/dataset-series/dataset-release?/data/${data["@id"]}`
+        document.getElementById('releaseBreadcrumbID').href = `/datasets/dataset-series/dataset-release?series=${seriesID}&release=${releaseID}`
         document.getElementById('releaseTitle').innerHTML = data["dcterms:title"]
         series = data["dcat:inSeries"]
         console.log("series" + series)
@@ -236,12 +251,13 @@ layout: basic
 
     populateSeries = data => {
         document.getElementById('seriesBreadcrumb').innerHTML = data["dcterms:title"]
-        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?/data/${data["@id"]}`
+        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?series=${seriesID}`
         document.getElementById('seriesTitle').innerHTML = data["dcterms:title"]
     }
 
 
     downloadCSV = (url, type) => {
+        console.log('downloading ' +    url)
         let request = new XMLHttpRequest();
         request.open("GET", url, true);
         request.setRequestHeader("Accept", "text/csv")

--- a/consumer-wireframes/_includes/dataset-series.html
+++ b/consumer-wireframes/_includes/dataset-series.html
@@ -18,7 +18,7 @@ layout: basic
                 <div class="col-lg-8">
                     <h1 class="font-weight-bold pr-5"><span id="title"></span>
                     </h1>
-                    <p class="lead"><strong>Last modified:</strong> <span id="modified"></span> </br><strong> Next
+                    <p class="lead"><strong>Last modified:</strong> <span id="modified"></span> </br><strong id="nextUpdateTitle"> Next
                             update: </strong><span id="nextupdate"> </span></p>
                     <p><span id="description"></span></p>
                 </div>
@@ -69,7 +69,7 @@ layout: basic
         </div>
         <div class="row">
             <div class="col-lg-8 pb-5">
-                <h2 class="pt-5">Related datasets</h2>
+                <!-- <h2 class="pt-5">Related datasets</h2> -->
             </div>
         </div>
     </div>
@@ -79,8 +79,11 @@ layout: basic
 <script>
     const envDomain = document.getElementById("getDomain").innerHTML;
     let url = window.location.href
-    uri = envDomain + url.split('?')[1]
+    const urlParams = new URLSearchParams(window.location.search);
+    const series = urlParams.get('series')
+    uri = envDomain + '/data/' + series
     document.getElementById('apiLink').href = uri
+
 
     const settings = {
         method: 'GET',
@@ -112,20 +115,73 @@ layout: basic
         document.getElementById('title').innerHTML = data["dcterms:title"]
         document.getElementById('titleBreadcrumb').innerHTML = data["dcterms:title"]
         document.getElementById('modified').innerHTML = humanReadableDate + " <i class='text-muted font-weight-light'>(" + data["dcterms:modified"] + ")</i>"
-        document.getElementById('nextupdate').innerHTML = data["dh:nextUpdate"]
-        document.getElementById('description').innerHTML = data["dcterms:description"]
-        document.getElementById('descriptionMetadata').innerHTML = data["dcterms:description"]
+        
+        
+        
+        
+        const description = data["dcterms:description"];
+        const maxDescriptionLength = 300;
+        if (data["rdfs:comment"] != null){
+                document.getElementById('description').innerHTML = data["rdfs:comment"]
+        }
+        
+        if (description.length > maxDescriptionLength) {
+            const truncatedDescription = description.substring(0, maxDescriptionLength) + "...";
+            const remainingDescription = description.substring(maxDescriptionLength);
+            if (data["rdfs:comment"] == null){
+                document.getElementById('description').innerHTML = truncatedDescription
+            }
+
+            document.getElementById('descriptionMetadata').innerHTML = 
+            `<span id="truncatedDescription">${truncatedDescription}</span><span id="remainingDescription" style="display:none">${remainingDescription}</span>
+            <button id="expandDescription" class="btn btn-sm breadcrumb-item btn-link">(Show more)</button><button id="collapseDescription" class="btn btn-sm btn-link" style="display:none">(Show less)</button>`
+            
+            document.getElementById('expandDescription').addEventListener('click', () => {
+                document.getElementById('truncatedDescription').innerHTML = truncatedDescription.substring(0, maxDescriptionLength);
+                document.getElementById('remainingDescription').style.display = 'inline';
+                document.getElementById('expandDescription').style.display = 'none';
+                document.getElementById('collapseDescription').style.display = 'inline';
+            });
+            
+            document.getElementById('collapseDescription').addEventListener('click', () => {
+                document.getElementById('truncatedDescription').style.display = 'inline';
+                document.getElementById('truncatedDescription').innerHTML = truncatedDescription;
+                document.getElementById('remainingDescription').style.display = 'none';
+                document.getElementById('expandDescription').style.display = 'inline';
+                document.getElementById('collapseDescription').style.display = 'none';
+            });
+            
+        } else {
+            if (data["rdfs:comment"] == null){
+            document.getElementById('description').innerHTML = data["dcterms:description"]
+            }
+            document.getElementById('descriptionMetadata').innerHTML = description;
+        }
+            
         if (data["dcterms:publisher"] != null) {
             document.getElementById('publisher').innerHTML = data["dcterms:publisher"]
+        } else {
+        document.getElementById('publisher').parentNode.style.display = 'none';
         }
         if (data["dcat:theme"] != null) {
             document.getElementById('theme').innerHTML = data["dcat:theme"]
+        } else {
+        document.getElementById('theme').parentNode.style.display = 'none';
         }
         if (data["dcterms:license"] != null) {
             document.getElementById('license').innerHTML = data["dcterms:license"]
+        } else {
+        document.getElementById('license').parentNode.style.display = 'none';
         }
         if (data["dcat:keywords"] != null) {
             document.getElementById('keywords').innerHTML = data["dcat:keywords"]
+        } else {
+        document.getElementById('keywords').parentNode.style.display = 'none';
+        }
+        if (data["dh:nextUpdate"] != null){
+            document.getElementById('nextupdate').innerHTML = data["dh:nextUpdate"]
+        } else {
+            document.getElementById('nextUpdateTitle').style.display = 'none';
         }
             document.getElementById('id').innerHTML = data["@id"]
         
@@ -143,21 +199,23 @@ layout: basic
         });
 
     populateReleases = data => {
+        console.log(data)
         let contents = data.contents
         let list = document.getElementById("releases")
         if (contents.length == 0) {
             releases.innerHTML = "<p class='h3'>No releases created yet</p>"
         } else {
             for (i = 0; i < contents.length; i++) {
+                const release = contents[i]["@id"].split('/').pop()
+                const link =  `<h3><a href="./dataset-release?series=${series}&release=${release}">${contents[i]["dcterms:title"]}</a></h3>`
                 let releases = document.createElement("div")
                 if (i == contents.length-1) {
+                    console.log(contents[i])
                     releases.innerHTML =
-                        `<h3><a href="./dataset-release?/data/${contents[i]["@id"]}">${contents[i]["dcterms:title"]}</a></h3><hr>`
-                } else {
+                        link + '<hr>'
+                } else if (contents[i]["dh:reasonForChange"] != undefined){
                     releases.innerHTML =
-                        `<h3>
-                            <a href="./dataset-release?/data/${contents[i]["@id"]}">${contents[i]["dcterms:title"]}</a>
-                        </h3>
+                        `${link}
                         <p>
                             <a class="" data-bs-toggle="collapse" href="#${contents[i]["@id"]}explain" role="button" aria-expanded="false"
                                 aria-controls="collapseExample">
@@ -165,9 +223,13 @@ layout: basic
                             </a>
                         </p>
                         <div class="collapse" id="${contents[i]["@id"]}explain">
-                            <p>${contents[i]["dcterms:description"]}</p>
+                            <p>${contents[i]["dh:reasonForChange"]}</p>
                         </div>
                         <hr>`
+                } else {
+                    releases.innerHTML =
+
+                    link + '<hr>'
                 }
                 list.appendChild(releases);
             }

--- a/consumer-wireframes/_includes/datasets.html
+++ b/consumer-wireframes/_includes/datasets.html
@@ -76,10 +76,41 @@ layout: basic
         document.getElementById("count").innerHTML=contents.length
         document.getElementById('apiLink').href = uri
         for (i = 0; i < contents.length; i++) {
+
             let dataset = document.createElement("div")
-            dataset.innerHTML =
-                `<h3><a href="./dataset-series/?/data/${contents[i]["@id"]}">${contents[i]["dcterms:title"]}</a></h3><p>${contents[i]["dcterms:description"]}</p><hr>`
+            let description = contents[i]["dcterms:description"]
+            let subtitle = ''
+            const title = contents[i]["dcterms:title"]
+            const seriesid = contents[i]["@id"]
+            const seriesURI = uri + "/" + contents[i]["@id"]
+
+            fetch(seriesURI, settings)
+                .then((response) => {
+                    return response.json();
+                })
+                .then((series) => {
+                    if (series["rdfs:comment"] != undefined) {
+                        subtitle = series["rdfs:comment"]
+                    } else if (description.length > 300) {
+                        subtitle = description.substring(0, 300) + "..."
+                    } else {
+                        subtitle = description
+                    }
+                    dataset.innerHTML =
+                        `<h3><a href="./dataset-series?series=${seriesid}">${title}</a></h3><p>${subtitle}</p><hr>`
+                    // `<h3><a href="./dataset-series/?/data/${seriesid}">${title}</a></h3><p>${subtitle}</p><hr>`
+                })
+
+            if (contents[i]["dcterms:description"].length > 300) {
+                const description = [i]["dcterms:description"] = contents[i]["dcterms:description"].substring(0, 300) + "..."
+                dataset.innerHTML =
+                    `<h3><a href="./dataset-series?series=${contents[i]["@id"]}">${contents[i]["dcterms:title"]}</a></h3><p>${description}</p><hr>`
+            } else {
+                dataset.innerHTML =
+                    `<h3><a href="./dataset-series?series=${contents[i]["@id"]}">${contents[i]["dcterms:title"]}</a></h3><p>${contents[i]["dcterms:description"]}</p><hr>`
+            }
             list.appendChild(dataset);
+
         }
     }
 </script>

--- a/consumer-wireframes/_includes/home.html
+++ b/consumer-wireframes/_includes/home.html
@@ -7,7 +7,9 @@ layout: basic
         <div class="container">
             <div class="row">
                 <div class="col-lg-8">
-                    <h1 class="font-weight-bold pr-5">Simple Consumer page/journey examples</h1>
+                    <h1 class="font-weight-bold pr-5">Publish My Data 5 (Basic Demo)</h1>
+                    <p class="lead"><strong>This simple UI demonstrates some of the capabilities of the PMD5 data platform.</strong> <span id="subtitle"></span></p>
+
                     <p class="lead"></p>
                 </div>
             </div>

--- a/consumer-wireframes/_includes/revisions.html
+++ b/consumer-wireframes/_includes/revisions.html
@@ -58,8 +58,11 @@ layout: basic
     const envDomain = document.getElementById("getDomain").innerHTML;
 
     let url = window.location.href
-    let uri = envDomain + url.split('?')[1]
-    let seriesUri = uri.match(/^((?:[^\/]*\/){4}[^\/]*)\//)[1];
+    const urlParams = new URLSearchParams(window.location.search);
+    const seriesID = urlParams.get('series')
+    const releaseID = urlParams.get('release')
+    uri = envDomain + '/data/' + seriesID + '/release/' + releaseID
+    let seriesUri = envDomain + '/data/' + seriesID
 
     const tableStructure = [{
         "name": "dcterms:title"
@@ -108,9 +111,9 @@ layout: basic
         document.getElementById('subTitle').innerHTML = series["dcterms:title"]
         document.getElementById('titleBreadcrumb').innerHTML = release["dcterms:title"]
         document.getElementById('seriesBreadcrumb').innerHTML = series["dcterms:title"]
-        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?/data/${series["@id"]}`
+        document.getElementById('seriesBreadcrumbID').href = `/datasets/dataset-series?series=${seriesID}`
         document.getElementById('releaseBreadcrumbID').href =
-            `/datasets/dataset-series/dataset-release/?/data/${release["@id"]}`
+            `/datasets/dataset-series/dataset-release?series=${seriesID}&release=${releaseID}`
 
         getRevision(release)
     }
@@ -134,12 +137,13 @@ layout: basic
             for (i = 0; i < revision.length; i++) {
                 let newRow = tableRef.insertRow(-1);
                 for (j = 0; j < tableStructure.length; j++) {
+                    const revisionID = revision[i]["@id"].split('/').pop()
                     if (tableStructure[j].name == "@id") {
                             let cellValue = `View ${revision[i]["dcterms:title"]}`
                             let cell = newRow.insertCell(j);
                             let text = document.createTextNode(cellValue);
                             let a = document.createElement('a');
-                            a.href = `/datasets/dataset-series/dataset-release/dataset-revision?/data/${revision[i]["@id"]}`;
+                            a.href = `/datasets/dataset-series/dataset-release/dataset-revision?series=${seriesID}&release=${releaseID}&revision=${revisionID}`;
                             a.appendChild(text);
                             cell.appendChild(a);
                         } else {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8888:80"
   ldapi:
-    image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-ld-openapi:c5618aa"
+    image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-ld-openapi:467f066"
     #platform: linux/arm64/v8
     #platform: linux/amd64
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8888:80"
   ldapi:
-    image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-ld-openapi:467f066"
+    image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-ld-openapi:dluhc-integration"
     #platform: linux/arm64/v8
     #platform: linux/amd64
     environment:
@@ -19,7 +19,7 @@ services:
       - "8889:80"
 
   frontendapp:
-    image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-fe-prototype:0.1.4448"
+    image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/public/datahost-fe-prototype:dluhc-integration"
     # platform: linux/amd64
     environment:
       LDAPI_SERVICE_URL: "http://localhost:8889"


### PR DESCRIPTION
I've made this version of the UI the live one on GCP: https://dluhc-pmd5-prototype-ui.publishmydata.com

Changed to query params: https://github.com/Swirrl/datahost-prototypes/issues/324

Visual changes - https://github.com/Swirrl/datahost-prototypes/issues/340 (and https://github.com/Swirrl/datahost-prototypes/issues/322)
 - Non-supplied metadata fields are not displayed
 - Show the comment rather than description if present.
 - Description is now collapsible (but still needs shortening for pilot) 
 - Fixed table schema not displaying
- Changed title to: "Publish My Data 5 (Basic Demo)"

Also did this https://github.com/Swirrl/datahost-prototypes/issues/354  and (#355) so the FE docker container has two tags - the dluhc-integration branch and the CI build number (preceded by 0.1.)

And this (#356 ) so that the FE container always builds on every branch