### PR TITLE
issue #395 Allow GET application/json for commit with dh:changeKind property, Update UI to match changes

### DIFF
--- a/consumer-wireframes/_includes/dataset-release.html
+++ b/consumer-wireframes/_includes/dataset-release.html
@@ -280,12 +280,27 @@ layout: basic
             });
     }
 
-    populateRevision = (data, release) => {
+    fetchCommit = commit => {
+        return fetch(commit, settings)
+            .then((response) => {
+                return response.json();
+            })
+            .then((data) => {
+                return data
+            })
+            .catch(error => {
+                throw error
+            });
+    }
+
+    populateRevision = async (data, release) => {
         document.getElementById('revisionReason').innerHTML = data["dcterms:description"]
         console.log(data)
        
         let changes = ""
         let changeURI = ""
+        let changeType = ''
+
         if (!data["dh:hasChange"] ){
             console.log('no changes')
             changes = document.getElementById("changesTitle")
@@ -314,11 +329,20 @@ layout: basic
         } else  {
             console.log('has change:' + data)
             html = ""
-            for (i=0; i<data["dh:hasChange"].length; i++){
-                changeID = data["dh:hasChange"][i].split('/').slice(8)
-            changeURI = uri + '/revision/' + changeID.join('/')
+            for (i = 0; i < data["dh:hasChange"].length; i++) {
+                changeURI = data["dh:hasChange"][i]
+                const changeURL = envDomain + '/' + changeURI.split('/').slice(3).join('/')
+                await fetchCommit(changeURL).then(commit => {
+                    changeType = commit["dh:changeKind"].split('/').pop().slice(10)
+                    if (changeType != 'Append') {
+                        changeType += 'ion'
+                    }
+                })
                 changes = document.getElementById("changes")
-                html += `<div><a class="btn btn-primary mt-2" onclick="downloadCSV('${changeURI}','change')">Download changes ${data["dh:hasChange"].length-i} (CSV)</a></div>`
+                let buttonText = `${data["dh:hasChange"].length-i}: ${changeType}s (CSV)`
+                html +=
+                `<div><a class="btn btn-primary mt-2" onclick="downloadCSV('${changeURL}','change')">${buttonText}</a></div>`
+
             }
             changes.innerHTML = html
         } 

--- a/consumer-wireframes/_includes/dataset-revision.html
+++ b/consumer-wireframes/_includes/dataset-revision.html
@@ -148,7 +148,20 @@ layout: basic
     });
 
 
-    populatePage = (series, release, revision) => {
+    fetchCommit = commit => {
+        return fetch(commit, settings)
+            .then((response) => {
+                return response.json();
+            })
+            .then((data) => {
+                return data
+            })
+            .catch(error => {
+                throw error
+            });
+    }
+
+    populatePage = async (series, release, revision) => {
         console.log(revision)
         console.log(release)
         console.log(series)
@@ -179,6 +192,7 @@ layout: basic
 
         let changes = ""
         let changeURI = ""
+        let changeType = ''
         if (revision["dh:hasChange"] == undefined) {
             document.getElementById("changes").innerHTML = ""
             changes = document.getElementById("changesTitle")
@@ -188,9 +202,17 @@ layout: basic
             html = ""
             for (i = 0; i < revision["dh:hasChange"].length; i++) {
                 changeURI = revision["dh:hasChange"][i]
+                const changeURL = envDomain + '/' + changeURI.split('/').slice(3).join('/')
+                await fetchCommit(changeURL).then(data => {
+                    changeType = data["dh:changeKind"].split('/').pop().slice(10)
+                    if (changeType != 'Append') {
+                        changeType += 'ion'
+                    }
+                })
                 changes = document.getElementById("changes")
+                let buttonText = `${revision["dh:hasChange"].length-i}: ${changeType}s (CSV)`
                 html +=
-                    `<div><a class="btn btn-primary mt-2" onclick="downloadCSV('${changeURI}','change')">Download changes ${revision["dh:hasChange"].length-i} (CSV)</a></div>`
+                `<div><a class="btn btn-primary mt-2" onclick="downloadCSV('${changeURL}','change')">${buttonText}</a></div>`
 
             }
             changes.innerHTML = html
@@ -207,6 +229,8 @@ layout: basic
 
 
     }
+
+    
 
     fetchRelease = release => {
         fetch(release, settings)

--- a/consumer-wireframes/hurl-scripts/issue-395.hurl
+++ b/consumer-wireframes/hurl-scripts/issue-395.hurl
@@ -1,0 +1,79 @@
+# Description: This test creates three revisions, 1 commit in each (1st rev + append, 2nd rev + retractions, 
+# 3rd rev + corrections).
+
+# hurl issue-395.hurl --variable series=x-series-on-GCP --variable host_name=dluhc-pmd5-prototype.publishmydata.com --variable scheme=https
+# run locally with docker compose:
+# hurl issue-395.hurl --variable series=x-series-on-GCP --variable admin_password=password --variable scheme=http --variable host_name=localhost:3000
+
+ DELETE {{scheme}}://{{host_name}}/data/{{series}}
+ HTTP 204
+
+
+PUT {{scheme}}://{{host_name}}/data/{{series}}
+Accept: application/json
+Content-Type: application/json
+{
+	"dcterms:title": "A series with all the fields",
+	"dcterms:description": "The sixth dataset",
+	"dh:nextUpdate": "7 July 2024 9:30:00 July 2024 June - July 2024 July 2024 (provisional)",
+    "dcterms:publisher": "https://www.gov.uk/government/organisations/ofcom",
+    "dcat:theme": "https://www.ons.gov.uk/businessindustryandtrade/itandinternetindustry",
+    "dcterms:license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+	"dcat:keywords": "annual population survey, national vocational qualification, exams"
+}
+
+HTTP 201
+[Captures]
+dataset: jsonpath "$['dh:baseEntity']"
+
+PUT {{scheme}}://{{host_name}}/data/{{series}}/release/release-1
+Accept: application/json
+Content-Type: application/json
+{
+	"dcterms:title": "Test Release",
+	"dcterms:description": "A release with all the metadata",
+	"dcterms:license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+	"dh:coverage": "http://statistics.data.gov.uk/id/statistical-geography/E92000001",
+	"dh:geographyDefinition": "Local Authority Districts and Unitary Authorities, Regions, Counties, Nation (England)",
+	"dh:reasonForChange": "Release: Major restructure of Local Authority reference data following the census leading to many new, updated or removed locations. Revision: The latest version of this data contains additional data for the new year of 2021. In addition some minor corrections to to rounding issues for some historic data in 2011 have been fixed. One duplicate piece of data was also deleted"
+}
+HTTP 201
+
+POST {{scheme}}://{{host_name}}/data/{{series}}/release/release-1/schema
+Content-Type: application/json
+file,common/schema-qualifications-by-area.json;
+
+HTTP 201
+
+POST {{scheme}}://{{host_name}}/data/{{series}}/release/release-1/revisions
+Accept: application/json
+Content-Type: application/json
+{
+	"dcterms:title": "Rev 1",
+	"dcterms:description": "A revision with all the details",
+	"dh:publicationDate": "13 July 2023 9:30",
+	"dcterms:license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+	"dh:reasonForChange" : "just felt like it"
+}
+
+HTTP 201
+[Captures]
+revision1_url: header "Location"
+
+POST {{scheme}}://{{host_name}}{{revision1_url}}/appends
+Content-Type: text/csv
+[QueryStringParams]
+title: changes (appends)
+description: change for {{series}}
+format: text/csv
+file,common/qualifications-by-area3.csv;
+
+HTTP 201
+
+GET {{scheme}}://{{host_name}}{{revision1_url}}/commit/1
+Accept: application/json
+#[Options]
+#location: true
+HTTP 200
+[Asserts]
+body == "hi"

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/db.clj
@@ -219,7 +219,8 @@
                                    [change-uri :dcterms/description '?description]
                                    [change-uri :dcterms/format '?format]
                                    [change-uri :dh/updates '?updates]
-                                   [change-uri :dh/appliesToRevision '?revision]]
+                                   [change-uri :dh/appliesToRevision '?revision]
+                                   [change-uri :dh/changeKind '?changeKind]]
                              snapshot-csv-tri [change-uri :dh/revisionSnapshotCSV '?snapshot]]
                          {:prefixes default-prefixes
                           :construct (conj bgps snapshot-csv-tri)

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -373,9 +373,9 @@
                        matcha/index-triples
                        triples->ld-resource)]
     (if (= accept "application/json")
-      {:status 200
+       (as-json-ld{:status 200
        :body (-> (json-ld/compact change (json-ld/context system-uris))
-                             (.toString))}
+                             (.toString))})
       {:status 200
        :headers {"content-type" "text/csv"
                  "content-disposition" "attachment ; filename=change.csv"}

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -372,13 +372,15 @@
                        (db/get-change triplestore)
                        matcha/index-triples
                        triples->ld-resource)]
-    (if (= accept "text/csv")
+    (if (= accept "application/json")
+      {:status 200
+       :body (-> (json-ld/compact change (json-ld/context system-uris))
+                             (.toString))}
       {:status 200
        :headers {"content-type" "text/csv"
                  "content-disposition" "attachment ; filename=change.csv"}
        :body (or (change->csv-stream change-store change) "")}
 
-      {:status 406
-       :headers {}
-       :body "Only text/csv format is available at this time."})
+      
+      )
     (errors/not-found-response request)))

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/routes/revision.clj
@@ -157,7 +157,8 @@ that make up that revision.
                        routes-shared/revision-id-param-spec
                        routes-shared/commit-id-param-spec]}
    :responses {200 {:content
-                    {"text/csv" any?}}
+                    {"text/csv" any?
+                     "application/ld+json" string?}}
                404 {:body routes-shared/NotFoundErrorBody}}
    :tags ["Consumer API"]})
 


### PR DESCRIPTION
With this PR: 
GET on a commit still defaults to text/csv if not specified in the accept header.
GET on a commit with accept application/json will give this: 


<pre>{
  "dh:updates": "09bafe350c94f417e9a881dd4d20e518cb9ade9b9c042ff7bbc3e48aaaa69832",
  "dh:revisionSnapshotCSV": "032b95eb3577d01e3dadca20336563ef2f1f4b1483747183e5130c2eadeabce4",
  "dcterms:description": "change for x-series-on-GCP",
  "dh:appliesToRevision": "https://example.org/data/x-series-on-GCP/release/release-1/revision/1",
  "dcterms:format": "text/csv",
  "@id": "x-series-on-GCP/release/release-1/revision/1/commit/1",
  "@type": "dh:Change",
  "dh:changeKind": "https://publishmydata.com/def/datahost/ChangeKindAppend",
  "@context": [
    "https://cdn.jsdelivr.net/gh/Swirrl/datahost-prototypes@1282114/datahost-ld-openapi/resources/jsonld-context.json",
    {
      "@base": "https://example.org/data/"
    }
  ]
}</pre>

Update the UI to match the changes: 
![Screen Shot 2024-02-21 at 15 43 52 pm](https://github.com/Swirrl/datahost-prototypes/assets/127414270/883aaeb4-a452-4665-abc7-689286670238)

