### PR TITLE
Use @base to shorten @id slugs

### DIFF
--- a/datahost-ld-openapi/hurl-scripts/int-013.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-013.hurl
@@ -154,7 +154,7 @@ HTTP 200
 [Asserts]
 jsonpath "$['dcterms:title']" == "Example Release"
 jsonpath "$['dcterms:description']" == "Description"
-jsonpath "$['@id']" == "{{series}}2/release/release-1"
+jsonpath "$['@id']" == "release-1"
 jsonpath "$['@type']" == "dh:Release"
 jsonpath "$['dcterms:license']" == "http://license-link"
 jsonpath "$['dcat:inSeries']" == "{{expected_scheme}}://{{expected_uri_root}}/data/{{series}}2"
@@ -168,7 +168,7 @@ jsonpath "$['dh:reasonForChange']" == "Comment about change"
 #jsonpath "$['@context'].['dcat']" == "http://www.w3.org/ns/dcat#"
 #jsonpath "$['@context'].['csvw']" == "http://www.w3.org/ns/csvw#"
 #jsonpath "$['@context'].['appropriate-csvw']" == "https://publishmydata.com/def/appropriate-csvw/"
-jsonpath "$['@context'].[1].['@base']" == "{{expected_scheme}}://{{expected_uri_root}}/data/"
+jsonpath "$['@context'].[1].['@base']" == "{{expected_scheme}}://{{expected_uri_root}}/data/{{series}}2/release/"
 
 #Multiple releases can be can be retrieved via the API
 PUT {{scheme}}://{{host_name}}/data/{{series}}2/release/release-2

--- a/datahost-ld-openapi/hurl-scripts/int-015.hurl
+++ b/datahost-ld-openapi/hurl-scripts/int-015.hurl
@@ -115,9 +115,9 @@ HTTP 200
 #jsonpath "$['@context'].['dcterms']" == "http://purl.org/dc/terms/"
 #jsonpath "$['@context'].['csvw']" == "http://www.w3.org/ns/csvw#"
 #jsonpath "$['@context'].['appropriate-csvw']" == "https://publishmydata.com/def/appropriate-csvw/"
-jsonpath "$['@context'].[1].['@base']" == "{{expected_scheme}}://{{expected_uri_root}}/data/"
+jsonpath "$['@context'].[1].['@base']" == "{{expected_scheme}}://{{expected_uri_root}}/data/{{series}}/release/release-1/"
 
-jsonpath "$['@id']" == "{{series}}/release/release-1/schema"
+jsonpath "$['@id']" == "schema"
 jsonpath "$['dh:appliesToRelease']" == "{{expected_scheme}}://{{expected_uri_root}}/data/{{series}}/release/release-1"
 jsonpath "$['appropriate-csvw:modeling-of-dialect']" == "UTF-8,RFC4180"
 jsonpath "$['dh:columns'].[0].['@type']" == "dh:DimensionColumn"

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
@@ -5,17 +5,27 @@
            (com.apicatalog.jsonld.document JsonDocument)
            (java.io StringReader)))
 
-(defn context [system-uris]
-  ;; Serve the context file with an application/json header from jsdelvir (free CDN)
-  ;; See here for instructions: https://www.jsdelivr.com/?docs=gh
-  ;;
-  ;; The context file cannot be served directly from raw.githubusercontent.com because
-  ;; Github serves all files as text/plain, and the com.apicatalog.jsonld requires that
-  ;; the file has the correct header.
-  ;;
-  ;; NOTE: This should be updated to track the dluhc-integration branch
-  ["https://cdn.jsdelivr.net/gh/Swirrl/datahost-prototypes@6a3ab99/datahost-ld-openapi/resources/jsonld-context.json"
-   {"@base" (su/rdf-base-uri system-uris)}])
+;; Serve the context file with an application/json header from jsdelvir (free CDN)
+;; See here for instructions: https://www.jsdelivr.com/?docs=gh
+;;
+;; The context file cannot be served directly from raw.githubusercontent.com because
+;; Github serves all files as text/plain, and the com.apicatalog.jsonld requires that
+;; the file has the correct header.
+;;
+;; NOTE: This should be updated to track the dluhc-integration branch
+(defn context
+  "Return a context map to be used in e.g. json-ld/compact.
+   Referrs to the external context in `jsonld-context.json` and
+    allows a dynamically-generated `@base` to be included.
+   `extended-base` allows you to extend the base provided in :rdf-base-uri 
+    in the system map, to specify e.g. a release or revision slug"
+  ([system-uris extended-base]
+   (let [base (cond-> (su/rdf-base-uri system-uris)
+                (some? extended-base) (.resolve extended-base))]
+     ["https://cdn.jsdelivr.net/gh/Swirrl/datahost-prototypes@6a3ab99/datahost-ld-openapi/resources/jsonld-context.json"
+      {"@base" base}]))
+  ([system-uris]
+   (context system-uris nil)))
 
 (defn ->json-document
   ^JsonDocument [edn]

--- a/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
+++ b/datahost-ld-openapi/test/tpximpact/datahost/ldapi/models/release_test.clj
@@ -177,7 +177,7 @@
           (let [response (GET (str release-1-path ".json"))
                 body (json/read-str (:body response))]
             (is (= 200 (:status response)))
-            (is (= (dissoc normalised-ednld "@context") (dissoc body "@context" "dcterms:issued" "dcterms:modified")))))
+            (is (= (dissoc normalised-ednld "@context" "@id") (dissoc body "@context" "@id" "dcterms:issued" "dcterms:modified")))))
 
         (testing "Multiple releases can be can be retrieved via the API"
           (PUT (str new-series-path "/release/release-2")


### PR DESCRIPTION
This PR addresses issue #349, and updates the `json-ld/context` function added in #380 to allow extending the `@base` of the JSON-LD context.
(This PR needs to either be merged into #380 before that branch is merged into `dluhc-integration`, or rebased onto `dluhc-integration` once #380 has been merged.

Note: this PR **will** break the prototype UI because some of the `@id`s of the resources will have changed, now that the `@base` in the context has been updated. I can start having a look at where the UI needs to be updated, but @xdrcft8000 you probably know that code much better than me, if you've also got time to have a look?