### PR TITLE
Added release context to series jsonld

### DIFF
--- a/consumer-wireframes/_includes/dataset-series.html
+++ b/consumer-wireframes/_includes/dataset-series.html
@@ -106,6 +106,7 @@ layout: basic
         });
 
     populatePage = data => {
+        console.log(data)
         const humanReadableDate = new Date(data["dcterms:modified"]).toLocaleString('en-GB', {
             day: 'numeric',
             month: 'long',
@@ -199,7 +200,6 @@ layout: basic
         });
 
     populateReleases = data => {
-        console.log(data)
         let contents = data.contents
         let list = document.getElementById("releases")
         if (contents.length == 0) {

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/handlers.clj
@@ -63,7 +63,7 @@
                        (matcha/index-triples)
                        (triples->ld-resource))]
     (as-json-ld {:status 200
-                 :body (-> (json-ld/compact series (json-ld/context system-uris))
+                 :body (-> (json-ld/compact series (json-ld/context system-uris series-slug))
                            (.toString))})
     (errors/not-found-response request)))
 

--- a/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/ldapi/json_ld.clj
@@ -5,7 +5,8 @@
            (com.apicatalog.jsonld.document JsonDocument)
            (java.io StringReader)))
 
-(defn context [system-uris]
+(defn context 
+  ([system-uris] 
   ;; Serve the context file with an application/json header from jsdelvir (free CDN)
   ;; See here for instructions: https://www.jsdelivr.com/?docs=gh
   ;;
@@ -14,8 +15,14 @@
   ;; the file has the correct header.
   ;;
   ;; NOTE: This should be updated to track the dluhc-integration branch
-  ["https://cdn.jsdelivr.net/gh/Swirrl/datahost-prototypes@1282114/datahost-ld-openapi/resources/jsonld-context.json"
-   {"@base" (su/rdf-base-uri system-uris)}])
+   ["https://cdn.jsdelivr.net/gh/Swirrl/datahost-prototypes@1282114/datahost-ld-openapi/resources/jsonld-context.json"
+    {"@base" (su/rdf-base-uri system-uris)}]
+   )
+  ([system-uris series-slug]
+   ["https://cdn.jsdelivr.net/gh/Swirrl/datahost-prototypes@1282114/datahost-ld-openapi/resources/jsonld-context.json"
+    {"@base" (su/rdf-base-uri system-uris)
+     "@dh:hasRelease" {"@context" {"@base" (su/release-uri-base system-uris series-slug)}}}])
+  )
 
 (defn ->json-document
   ^JsonDocument [edn]

--- a/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
+++ b/datahost-ld-openapi/src/tpximpact/datahost/system_uris.clj
@@ -38,6 +38,8 @@
 
   (dataset-series-uri* [this api-params])
 
+  (release-uri-base [this series-slug])
+
   (dataset-release-uri [this ^URI series-uri release-slug])
 
   (dataset-release-uri* [this api-params])
@@ -64,6 +66,9 @@
 
     (dataset-series-uri* [this {:keys [series-slug] :as _api-params}]
       (dataset-series-uri this series-slug))
+
+    (release-uri-base [_ series-slug]
+      (str "/data/" series-slug "/release/"))
 
     (dataset-release-uri [_ series-uri release-slug]
       (URI. (format "%s/release/%s" series-uri release-slug)))


### PR DESCRIPTION
as per issue #369 
with this PR the jsonld context for series will also contain a base context for releases. 
![Screen Shot 2024-03-07 at 14 20 27 pm](https://github.com/Swirrl/datahost-prototypes/assets/127414270/1b404128-1657-4631-8edc-1c8049c7ee3e)
