### PR TITLE
Fix GET commit-ID in swagger and tag untagged publisher routes

### DIFF
--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/release.clj
@@ -177,4 +177,5 @@ The supplied document should conform to the Datahost TableSchema."
                500 {:description "Internal server error"
                     :body [:map
                            [:status [:enum "error"]]
-                           [:message string?]]}}})
+                           [:message string?]]}}
+   :tags ["Publisher API"]})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -155,7 +155,7 @@ that make up that revision.
                        routes-shared/series-slug-param-spec
                        routes-shared/release-slug-param-spec
                        routes-shared/revision-id-param-spec
-                       routes-shared/change-id-param-spec]}
+                       routes-shared/commit-id-param-spec]}
    :responses {200 {:content
                     {"text/csv" any?}}
                404 {:body routes-shared/NotFoundErrorBody}}
@@ -176,4 +176,5 @@ that make up that revision.
                500 {:description "Internal server error"
                     :body [:map
                            [:status [:enum "error"]]
-                           [:message string?]]}}})
+                           [:message string?]]}}
+   :tags ["Publisher API"]})

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/shared.clj
@@ -23,8 +23,8 @@
 (def revision-id-param-spec
   [:revision-id [:int {:description "The revision identifier.  _Note: Consuming applications should not make any assumptions about the format of this identifier and should treat it as opaque._"}]])
 
-(def change-id-param-spec
-  [:change-id [:int {:description "The change or commit identifier.  _Note: Consuming applications should not make any assumptions about the format of this identifier and should treat it as opaque._"}]])
+(def commit-id-param-spec
+  [:commit-id [:int {:description "The change or commit identifier.  _Note: Consuming applications should not make any assumptions about the format of this identifier and should treat it as opaque._"}]])
 
 (def NotFoundErrorBody
   "Default body for 404 errors, for 'application/[ld+]json and others."


### PR DESCRIPTION
1. On the swagger API page, there are two routes that were under 'default' because they were untagged with either publisher or consumer. (fixes #361)

![image](https://github.com/Swirrl/datahost-prototypes/assets/127414270/8eaff610-91c2-474c-902f-0b8c35a7c92d)

This PR has tags them both as Publisher

2. Error when using swagger to GET a commit by commit-id. There was an erroneous use of :change-id instead of :commit-id in routes/revision.clj. This PR changes it to :commit-id