### PR TITLE
Add titles and fix number order for commits in the UI

### DIFF
--- a/consumer-wireframes/_includes/dataset-release.html
+++ b/consumer-wireframes/_includes/dataset-release.html
@@ -18,7 +18,8 @@ layout: basic
         <div class="container">
             <div class="row">
                 <div class="col-lg-8">
-                    <h1 class="font-weight-bold h3 pr-5"><span id="subTitle"></span>
+                    <h1 class="h3 text-muted pb-2"><span>Release</span>
+                    <h1 class="font-weight-bold h2 pr-5"><span id="subTitle"></span>
                     </h1>
                     <h1 class="font-weight-bold pr-5">
                         <span id="title"></span></h1>
@@ -318,7 +319,7 @@ layout: basic
                 changeID = data["dh:hasChange"][i].split('/').slice(8)
             changeURI = uri + '/revision/' + changeID.join('/')
                 changes = document.getElementById("changes")
-                html += `<div><a class="btn btn-primary mt-2" onclick="downloadCSV('${changeURI}','change')">Download changes ${data["dh:hasChange"].length-i} (CSV)</a></div>`
+                html += `<div><a class="btn btn-primary mt-2" onclick="downloadCSV('${changeURI}','change')">Download changes ${i+1} (CSV)</a></div>`
             }
             changes.innerHTML = html
         } 

--- a/consumer-wireframes/_includes/dataset-revision.html
+++ b/consumer-wireframes/_includes/dataset-revision.html
@@ -20,7 +20,8 @@ layout: basic
         <div class="container">
             <div class="row">
                 <div class="col-lg-8">
-                    <h1 class="font-weight-bold h3 pr-5"><span id="seriesTitle"></span>: <span id="releaseTitle"></span></h1>
+                    <h1 class="h3 text-muted pb-2"><span>Revision</span>
+                    <h1 class="font-weight-bold h2 pr-5"><span id="seriesTitle"></span>: <span id="releaseTitle"></span></h1>
                     <h1 class="font-weight-bold pr-5"><span id="title"></span></h1>
                     <!-- <p class="lead"><strong>Last update:</strong> <span id="modified"></span> | <strong> Next
                             update:</strong> </p> -->
@@ -190,7 +191,7 @@ layout: basic
                 changeURI = revision["dh:hasChange"][i]
                 changes = document.getElementById("changes")
                 html +=
-                    `<div><a class="btn btn-primary mt-2" onclick="downloadCSV('${changeURI}','change')">Download changes ${revision["dh:hasChange"].length-i} (CSV)</a></div>`
+                    `<div><a class="btn btn-primary mt-2" onclick="downloadCSV('${changeURI}','change')">Download changes ${i+1} (CSV)</a></div>`
 
             }
             changes.innerHTML = html

--- a/consumer-wireframes/_includes/dataset-series.html
+++ b/consumer-wireframes/_includes/dataset-series.html
@@ -16,6 +16,7 @@ layout: basic
         <div class="container">
             <div class="row">
                 <div class="col-lg-8">
+                    <h1 class="h2 text-muted pb-2"><span>Series</span>
                     <h1 class="font-weight-bold pr-5"><span id="title"></span>
                     </h1>
                     <p class="lead"><strong>Last modified:</strong> <span id="modified"></span> </br><strong id="nextUpdateTitle"> Next

--- a/consumer-wireframes/_includes/revisions.html
+++ b/consumer-wireframes/_includes/revisions.html
@@ -148,7 +148,7 @@ layout: basic
                     console.log(revisions[i]['dh:hasChange'][0])
                     const beLink = revisions[i]['dh:hasChange'][0]
                     if (tableStructure[j].name == "@id") {
-                            let cellValue = `View ${revisions[i]["dcterms:title"]}`
+                            let cellValue = `View`
                             let cell = newRow.insertCell(j);
                             let text = document.createTextNode(cellValue);
                             let a = document.createElement('a');


### PR DESCRIPTION
#392 
- display title that says series, release or revision.
![Screen Shot 2024-02-20 at 13 34 14 pm](https://github.com/Swirrl/datahost-prototypes/assets/127414270/6691a67a-64bc-4955-930a-326c70d60819)
![Screen Shot 2024-02-20 at 13 34 29 pm](https://github.com/Swirrl/datahost-prototypes/assets/127414270/73b1461d-ccc6-4ed2-9591-e76d61e7ef19)
![Screen Shot 2024-02-20 at 13 34 34 pm](https://github.com/Swirrl/datahost-prototypes/assets/127414270/9f5e59fc-eaff-4a3d-a5e4-fc9719a3de20)




#394
- correct commit number when looking at 'what has changed in this revision'
![Screen Shot 2024-02-20 at 13 35 35 pm](https://github.com/Swirrl/datahost-prototypes/assets/127414270/efdb6b40-cfa4-4817-84f9-537585b6b61e)

